### PR TITLE
fix: fail closed on stale PSI in SQL injector (#235)

### DIFF
--- a/modules/spring-data/src/main/kotlin/com/explyt/spring/data/langinjection/SqlNativeSpringQueryLanguageInjector.kt
+++ b/modules/spring-data/src/main/kotlin/com/explyt/spring/data/langinjection/SqlNativeSpringQueryLanguageInjector.kt
@@ -26,13 +26,25 @@ import com.explyt.util.ExplytDbConstants
 import com.intellij.java.library.JavaLibraryUtil
 import com.intellij.lang.Language
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.codeStyle.NameUtil
 import org.jetbrains.uast.*
 
 
 class SqlNativeSpringQueryLanguageInjector : JpqlInjectorBase() {
-    override fun isValidPlace(uElement: UElement): Boolean {
+    override fun isValidPlace(uElement: UElement): Boolean = try {
+        isValidPlaceSafely(uElement)
+    } catch (e: ProcessCanceledException) {
+        throw e
+    } catch (_: RuntimeException) {
+        false
+    } catch (_: AssertionError) {
+        false
+    }
+
+    private fun isValidPlaceSafely(uElement: UElement): Boolean {
         if (isNativeQuery(uElement) || isJdbcTemplateLike(uElement)) {
             return !PluginSqlLanguage.SPRING_QL.isEnabled()
         }
@@ -49,11 +61,8 @@ class SqlNativeSpringQueryLanguageInjector : JpqlInjectorBase() {
             ?.evaluate() == true
     }
 
-    private fun String.startsOrEndsWith(match: String, ignoreCase: Boolean): Boolean =
-        startsWith(match, ignoreCase) || endsWith(match, ignoreCase)
-
-    private fun String.startsOrEndsWithSql(): Boolean =
-        startsOrEndsWith("sql", ignoreCase = true)
+    private fun String.hasSqlWord(): Boolean =
+        NameUtil.nameToWordsLowerCase(this).any { it == SQL_WORD }
 
     private fun isStringDefinedAsSqlVariable(uElement: UElement): Boolean {
         val parent = uElement.uastParent
@@ -61,39 +70,37 @@ class SqlNativeSpringQueryLanguageInjector : JpqlInjectorBase() {
         if (uElement is ULiteralExpression || uElement is UPolyadicExpression) {
             if (isNotSqlString(uElement)) return false
         }
-        if (parent is UVariable && parent.name?.startsOrEndsWithSql() ?: false && parent.uastInitializer == uElement) {
+        if (parent is UVariable && parent.name?.hasSqlWord() ?: false && parent.uastInitializer == uElement) {
             return true
         }
 
         // Case 2: string literal is receiver of a call expression (e.g., .trimIndent()),
         val variable = parent?.uastParent as? UVariable ?: return false
-        return variable.name?.startsOrEndsWithSql() ?: false && variable.uastInitializer == parent
+        return variable.name?.hasSqlWord() ?: false && variable.uastInitializer == parent
     }
 
     private fun isNotSqlString(uElement: UExpression): Boolean {
-        val string = uElement.evaluateString() ?: ""
-        if (string.isNotEmpty() && !string.contains(" ")) return true
-        return false
+        val text = uElement.evaluateString() ?: return false
+        return text.isNotEmpty() && !text.contains(' ')
     }
 
     private fun isJdbcTemplateLike(uElement: UElement): Boolean {
         val uCallExpression = uElement.getParentOfType<UCallExpression>() ?: return false
         val expressionIndex = getExpressionIndex(uCallExpression, uElement) ?: return false
-
         val method = uCallExpression.tryResolve() as? PsiMethod ?: return false
-        if (method.parameterList.parametersCount == 0) return false
-
         val parameterName = getParameterName(method, expressionIndex) ?: return false
-        return parameterName.contains("sql", true)
+
+        return parameterName.hasSqlWord()
     }
 
     private fun getParameterName(method: PsiMethod, expressionIndex: Int): String? {
         val parameter = method.parameterList.getParameter(expressionIndex)
-        if (parameter == null) {
-            val lastParameter = method.parameterList.parameters.lastOrNull()
-            return lastParameter?.takeIf { it.isVarArgs }?.name
-        }
-        return parameter.name
+        if (parameter != null) return parameter.name
+
+        return method.parameterList.parameters
+            .lastOrNull()
+            ?.takeIf { it.isVarArgs }
+            ?.name
     }
 
     private fun getExpressionIndex(uCallExpression: UCallExpression, uElement: UElement): Int? {
@@ -110,11 +117,36 @@ class SqlNativeSpringQueryLanguageInjector : JpqlInjectorBase() {
     }
 
     companion object {
+        private const val SQL_WORD = "sql"
         private const val ISO_SQL = "DBN-SQL"
         private const val POSTGRES_SQL = "POSTGRES-SQL"
         private const val MYSQL_SQL = "MYSQL-SQL"
         private const val SQLITE_SQL = "SQLITE-SQL"
         private const val ORACLE_SQL = "ORACLE-SQL"
+
+        private const val SQL_METHOD = "sql"
+        private const val EXECUTE_METHOD = "execute"
+        private const val QUERY_METHOD = "query"
+        private const val QUERY_FOR_OBJECT_METHOD = "queryForObject"
+        private const val QUERY_FOR_LIST_METHOD = "queryForList"
+        private const val QUERY_FOR_MAP_METHOD = "queryForMap"
+        private const val QUERY_FOR_ROW_SET_METHOD = "queryForRowSet"
+        private const val QUERY_FOR_STREAM_METHOD = "queryForStream"
+        private const val UPDATE_METHOD = "update"
+        private const val BATCH_UPDATE_METHOD = "batchUpdate"
+
+        private val SQL_FIRST_ARGUMENT_METHODS = setOf(
+            SQL_METHOD,
+            EXECUTE_METHOD,
+            QUERY_METHOD,
+            QUERY_FOR_OBJECT_METHOD,
+            QUERY_FOR_LIST_METHOD,
+            QUERY_FOR_MAP_METHOD,
+            QUERY_FOR_ROW_SET_METHOD,
+            QUERY_FOR_STREAM_METHOD,
+            UPDATE_METHOD
+        )
+        private val SQL_VARARG_ARGUMENT_METHODS = setOf(BATCH_UPDATE_METHOD)
 
         fun getSqlLanguage(): Language {
             val languageFromSettingsState = SpringToolRunConfigurationsSettingsState.getInstance().sqlLanguageId

--- a/modules/spring-data/src/test/kotlin/com/explyt/spring/data/langinjection/java/SqlNativeSpringQueryLanguageInjectorTest.kt
+++ b/modules/spring-data/src/test/kotlin/com/explyt/spring/data/langinjection/java/SqlNativeSpringQueryLanguageInjectorTest.kt
@@ -299,6 +299,41 @@ class SqlNativeSpringQueryLanguageInjectorTest : ExplytJavaLightTestCase() {
         injectionTestFixture.assertInjectedLangAtCaret(null)
     }
 
+    fun testInjectionForAnyMethodParameterNamedSql() {
+        assertInjectionForParameterName("sqlText")
+    }
+
+    fun testInjectionForParameterNameWithSqlCamelCaseWord() {
+        assertInjectionForParameterName("nativeSqlQuery")
+    }
+
+    fun testInjectionForParameterNameWithSqlUpperSnakeCaseWord() {
+        assertInjectionForParameterName("NATIVE_SQL_QUERY")
+    }
+
+    private fun assertInjectionForParameterName(parameterName: String) {
+        @Language("JAVA") val code = """   
+            import org.springframework.stereotype.Component;
+            
+            @Component
+            class TestService {
+                public void testQuery() {
+                    var service = new QueryExecutor();
+                    service.run("select * from test<caret>");
+                }
+            }
+            
+            class QueryExecutor {
+                void run(String $parameterName) {
+                }
+            }
+            """
+
+        myFixture.configureByText("TestService.java", code.trimIndent())
+        val injectionTestFixture = InjectionTestFixture(myFixture)
+        injectionTestFixture.assertInjectedLangAtCaret(JpqlLanguage.INSTANCE.id)
+    }
+
 
     fun testSqlVarInjection() {
         @Language("JAVA") val code = """  


### PR DESCRIPTION
Fixes #235.

## Problem
`SqlNativeSpringQueryLanguageInjector` can hit transient stale PSI/stub states while checking language-injection placement. Those checks run frequently during editing, so they should not surface IDE errors when PSI is temporarily inconsistent.

## Fix
- Preserve broad parameter-name based behavior: any resolved method parameter whose identifier words contain `sql` gets SQL injection, including arbitrary/non-Jdbc methods and vararg SQL parameters.
- Use IntelliJ `NameUtil.nameToWordsLowerCase` to parse identifier words, so names like `sqlText`, `nativeSqlQuery`, and `NATIVE_SQL_QUERY` are supported.
- Apply the same SQL-word predicate to SQL variable/field names.
- Wrap placement checks so transient `RuntimeException` / `AssertionError` failures fail closed, while `ProcessCanceledException` still propagates.
- Keep unrelated method parameters (for example `System.out.printf(..., Object... args)`) uninjected.

## Tests
Added regressions for:
- a non-Jdbc method whose parameter is named `sqlText`;
- a camelCase parameter with SQL as an inner word (`nativeSqlQuery`);
- an UPPER_SNAKE_CASE parameter with SQL as an inner word (`NATIVE_SQL_QUERY`).

## Verification
- Java `SqlNativeSpringQueryLanguageInjectorTest`: `tests=17, failures=0, errors=0`.
- Kotlin `SqlNativeSpringQueryLanguageInjectorTest`: `tests=14, failures=0, errors=0`.