### PR TITLE
fix: ConstructorBinding is not required in Spring Boot 3

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringConfigurationPropertiesConstructorBindingInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringConfigurationPropertiesConstructorBindingInspection.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections
+
+import com.explyt.inspection.SpringBaseUastLocalInspectionTool
+import com.explyt.spring.core.SpringCoreBundle.message
+import com.explyt.spring.core.SpringCoreClasses.CONFIGURATION_PROPERTIES
+import com.explyt.spring.core.SpringCoreClasses.CONSTRUCTOR_BINDING
+import com.explyt.spring.core.util.SpringBootUtil
+import com.explyt.util.ExplytPsiUtil.isMetaAnnotatedBy
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.uast.UClass
+
+/**
+ * Reports a redundant `@ConstructorBinding` on a single-constructor `@ConfigurationProperties` class.
+ *
+ * Since Spring Boot 3.0 `@ConstructorBinding` is no longer needed when a class (or record) has a single constructor:
+ * such a class is bound through its constructor automatically. The annotation is only meaningful when there are
+ * multiple constructors and one of them must be selected for binding.
+ *
+ * @see <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#constructingbinding-no-longer-needed-at-the-type-level">Spring Boot 3.0 Migration Guide</a>
+ */
+class SpringConfigurationPropertiesConstructorBindingInspection : SpringBaseUastLocalInspectionTool() {
+
+    override fun checkClass(
+        uClass: UClass,
+        manager: InspectionManager,
+        isOnTheFly: Boolean
+    ): Array<out ProblemDescriptor?> {
+        if (uClass.lang != KotlinLanguage.INSTANCE) return emptyArray()
+        val javaPsi = uClass.javaPsi
+        if (!javaPsi.isMetaAnnotatedBy(CONFIGURATION_PROPERTIES)) return emptyArray()
+        // The annotation only becomes redundant for a single-constructor class on Spring Boot 3.0+.
+        if (javaPsi.constructors.size > 1) return emptyArray()
+        if (!SpringBootUtil.isAtLeastSpringBoot3(javaPsi)) return emptyArray()
+
+        val problems = mutableListOf<ProblemDescriptor>()
+        for (annotationPsi in findRedundantConstructorBindingAnnotations(uClass)) {
+            problems += manager.createProblemDescriptor(
+                annotationPsi,
+                message("explyt.spring.inspection.kotlin.constructor.binding.redundant"),
+                isOnTheFly,
+                arrayOf<LocalQuickFix>(RemoveRedundantConstructorBindingFix()),
+                ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+            )
+        }
+        return problems.toTypedArray()
+    }
+
+    private fun findRedundantConstructorBindingAnnotations(uClass: UClass): List<PsiElement> {
+        val classAnnotations = uClass.uAnnotations
+            .filter { it.qualifiedName == CONSTRUCTOR_BINDING }
+            .mapNotNull { it.sourcePsi }
+        val constructorAnnotations = uClass.methods.asSequence()
+            .filter { it.isConstructor }
+            .flatMap { it.uAnnotations.asSequence() }
+            .filter { it.qualifiedName == CONSTRUCTOR_BINDING }
+            .mapNotNull { it.sourcePsi }
+            .toList()
+
+        return classAnnotations + constructorAnnotations
+    }
+}
+
+private class RemoveRedundantConstructorBindingFix : LocalQuickFix {
+
+    override fun getFamilyName(): String =
+        message("explyt.spring.inspection.kotlin.constructor.binding.redundant.fix")
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element: PsiElement = descriptor.psiElement ?: return
+        if (!element.isValid) return
+        // Capture the enclosing primary constructor before the annotation is removed so the now-redundant
+        // `constructor` keyword (only required because of the annotation) can be dropped afterwards.
+        val primaryConstructor = (element as? KtAnnotationEntry)?.parentOfType<KtPrimaryConstructor>()
+        element.delete()
+        primaryConstructor?.removeRedundantConstructorKeywordAndSpace()
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringConfigurationPropertiesNullableParametersInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringConfigurationPropertiesNullableParametersInspection.kt
@@ -8,7 +8,9 @@ package com.explyt.spring.core.inspections
 import com.explyt.inspection.SpringBaseUastLocalInspectionTool
 import com.explyt.spring.core.SpringCoreBundle
 import com.explyt.spring.core.SpringCoreClasses
+import com.explyt.spring.core.SpringCoreClasses.AUTOWIRED
 import com.explyt.spring.core.SpringCoreClasses.CONSTRUCTOR_BINDING
+import com.explyt.spring.core.util.SpringBootUtil
 import com.explyt.util.AddParameterMethodAnnotationKotlinFix
 import com.explyt.util.ExplytPsiUtil.getHighlightRange
 import com.explyt.util.ExplytPsiUtil.isMetaAnnotatedBy
@@ -31,6 +33,15 @@ class SpringConfigurationPropertiesNullableParametersInspection : SpringBaseUast
         val javaPsi = uClass.javaPsi
         if (!javaPsi.isMetaAnnotatedBy(SpringCoreClasses.CONFIGURATION_PROPERTIES)) return emptyArray()
         if (javaPsi.constructors.any { it?.isMetaAnnotatedBy(CONSTRUCTOR_BINDING) == true }) return emptyArray()
+        // Since Spring Boot 3.0 a single-constructor class is bound through its constructor automatically,
+        // so non-nullable properties are valid and must not be reported. Older Boot versions, @Autowired
+        // constructors, and classes with multiple constructors still rely on JavaBean (setter) binding unless
+        // @ConstructorBinding is present.
+        val singleConstructor = javaPsi.constructors.singleOrNull()
+        if (singleConstructor != null
+            && !singleConstructor.isMetaAnnotatedBy(AUTOWIRED)
+            && SpringBootUtil.isAtLeastSpringBoot3(javaPsi)
+        ) return emptyArray()
 
         val problems = mutableListOf<ProblemDescriptor>()
         for (method in uClass.methods) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/SpringBootUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/SpringBootUtil.kt
@@ -14,11 +14,13 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.concurrency.annotations.RequiresReadLock
+import com.intellij.util.text.VersionComparatorUtil
 
 
 private const val SPRING_BOOT_STARTER_SUFFIX = "-starter"
 private const val SPRING_BOOT_MAIN_STARTER = "spring-boot-starter"
 private const val SPRING_BOOT_KAFKA = "spring-kafka"
+private const val SPRING_BOOT_3_VERSION = "3.0"
 
 object SpringBootUtil {
 
@@ -32,6 +34,18 @@ object SpringBootUtil {
                 ProjectRootManager.getInstance(module.project)
             )
         }
+    }
+
+    /**
+     * Returns `true` when the detected Spring Boot version is 3.0 or later.
+     * Since Spring Boot 3.0 `@ConstructorBinding` is no longer needed at the type level and a single-constructor
+     * `@ConfigurationProperties` class is bound through its constructor automatically.
+     */
+    @RequiresReadLock
+    fun isAtLeastSpringBoot3(psiElement: PsiElement): Boolean {
+        val version = getSpringBootVersion(psiElement)
+        if (version.isEmpty()) return false
+        return VersionComparatorUtil.compare(version, SPRING_BOOT_3_VERSION) >= 0
     }
 
     @RequiresReadLock

