### PR TITLE
fix: handle transient PSI file text mismatch in bean search (#232)

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
@@ -50,8 +50,10 @@ import com.intellij.codeInsight.AnnotationUtil
 import com.intellij.codeInsight.MetaAnnotationUtil
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.modules
 import com.intellij.psi.*
@@ -430,12 +432,21 @@ class SpringSearchService(private val project: Project) {
     private fun searchBeanPsiClassesByAnnotations(
         module: Module, annotationPsiClasses: Collection<PsiClass>, scope: SearchScope
     ): Set<PsiBean> {
-        return annotationPsiClasses.asSequence()
-            .flatMap { AnnotatedElementsSearch.searchPsiClasses(it, scope) }
-            .filter { SpringCoreUtil.isSpringBeanCandidateClass(it) }
-            .filter { isActive(it) }
-            .map { PsiBean(it.resolveBeanName(module), it, it.getQualifierAnnotation(), it) }
-            .toSet()
+        try {
+            return annotationPsiClasses.asSequence()
+                .flatMap { AnnotatedElementsSearch.searchPsiClasses(it, scope) }
+                .filter { it.isValid }
+                .filter { SpringCoreUtil.isSpringBeanCandidateClass(it) }
+                .filter { isActive(it) }
+                .map { PsiBean(it.resolveBeanName(module), it, it.getQualifierAnnotation(), it) }
+                .toSet()
+        } catch (e: RuntimeExceptionWithAttachments) {
+            // PSI/document/stub can be transiently out of sync during editing ("file text mismatch").
+            // Abort this pass via cancellation so the cached value is recomputed once PSI is
+            // consistent again, instead of caching a partial result or logging a crash (issue #232).
+            if (e.userMessage != FILE_TEXT_MISMATCH_MESSAGE) throw e
+            throw ProcessCanceledException(e)
+        }
     }
 
     private fun searchBeanPsiClassesByComponentAnnotationLibraryScopeCached(module: Module): Set<PsiBean> {
@@ -660,6 +671,9 @@ class SpringSearchService(private val project: Project) {
     }
 
     companion object {
+        // User message of com.intellij.psi.PsiConsistencyAssertions#assertNoFileTextMismatch.
+        private const val FILE_TEXT_MISMATCH_MESSAGE = "File text mismatch"
+
         fun getInstance(project: Project): SpringSearchService = project.service()
     }
 }


### PR DESCRIPTION
Fixes #232.

## Problem
`SpringSearchService.searchBeanPsiClassesByAnnotations` runs `AnnotatedElementsSearch` and reads PSI while building the bean set. During editing, PSI/document/stub can be transiently out of sync, and the platform's `PsiConsistencyAssertions` then throws `RuntimeExceptionWithAttachments("File text mismatch")`. Because the result is cached against modification trackers, this surfaced as a recurring logged crash (the largest crash cluster) reached from inspections and the bean line marker.

## Fix
- Convert the specific transient `"File text mismatch"` failure into `ProcessCanceledException`, so the cancelable computation aborts and is recomputed once PSI is consistent — instead of caching a partial result or logging a crash.
- Defensively skip invalid PSI classes (`it.isValid`).
- Any other `RuntimeExceptionWithAttachments` is rethrown unchanged, so unrelated errors are not masked.

## Verification
- Java `SpringSearchServiceTest`: `tests=4, failures=0, errors=0`.
- Kotlin `SpringSearchServiceTest`: `tests=4, failures=0, errors=0`.
- `spring-core:compileKotlin`: `BUILD SUCCESSFUL`.