### PR TITLE
fix: read HTTP env PSI under read action (#237)

### DIFF
--- a/modules/spring-web/src/main/kotlin/com/explyt/spring/web/httpclient/EnvDataHolder.kt
+++ b/modules/spring-web/src/main/kotlin/com/explyt/spring/web/httpclient/EnvDataHolder.kt
@@ -19,6 +19,7 @@ package com.explyt.spring.web.httpclient
 
 import com.intellij.json.psi.JsonFile
 import com.intellij.json.psi.JsonObject
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.observable.properties.PropertyGraph
@@ -89,13 +90,11 @@ class EnvDataHolder(
         val file = envFiles.selected?.let { httpFileState.filesPathByName[it] }
             ?.let { VfsUtil.findFile(Path.of(it), false) } ?: return
 
-        val psiJsonFile = getPsiJsonFile(file, project)
-        envFileIsJson.set(psiJsonFile != null)
-        val obj = psiJsonFile?.children?.filterIsInstance<JsonObject>() ?: emptyList()
-        val envList = obj.flatMap { it.propertyList }.map { it.name }
+        val envList = readEnvList(file, project)
+        envFileIsJson.set(envList != null)
         envModel.removeAll()
         envModel.add("")
-        envList.forEach { envModel.add(it) }
+        envList.orEmpty().forEach { envModel.add(it) }
         envModel.selectedItem = envModel.items[0]
     }
 
@@ -133,8 +132,13 @@ class EnvDataHolder(
         return fileName
     }
 
-    private fun getPsiJsonFile(file: VirtualFile, project: Project?): JsonFile? {
-        return project?.let { file.toPsiFile(it) as? JsonFile }
+    private fun readEnvList(file: VirtualFile, project: Project?): List<String>? {
+        project ?: return null
+        return runReadAction {
+            val psiJsonFile = file.toPsiFile(project) as? JsonFile ?: return@runReadAction null
+            val obj = psiJsonFile.children.filterIsInstance<JsonObject>()
+            obj.flatMap { it.propertyList }.map { it.name }
+        }
     }
 
     private fun isExist(file: Path) = HttpFileStateService.getInstance().getOrCreateState(this.file).filesPathByName

--- a/modules/spring-web/src/test/kotlin/com/explyt/spring/web/httpclient/EnvDataHolderTest.kt
+++ b/modules/spring-web/src/test/kotlin/com/explyt/spring/web/httpclient/EnvDataHolderTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2025 Explyt Ltd
+ *
+ * All rights reserved.
+ *
+ * This code and software are the property of Explyt Ltd and are protected by copyright and other intellectual property laws.
+ *
+ * You may use this code under the terms of the Explyt Source License Version 1.0 ("License"), if you accept its terms and conditions.
+ *
+ * By installing, downloading, accessing, using, or distributing this code, you agree to the terms and conditions of the License.
+ * If you do not agree to such terms and conditions, you must cease using this code and immediately delete all copies of it.
+ *
+ * You may obtain a copy of the License at: https://github.com/explyt/spring-plugin/blob/main/EXPLYT-SOURCE-LICENSE.md
+ *
+ * Unauthorized use of this code constitutes a violation of intellectual property rights and may result in legal action.
+ */
+
+package com.explyt.spring.web.httpclient
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.intellij.openapi.vfs.LocalFileSystem
+import java.nio.file.Files
+import kotlin.io.path.writeText
+
+class EnvDataHolderTest : ExplytJavaLightTestCase() {
+
+    fun testSelectFileLoadsJsonEnvironments() {
+        val tempDir = Files.createTempDirectory("env-data-holder-test")
+        val httpFile = tempDir.resolve("requests.http").apply {
+            writeText("GET http://localhost")
+        }
+        val envFile = tempDir.resolve("http-client.env.json").apply {
+            writeText(
+                """
+                {
+                  "dev": {
+                    "host": "localhost"
+                  },
+                  "prod": {
+                    "host": "example.com"
+                  }
+                }
+                """.trimIndent()
+            )
+        }
+        val envVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(envFile)
+        assertNotNull("Env file must be visible to VFS", envVirtualFile)
+
+        val holder = EnvDataHolder(httpFile)
+        holder.addFile(envVirtualFile!!, project)
+
+        assertTrue(holder.envFileIsJson.get())
+        assertEquals(listOf("", "dev", "prod"), holder.envModel.items)
+    }
+}


### PR DESCRIPTION
Fixes #237.

## Problem
`EnvDataHolder.selectFile` converted the selected env `VirtualFile` to PSI and traversed JSON PSI without holding a read lock, which can trigger IntelliJ's "Read access is allowed from inside read-action only" assertion.

## Fix
Move JSON env-name extraction into `runReadAction`, while keeping UI model mutation outside the read action.

## Tests
Added `EnvDataHolderTest.testSelectFileLoadsJsonEnvironments` covering JSON env-file selection and env-name loading.

Module test run: `tests=1, failures=0, errors=0`.