--- a/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
+++ b/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
@@ -503,6 +503,17 @@
                          implementationClass="com.explyt.spring.core.inspections.SpringConfigurationPropertiesNullableParametersInspection"/>
 
         <localInspection language="UAST"
+                         shortName="SpringConfigurationPropertiesConstructorBindingInspection"
+                         groupBundle="messages.SpringCoreBundle"
+                         groupPath="Explyt Spring"
+                         groupKey="explyt.spring.common.notifications.core"
+                         bundle="messages.SpringCoreBundle"
+                         key="explyt.spring.inspection.kotlin.constructor.binding.redundant"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.explyt.spring.core.inspections.SpringConfigurationPropertiesConstructorBindingInspection"/>
+
+        <localInspection language="UAST"
                          shortName="SpringValueAnnotationInspection"
                          groupBundle="messages.SpringCoreBundle"
                          groupPath="Explyt Spring"

--- a/modules/spring-core/src/main/resources/inspectionDescriptions/SpringConfigurationPropertiesConstructorBindingInspection.html
+++ b/modules/spring-core/src/main/resources/inspectionDescriptions/SpringConfigurationPropertiesConstructorBindingInspection.html
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (c) 2026 Explyt Ltd
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<html lang="en">
+<head>
+    <title>Redundant @ConstructorBinding Inspection</title>
+</head>
+<body>
+
+<p>
+    Reports a redundant <code>@ConstructorBinding</code> annotation on a single-constructor
+    <code>@ConfigurationProperties</code> class.
+</p>
+
+<p>
+    Since Spring Boot 3.0 <code>@ConstructorBinding</code> is no longer needed when a class (or record) has a single
+    constructor: such a class is bound through its constructor automatically. The annotation should only be used when
+    there are multiple constructors and one of them must be selected for property binding.
+</p>
+
+<p><b>Example:</b></p>
+<pre><code lang="kotlin">
+@ConfigurationProperties(prefix = "some.prefix")
+data class SomeProperties @ConstructorBinding constructor( // @ConstructorBinding is redundant
+        val first: String,
+        val second: Long
+)
+</code></pre>
+
+<p>The quick-fix removes the redundant annotation.</p>
+
+</body>
+</html>

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -156,6 +156,8 @@ explyt.spring.inspection.kotlin.object=Kotlin object inspection
 explyt.spring.inspection.kotlin.object.title=It is not recommended to use a Kotlin object as a Spring Component. \
   Spring creates a redundant instance for a Kotlin object component and DI does not work.
 explyt.spring.inspection.kotlin.constructor.nullable=Class constructor properties annotated with @ConfigurationProperties must be nullable
