### PR TITLE
feat: In-IDE feedback nudge for engaged users

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecision.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecision.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+/**
+ * Engagement thresholds that gate the one-time feedback nudge.
+ *
+ * The nudge is shown only to genuinely engaged users (proven by real usage spread across
+ * several days), which keeps review prompts effective instead of rating-poisoning.
+ */
+const val MIN_TOTAL_USAGES_FOR_NUDGE: Int = 30
+const val MIN_ACTIVE_DAYS_FOR_NUDGE: Int = 3
+
+/** Immutable snapshot of the persisted engagement state, used by [shouldShowFeedbackNudge]. */
+data class NudgeStats(
+    val totalUsages: Int,
+    val distinctActiveDays: Int,
+    val nudgeShown: Boolean,
+    val dismissed: Boolean,
+)
+
+/**
+ * Pure decision function: returns `true` when the feedback nudge should be shown.
+ *
+ * Kept free of any IntelliJ-platform dependency so it can be unit-tested in isolation.
+ */
+fun shouldShowFeedbackNudge(stats: NudgeStats): Boolean =
+    !stats.nudgeShown &&
+        !stats.dismissed &&
+        stats.totalUsages >= MIN_TOTAL_USAGES_FOR_NUDGE &&
+        stats.distinctActiveDays >= MIN_ACTIVE_DAYS_FOR_NUDGE

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+import com.explyt.spring.core.SpringCoreBundle.message
+import com.explyt.spring.core.notifications.SpringToolNotificationGroup
+import com.intellij.ide.BrowserUtil
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import java.time.LocalDate
+
+/**
+ * Shows a one-time, non-intrusive notification that invites engaged users to rate the plugin on
+ * the Marketplace or star it on GitHub — directly targeting the very low rating-vote conversion.
+ *
+ * Engagement is measured with [FeedbackNudgeState] (local counters only — no telemetry, no network)
+ * and gated by the pure [shouldShowFeedbackNudge] decision. The balloon is shown at most once ever,
+ * and "Dismiss" suppresses it permanently.
+ */
+@Service(Service.Level.APP)
+class FeedbackNudgeService {
+
+    private val logger = Logger.getInstance(FeedbackNudgeService::class.java)
+
+    /**
+     * Records a single unit of engagement: increments the total usage counter and, the first time
+     * the plugin is used on a new calendar day, the distinct-active-days counter.
+     */
+    fun recordEngagement() {
+        if (skipForUnitTestAndHeadlessMode()) return
+        try {
+            val state = FeedbackNudgeState.getInstance().state
+            synchronized(this) {
+                state.totalUsages += 1
+                val today = LocalDate.now().toEpochDay()
+                if (state.lastActiveEpochDay != today) {
+                    state.lastActiveEpochDay = today
+                    state.distinctActiveDays += 1
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn(e)
+        }
+    }
+
+    /** Evaluates the thresholds and, if met, shows the nudge exactly once. */
+    fun maybeShowNudge(project: Project) {
+        if (skipForUnitTestAndHeadlessMode()) return
+        try {
+            val nudgeState = FeedbackNudgeState.getInstance()
+            if (!shouldShowFeedbackNudge(nudgeState.toStats())) return
+
+            // Mark as shown *before* displaying, so a crash/restart can never double-show it.
+            nudgeState.state.nudgeShown = true
+            showNotification(project)
+        } catch (e: Exception) {
+            logger.warn(e)
+        }
+    }
+
+    private fun showNotification(project: Project) {
+        SpringToolNotificationGroup
+            .createNotification(
+                message("explyt.spring.feedback.nudge.title"),
+                message("explyt.spring.feedback.nudge.content"),
+                NotificationType.INFORMATION
+            )
+            .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.rate")) {
+                BrowserUtil.browse(MARKETPLACE_REVIEWS_URL)
+            })
+            .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.star")) {
+                BrowserUtil.browse(GITHUB_REPO_URL)
+            })
+            .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.dismiss")) {
+                FeedbackNudgeState.getInstance().state.dismissed = true
+            })
+            .notify(project)
+    }
+
+    private fun skipForUnitTestAndHeadlessMode(): Boolean =
+        ApplicationManager.getApplication().isUnitTestMode ||
+            ApplicationManager.getApplication().isHeadlessEnvironment
+
+    companion object {
+        fun getInstance(): FeedbackNudgeService = service()
+
+        const val MARKETPLACE_REVIEWS_URL = "https://plugins.jetbrains.com/plugin/28675-spring-explyt/reviews"
+        const val GITHUB_REPO_URL = "https://github.com/explyt/spring-plugin"
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.statistic
 
 import com.explyt.spring.core.SpringCoreBundle.message
 import com.explyt.spring.core.notifications.SpringToolNotificationGroup
+import com.intellij.icons.AllIcons
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
@@ -75,6 +76,7 @@ class FeedbackNudgeService {
                 message("explyt.spring.feedback.nudge.content"),
                 NotificationType.INFORMATION
             )
+            .setIcon(AllIcons.Nodes.Favorite)
             .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.rate")) {
                 BrowserUtil.browse(MARKETPLACE_REVIEWS_URL)
             })

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
 import java.time.LocalDate
 
 /**
@@ -56,7 +57,8 @@ class FeedbackNudgeService {
         if (skipForUnitTestAndHeadlessMode()) return
         try {
             val nudgeState = FeedbackNudgeState.getInstance()
-            if (!shouldShowFeedbackNudge(nudgeState.toStats())) return
+            val forceShow = Registry.`is`("explyt.spring.feedback.nudge.debug", false)
+            if (!forceShow && !shouldShowFeedbackNudge(nudgeState.toStats())) return
 
             // Mark as shown *before* displaying, so a crash/restart can never double-show it.
             nudgeState.state.nudgeShown = true

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeState.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeState.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+import com.explyt.spring.core.statistic.FeedbackNudgeState.NudgeData
+import com.intellij.openapi.components.*
+
+/**
+ * Durable, application-level persistence for the feedback nudge.
+ *
+ * Stored in a regular settings file (not a cache) so that "never show twice" and a permanent
+ * "Dismiss" survive IDE restarts and cache invalidation.
+ */
+@Service(Service.Level.APP)
+@State(
+    name = "ExplytSpringFeedbackNudge",
+    category = SettingsCategory.PLUGINS,
+    storages = [Storage("explyt-spring-feedback.xml")]
+)
+class FeedbackNudgeState : SimplePersistentStateComponent<NudgeData>(NudgeData()) {
+
+    class NudgeData : BaseState() {
+        /** Total tracked Explyt action usages observed for this installation. */
+        var totalUsages by property(0)
+
+        /** Number of distinct calendar days on which the plugin was used. */
+        var distinctActiveDays by property(0)
+
+        /** Epoch day of the most recent recorded usage (used to count distinct days). */
+        var lastActiveEpochDay by property(0L)
+
+        /** Set once the nudge has been shown — it is never shown again. */
+        var nudgeShown by property(false)
+
+        /** Set when the user explicitly dismisses the nudge — honored forever. */
+        var dismissed by property(false)
+    }
+
+    fun toStats(): NudgeStats = with(state) {
+        NudgeStats(
+            totalUsages = totalUsages,
+            distinctActiveDays = distinctActiveDays,
+            nudgeShown = nudgeShown,
+            dismissed = dismissed,
+        )
+    }
+
+    companion object {
+        fun getInstance(): FeedbackNudgeState = service()
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
@@ -46,6 +46,7 @@ class StatisticService {
                     if (count == null) 1 else count + 1
                 }
             }
+            FeedbackNudgeService.getInstance().recordEngagement()
         } catch (e: Exception) {
             logger.warn(e)
         }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticStartupActivity.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticStartupActivity.kt
