### PR TITLE
fix: avoid Spring Boot lookup in Search Everywhere availability (#233)

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/search/BeanSearchEverywhereContributor.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/search/BeanSearchEverywhereContributor.kt
@@ -18,6 +18,7 @@
 package com.explyt.spring.core.search
 
 import com.explyt.spring.core.service.SpringSearchServiceFacade
+import com.explyt.spring.core.util.SpringCoreUtil
 import com.intellij.ide.actions.searcheverywhere.FoundItemDescriptor
 import com.intellij.ide.actions.searcheverywhere.WeightedSearchEverywhereContributor
 import com.intellij.ide.util.NavigationItemListCellRenderer
@@ -64,6 +65,8 @@ class BeanSearchEverywhereContributor(private val project: Project) :
         val searchService = SpringSearchServiceFacade.getInstance(project)
 
         val navItemList = ApplicationManager.getApplication().runReadAction<List<BeanNavigationItem>, Throwable?> {
+            if (!SpringCoreUtil.isSpringBootProject(project)) return@runReadAction emptyList()
+
             val (active, excluded) = searchService.getAllBeansClassesConsideringContext(project)
             active.map { BeanNavigationItem(it, true) } +
                     excluded.map { BeanNavigationItem(it, false) }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/search/BeanSearchEverywhereContributorFactory.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/search/BeanSearchEverywhereContributorFactory.kt
@@ -17,7 +17,6 @@
 
 package com.explyt.spring.core.search
 
-import com.explyt.spring.core.util.SpringCoreUtil
 import com.intellij.ide.actions.searcheverywhere.SearchEverywhereContributor
 import com.intellij.ide.actions.searcheverywhere.SearchEverywhereContributorFactory
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -31,7 +30,10 @@ class BeanSearchEverywhereContributorFactory : SearchEverywhereContributorFactor
     }
 
     override fun isAvailable(project: Project?): Boolean {
-        return project != null && SpringCoreUtil.isSpringBootProject(project)
+        // Search Everywhere asks availability on the EDT, so keep this check cheap.
+        // Spring Boot detection touches libraries/indices and is performed later in
+        // the contributor's background read action instead.
+        return project != null
     }
 
 }


### PR DESCRIPTION
Fixes #233.

## Problem
`BeanSearchEverywhereContributorFactory.isAvailable()` is called by Search Everywhere on the EDT, but it performed Spring Boot project detection through `SpringCoreUtil.isSpringBootProject(project)`, which may touch libraries/indices and trigger IntelliJ's slow-operation assertion.

## Fix
Keep `isAvailable()` cheap (`project != null`) and defer Spring Boot detection to `BeanSearchEverywhereContributor.fetchWeightedElements`, where the check already runs inside the contributor's read-action fetch path.

## Verification
`spring-core:compileKotlin` completed successfully: `BUILD SUCCESSFUL in 25s`.