+explyt.spring.inspection.kotlin.constructor.binding.redundant=@ConstructorBinding is redundant since Spring Boot 3.0 for a single-constructor class
+explyt.spring.inspection.kotlin.constructor.binding.redundant.fix=Remove redundant @ConstructorBinding
 explyt.spring.inspection.kotlin.object.fix=Replace 'object' to 'class'
 explyt.spring.inspection.method.same.class=Check call bean method from the same class
 explyt.spring.inspection.method.same.class.title=Not call AOP Spring methods from the same class. Proxy does not work in this case. Use a call through a proxy qualifier.

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringConfigurationPropertiesConstructorBindingInspectionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringConfigurationPropertiesConstructorBindingInspectionTest.kt
@@ -1,28 +1,62 @@
 /*
- * Copyright (c) 2024 Explyt Ltd
+ * Copyright (c) 2026 Explyt Ltd
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.explyt.spring.core.inspections.kotlin
 
-import com.explyt.spring.core.inspections.SpringConfigurationPropertiesNullableParametersInspection
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringConfigurationPropertiesConstructorBindingInspection
 import com.explyt.spring.test.ExplytInspectionKotlinTestCase
 import com.explyt.spring.test.TestLibrary
 import org.intellij.lang.annotations.Language
 
-class SpringConfigurationPropertiesNullableParametersInspectionTest : ExplytInspectionKotlinTestCase() {
+class SpringConfigurationPropertiesConstructorBindingInspectionTest : ExplytInspectionKotlinTestCase() {
 
     override val libraries: Array<TestLibrary> =
         arrayOf(TestLibrary.springContext_6_0_7, TestLibrary.springBootAutoConfigure_3_1_1)
 
     override fun setUp() {
         super.setUp()
-        myFixture.enableInspections(SpringConfigurationPropertiesNullableParametersInspection::class.java)
+        myFixture.enableInspections(SpringConfigurationPropertiesConstructorBindingInspection::class.java)
     }
 
-    fun testConfigurationPropertiesMultipleConstructorsError() {
-        // With several constructors and no @ConstructorBinding, Spring falls back to JavaBean (setter) binding,
-        // so non-nullable properties without defaults are still reported even on Spring Boot 3+.
+    fun testRedundantConstructorBindingOnConstructor() {
+        @Language("kotlin") val code = """
+            import org.springframework.boot.context.properties.bind.ConstructorBinding
+            import org.springframework.stereotype.Component
+            import org.springframework.boot.context.properties.ConfigurationProperties
+            
+            @Component
+            @ConfigurationProperties(prefix = "some.prefix")
+            data class SomeProperties <warning>@ConstructorBinding</warning> constructor(
+                val first: String,
+                val second: Long
+            )
+        """.trimIndent()
+        myFixture.configureByText("SomeProperties.kt", code)
+        myFixture.testHighlighting("SomeProperties.kt")
+    }
+
+    fun testRedundantConstructorBindingOnClass() {
+        @Language("kotlin") val code = """
+            import org.springframework.boot.context.properties.bind.ConstructorBinding
+            import org.springframework.stereotype.Component
+            import org.springframework.boot.context.properties.ConfigurationProperties
+            
+            @Component
+            @ConfigurationProperties(prefix = "some.prefix")
+            <warning><error>@ConstructorBinding</error></warning>
+            data class SomeProperties(
+                val first: String,
+                val second: Long
+            )
+        """.trimIndent()
+        myFixture.configureByText("SomeProperties.kt", code)
+        myFixture.testHighlighting("SomeProperties.kt")
+    }
+
+    fun testNoConstructorBinding() {
         @Language("kotlin") val code = """
             import org.springframework.stereotype.Component
             import org.springframework.boot.context.properties.ConfigurationProperties
@@ -30,87 +64,15 @@ class SpringConfigurationPropertiesNullableParametersInspectionTest : ExplytInsp
             @Component
             @ConfigurationProperties(prefix = "some.prefix")
             data class SomeProperties(
-                var first: String?,
-                <error>var mustBeNullable: String</error>
-            ) {
-                constructor() : this(null, "")
-            }
-        """.trimIndent()
-        myFixture.configureByText("SomeProperties.kt", code)
-        myFixture.testHighlighting("SomeProperties.kt")
-    }
-
-    fun testSpringBoot3SingleConstructorNoError() {
-        // Since Spring Boot 3.0 a single-constructor class is bound through its constructor automatically,
-        // so non-nullable properties are valid and must not be reported.
-        @Language("kotlin") val code = """
-            import org.springframework.stereotype.Component
-            import org.springframework.boot.context.properties.ConfigurationProperties
-            
-            @Component
-            @ConfigurationProperties(prefix = "some.prefix")
-            data class SomeProperties(
-                var first: String?,
-                var second: String
+                val first: String,
+                val second: Long
             )
         """.trimIndent()
         myFixture.configureByText("SomeProperties.kt", code)
         myFixture.testHighlighting("SomeProperties.kt")
     }
 
-    fun testSpringBoot3AutowiredConstructorError() {
-        // @Autowired prevents the constructor from being used as a property-binding constructor, so the JavaBean
-        // binding rules still apply even when Spring Boot 3+ is detected.
-        @Language("kotlin") val code = """
-            import org.springframework.beans.factory.annotation.Autowired
-            import org.springframework.stereotype.Component
-            import org.springframework.boot.context.properties.ConfigurationProperties
-            
-            @Component
-            @ConfigurationProperties(prefix = "some.prefix")
-            data class SomeProperties @Autowired constructor(
-                var first: String?,
-                <error>var mustBeNullable: String</error>
-            )
-        """.trimIndent()
-        myFixture.configureByText("SomeProperties.kt", code)
-        myFixture.testHighlighting("SomeProperties.kt")
-    }
-
-    fun testNoConfigurationProperties() {
-        @Language("kotlin") val code = """
-            import org.springframework.stereotype.Component
-            import org.springframework.boot.context.properties.ConfigurationProperties
-            
-            @Component
-            //@ConfigurationProperties(prefix = "some.prefix")
-            data class SomeProperties(
-                var first: String?,
-                var notAProblem: String
-            )
-        """.trimIndent()
-        myFixture.configureByText("SomeProperties.kt", code)
-        myFixture.testHighlighting("SomeProperties.kt")
-    }
-
-    fun testConfigurationPropertiesSuccess() {
-        @Language("kotlin") val code = """
-            import org.springframework.stereotype.Component
-            import org.springframework.boot.context.properties.ConfigurationProperties
-            
-            @Component
-            @ConfigurationProperties(prefix = "some.prefix")
-            data class SomeProperties(
-                var first: String?,
-                var notAProblemA: String = "A",
-                val notAProblemB: String = "B"
-            )
-        """.trimIndent()
-        myFixture.configureByText("SomeProperties.kt", code)
-        myFixture.testHighlighting("SomeProperties.kt")
-    }
-
-    fun testConstructorBinding() {
+    fun testMultipleConstructorsNoWarning() {
         @Language("kotlin") val code = """
             import org.springframework.boot.context.properties.bind.ConstructorBinding
             import org.springframework.stereotype.Component
@@ -119,15 +81,17 @@ class SpringConfigurationPropertiesNullableParametersInspectionTest : ExplytInsp
             @Component
             @ConfigurationProperties(prefix = "some.prefix")
             data class SomeProperties @ConstructorBinding constructor(
-                var first: String,
-                var second: Long
-            )
+                val first: String,
+                val second: Long
+            ) {
+                constructor() : this("", 0)
+            }
         """.trimIndent()
         myFixture.configureByText("SomeProperties.kt", code)
         myFixture.testHighlighting("SomeProperties.kt")
     }
 
-    fun testNotConstructorMethod() {
+    fun testRemoveRedundantConstructorBindingFromConstructorQuickFix() {
         @Language("kotlin") val code = """
             import org.springframework.boot.context.properties.bind.ConstructorBinding
             import org.springframework.stereotype.Component
@@ -135,16 +99,62 @@ class SpringConfigurationPropertiesNullableParametersInspectionTest : ExplytInsp
             
             @Component
             @ConfigurationProperties(prefix = "some.prefix")
-            data class SomeProperties(
-                var first: String?,
-                var notAProblemA: String = "A",
-                val notAProblemB: String = "B"
-            ) {
-                fun getTest(orgId1: String) = "test"
-            }        
-
+            data class SomeProperties @ConstructorB<caret>inding constructor(
+                val first: String,
+                val second: Long
+            )
         """.trimIndent()
         myFixture.configureByText("SomeProperties.kt", code)
-        myFixture.testHighlighting("SomeProperties.kt")
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.kotlin.constructor.binding.redundant.fix")
+        val intention = myFixture.findSingleIntention(fixName)
+        myFixture.launchAction(intention)
+
+        @Language("kotlin") val expected = """
+            import org.springframework.boot.context.properties.bind.ConstructorBinding
+            import org.springframework.stereotype.Component
+            import org.springframework.boot.context.properties.ConfigurationProperties
+            
+            @Component
+            @ConfigurationProperties(prefix = "some.prefix")
+            data class SomeProperties(
+                val first: String,
+                val second: Long
+            )
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
+
+    fun testRemoveRedundantConstructorBindingFromClassQuickFix() {
+        @Language("kotlin") val code = """
+            import org.springframework.boot.context.properties.bind.ConstructorBinding
+            import org.springframework.stereotype.Component
+            import org.springframework.boot.context.properties.ConfigurationProperties
+            
+            @Component
+            @ConfigurationProperties(prefix = "some.prefix")
+            @ConstructorB<caret>inding
+            data class SomeProperties(
+                val first: String,
+                val second: Long
+            )
+        """.trimIndent()
+        myFixture.configureByText("SomeProperties.kt", code)
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.kotlin.constructor.binding.redundant.fix")
+        val intention = myFixture.findSingleIntention(fixName)
+        myFixture.launchAction(intention)
+
+        @Language("kotlin") val expected = """
+            import org.springframework.boot.context.properties.bind.ConstructorBinding
+            import org.springframework.stereotype.Component
+            import org.springframework.boot.context.properties.ConfigurationProperties
+            
+            @Component
+            @ConfigurationProperties(prefix = "some.prefix")
+            data class SomeProperties(
+                val first: String,
+                val second: Long
+            )
+        """.trimIndent()
+        myFixture.checkResult(expected)
     }
 }


### PR DESCRIPTION
## Summary
- Add a Spring Boot 3+ inspection that reports redundant `@ConstructorBinding` on single-constructor Kotlin `@ConfigurationProperties` classes.
- Keep `@ConstructorBinding` valid for classes with multiple constructors, where it selects the constructor used for property binding.
- Update nullable-parameter inspection behavior for Spring Boot 3+: single-constructor properties classes are treated as constructor-bound automatically, except when the constructor is `@Autowired`.
- Register the new inspection with description, bundle messages, and quick-fix support.

## Tests
- `SpringConfigurationPropertiesConstructorBindingInspectionTest`
- `SpringConfigurationPropertiesNullableParametersInspectionTest`