@@ -24,6 +24,7 @@ class StatisticStartupActivity : ProjectActivity {
         delay(initDelaySec.seconds)
 
         StatisticService.getInstance().removeOldFile()
+        FeedbackNudgeService.getInstance().maybeShowNudge(project)
         while (!ApplicationManager.getApplication().isUnitTestMode) {
             StatisticService.getInstance().writeStateToFile()
             delay(intervalSec.seconds)

--- a/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
+++ b/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
@@ -682,6 +682,8 @@
                      description="Support Spring Boot old versions before 2.4"/>
         <registryKey key="explyt.statistic.debug" defaultValue="false"
                      description="Enable statistic in debug mode"/>
+        <registryKey key="explyt.spring.feedback.nudge.debug" defaultValue="false"
+                     description="Force-show the feedback nudge on next startup (ignores engagement thresholds)"/>
         <registryKey key="explyt.statistic.interval" defaultValue="3600"
                      description="Update statistic interval seconds"/>
         <registryKey key="explyt.spring.agent.path" defaultValue=""

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -4,6 +4,11 @@
 explyt.spring.common.notifications=Explyt Spring
 explyt.spring.common.notifications.core=Spring Core
 explyt.spring.common.notifications.boot=Spring Boot
+explyt.spring.feedback.nudge.title=Enjoying Explyt Spring?
+explyt.spring.feedback.nudge.content=If the plugin saves you time, a quick rating or star helps other developers discover it. Thank you!
+explyt.spring.feedback.nudge.rate=Rate on Marketplace
+explyt.spring.feedback.nudge.star=Star on GitHub
+explyt.spring.feedback.nudge.dismiss=Don''t show again
 explyt.spring.inspection.bean.autowired=Incorrect @Autowired placement in Spring bean components
 explyt.spring.inspection.bean.autowired.type.none=Autowire failed. No beans of ''{0}'' found
 explyt.spring.inspection.bean.autowired.type.none.or=Autowire failed. No beans of ''{0}'' or ''{1}'' found

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecisionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecisionTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FeedbackNudgeDecisionTest {
+
+    private fun stats(
+        totalUsages: Int = MIN_TOTAL_USAGES_FOR_NUDGE,
+        distinctActiveDays: Int = MIN_ACTIVE_DAYS_FOR_NUDGE,
+        nudgeShown: Boolean = false,
+        dismissed: Boolean = false,
+    ) = NudgeStats(totalUsages, distinctActiveDays, nudgeShown, dismissed)
+
+    @Test
+    fun showsWhenThresholdsMet() {
+        assertTrue(shouldShowFeedbackNudge(stats()))
+    }
+
+    @Test
+    fun showsWhenWellAboveThresholds() {
+        assertTrue(shouldShowFeedbackNudge(stats(totalUsages = 500, distinctActiveDays = 42)))
+    }
+
+    @Test
+    fun hiddenWhenNotEnoughUsages() {
+        assertFalse(shouldShowFeedbackNudge(stats(totalUsages = MIN_TOTAL_USAGES_FOR_NUDGE - 1)))
+    }
+
+    @Test
+    fun hiddenWhenNotEnoughActiveDays() {
+        assertFalse(shouldShowFeedbackNudge(stats(distinctActiveDays = MIN_ACTIVE_DAYS_FOR_NUDGE - 1)))
+    }
+
+    @Test
+    fun hiddenWhenAlreadyShown() {
+        assertFalse(shouldShowFeedbackNudge(stats(nudgeShown = true)))
+    }
+
+    @Test
+    fun hiddenWhenDismissed() {
+        assertFalse(shouldShowFeedbackNudge(stats(dismissed = true)))
+    }
+
+    @Test
+    fun dismissedTakesPrecedenceOverHighEngagement() {
+        assertFalse(shouldShowFeedbackNudge(stats(totalUsages = 9999, distinctActiveDays = 99, dismissed = true)))
+    }
+
+    @Test
+    fun hiddenAtZeroEngagement() {
+        assertFalse(shouldShowFeedbackNudge(stats(totalUsages = 0, distinctActiveDays = 0)))
+    }
+}


### PR DESCRIPTION
Adds a one-time, non-intrusive notification inviting genuinely engaged users to rate the plugin on the JetBrains Marketplace or star it on GitHub. Directly targets the low rating-vote conversion.

## How it works
- Engagement is tracked locally only (no telemetry, no network) by riding the existing usage tracking in `StatisticService.addActionUsage`.
- The nudge is shown at most **once ever**, and only after the user is proven engaged: **>= 30 tracked usages across >= 3 distinct calendar days**.
- Three actions: **Rate on Marketplace**, **Star on GitHub**, **Don't show again** (permanent dismissal).
- State persists in a settings file (`explyt-spring-feedback.xml`) so "shown once" and "dismiss" survive restarts.
- Skipped in unit-test and headless modes.

## Design notes
- Decision logic is a pure function (`shouldShowFeedbackNudge`) with no platform dependencies, fully unit-tested.
- Balloon uses the star icon (`AllIcons.Nodes.Favorite`) to stand out.
- Debug registry key `explyt.spring.feedback.nudge.debug` (default `false`) force-shows the nudge for manual QA, ignoring thresholds. No effect in production.

## Files
- New: `FeedbackNudgeDecision.kt`, `FeedbackNudgeState.kt`, `FeedbackNudgeService.kt`, `FeedbackNudgeDecisionTest.kt`
- Wired: `StatisticService.kt`, `StatisticStartupActivity.kt`
- Strings: `SpringCoreBundle.properties`; registry key in `spring-core-plugin.xml`

## Tests
`:spring-core:test --tests "*FeedbackNudgeDecisionTest"` -> 8 tests, 0 failures.