### PR TITLE
feat: migrate @MockBean/@SpyBean to @MockitoBean/@MockitoSpyBean (Spring Boot 4)

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4MockBeanMigrationInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4MockBeanMigrationInspection.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections
+
+import com.explyt.spring.core.SpringCoreBundle.message
+import com.explyt.spring.core.inspections.quickfix.RewriteAnnotationQuickFix
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiModifierListOwner
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.getParentOfType
+
+/**
+ * Reports Spring Boot's `@MockBean` / `@SpyBean` test annotations, removed in Spring Boot 4.0, and offers a
+ * quick-fix that replaces them with Spring Framework's `@MockitoBean` / `@MockitoSpyBean`.
+ *
+ * Only runs in a Spring Boot 4+ project.
+ *
+ * @see <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide">Spring Boot 4.0 Migration Guide</a>
+ */
+class SpringBoot4MockBeanMigrationInspection : Spring4UastLocalInspectionTool() {
+
+    override fun isAvailableForFile(file: PsiFile): Boolean {
+        return super.isAvailableForFile(file) && isAnyClassAvailable(file, MOCK_BEAN, SPY_BEAN)
+    }
+
+    override fun checkField(field: UField, manager: InspectionManager, isOnTheFly: Boolean): Array<ProblemDescriptor> {
+        val problems = mutableListOf<ProblemDescriptor>()
+        for ((oldFqn, newFqn) in REPLACEMENTS) {
+            val annotation = field.findAnnotation(oldFqn) ?: continue
+            problems += createProblem(annotation, oldFqn, newFqn, manager, isOnTheFly) ?: continue
+        }
+        return problems.toTypedArray()
+    }
+
+    private fun createProblem(
+        annotation: UAnnotation,
+        oldFqn: String,
+        newFqn: String,
+        manager: InspectionManager,
+        isOnTheFly: Boolean
+    ): ProblemDescriptor? {
+        val highlightElement = annotation.sourcePsi ?: return null
+        // The annotation owner is the annotated field; RewriteAnnotationQuickFix removes the old annotation and
+        // adds the new one (handling imports) for both Java and Kotlin via the field's light PsiModifierListOwner.
+        val owner = annotation.getParentOfType<UField>()?.javaPsi as? PsiModifierListOwner ?: return null
+        val newShortName = newFqn.substringAfterLast('.')
+        return manager.createProblemDescriptor(
+            highlightElement,
+            message("explyt.spring.inspection.boot4.mockbean", newShortName),
+            isOnTheFly,
+            arrayOf<LocalQuickFix>(RewriteAnnotationQuickFix(newFqn, owner, oldFqn)),
+            ProblemHighlightType.LIKE_DEPRECATED
+        )
+    }
+
+    companion object {
+        private const val MOCK_BEAN = "org.springframework.boot.test.mock.mockito.MockBean"
+        private const val SPY_BEAN = "org.springframework.boot.test.mock.mockito.SpyBean"
+        private const val MOCKITO_BEAN = "org.springframework.test.context.bean.override.mockito.MockitoBean"
+        private const val MOCKITO_SPY_BEAN = "org.springframework.test.context.bean.override.mockito.MockitoSpyBean"
+
+        // old annotation FQN -> new annotation FQN
+        private val REPLACEMENTS: Map<String, String> = mapOf(
+            MOCK_BEAN to MOCKITO_BEAN,
+            SPY_BEAN to MOCKITO_SPY_BEAN,
+        )
+    }
+}

--- a/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
+++ b/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
@@ -547,6 +547,17 @@
                          implementationClass="com.explyt.spring.core.inspections.SpringKotlinInternalBeanInspection"/>
 
         <localInspection language="UAST"
+                         shortName="SpringBoot4MockBeanMigrationInspection"
+                         groupBundle="messages.SpringCoreBundle"
+                         groupPath="Explyt Spring"
+                         groupKey="explyt.spring.common.notifications.boot"
+                         bundle="messages.SpringCoreBundle"
+                         key="explyt.spring.inspection.boot4.mockbean.name"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.explyt.spring.core.inspections.SpringBoot4MockBeanMigrationInspection"/>
+
+        <localInspection language="UAST"
                          shortName="SpringEntityScanInspection"
                          groupBundle="messages.SpringCoreBundle"
                          groupPath="Explyt Spring"

--- a/modules/spring-core/src/main/resources/inspectionDescriptions/SpringBoot4MockBeanMigrationInspection.html
+++ b/modules/spring-core/src/main/resources/inspectionDescriptions/SpringBoot4MockBeanMigrationInspection.html
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright (c) 2026 Explyt Ltd
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<html lang="en">
+<head>
+    <title>Spring Boot 4 MockBean/SpyBean Migration Inspection</title>
+</head>
+<body>
+
+<p>
+    Reports Spring Boot's <code>@MockBean</code> / <code>@SpyBean</code> test annotations, which were removed in
+    Spring Boot 4.0, and offers a quick-fix that replaces them with Spring Framework's
+    <code>@MockitoBean</code> / <code>@MockitoSpyBean</code> (updating the import).
+</p>
+
+<p>
+    Only runs in a Spring Boot 4+ project.
+</p>
+
+<p><b>Example:</b></p>
+<pre><code lang="java">
+// before
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@MockBean
+private UserService userService;
+
+// after
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@MockitoBean
+private UserService userService;
+</code></pre>
+
+<p>
+    See the
+    <a href="https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide">Spring Boot 4.0 Migration Guide</a>.
+</p>
+
+</body>
+</html>

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -229,3 +229,5 @@ explyt.spring.debugger.property.inlay.hints=Explyt: property runtime value
 explyt.spring.properties.action.yaml=Convert Properties to YAML
 explyt.spring.properties.action.prop=Convert YAML to Properties
 explyt.spring.inspection.boot4.import.migrate.fix=Update import to the Spring Boot 4 package
+explyt.spring.inspection.boot4.mockbean.name=Spring Boot 4 MockBean/SpyBean migration
+explyt.spring.inspection.boot4.mockbean=This annotation was removed in Spring Boot 4. Use ''@{0}''

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4MockBeanMigrationInspectionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4MockBeanMigrationInspectionTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.inspections.SpringBoot4MockBeanMigrationInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+class SpringBoot4MockBeanMigrationInspectionTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        addAnnotationStubs()
+        myFixture.enableInspections(SpringBoot4MockBeanMigrationInspection::class.java)
+    }
+
+    private fun addAnnotationStubs() {
+        myFixture.addClass(
+            """
+            package org.springframework.boot.test.mock.mockito;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.FIELD, ElementType.TYPE})
+            public @interface MockBean { }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.boot.test.mock.mockito;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.FIELD, ElementType.TYPE})
+            public @interface SpyBean { }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.test.context.bean.override.mockito;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.FIELD, ElementType.TYPE})
+            public @interface MockitoBean { }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.test.context.bean.override.mockito;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.FIELD, ElementType.TYPE})
+            public @interface MockitoSpyBean { }
+            """.trimIndent()
+        )
+        myFixture.addClass("public class UserService { }")
+    }
+
+    fun testMockBeanReported() {
+        myFixture.configureByText(
+            "MyTest.java",
+            """
+            import org.springframework.boot.test.mock.mockito.MockBean;
+            
+            public class MyTest {
+                <warning descr="This annotation was removed in Spring Boot 4. Use '@MockitoBean'">@MockBean</warning>
+                private UserService userService;
+            }
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("MyTest.java")
+    }
+
+    fun testSpyBeanReported() {
+        myFixture.configureByText(
+            "MyTest.java",
+            """
+            import org.springframework.boot.test.mock.mockito.SpyBean;
+            
+            public class MyTest {
+                <warning descr="This annotation was removed in Spring Boot 4. Use '@MockitoSpyBean'">@SpyBean</warning>
+                private UserService userService;
+            }
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("MyTest.java")
+    }
+
+    fun testMockitoBeanNotReported() {
+        myFixture.configureByText(
+            "MyTest.java",
+            """
+            import org.springframework.test.context.bean.override.mockito.MockitoBean;
+            
+            public class MyTest {
+                @MockitoBean
+                private UserService userService;
+            }
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("MyTest.java")
+    }
+
+    fun testMockBeanQuickFix() {
+        myFixture.configureByText(
+            "MyTest.java",
+            """
+            import org.springframework.boot.test.mock.mockito.MockBean;
+            
+            public class MyTest {
+                @Mock<caret>Bean
+                private UserService userService;
+            }
+            """.trimIndent()
+        )
+        val intention = myFixture.availableIntentions
+            .firstOrNull { it.text.contains("MockitoBean") }
+        requireNotNull(intention) { "Replace-annotation quick-fix not found; available: " + myFixture.availableIntentions.map { it.text } }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue("new annotation should be applied:\n$result", result.contains("@MockitoBean"))
+        assertTrue(
+            "new import should be added:\n$result",
+            result.contains("import org.springframework.test.context.bean.override.mockito.MockitoBean;")
+        )
+        // The annotation use itself must be replaced; the now-unused old import is left for the IDE's
+        // "unused import" inspection to clean up and is not the responsibility of this quick-fix.
+        assertFalse("old annotation use should be removed:\n$result", result.contains("@MockBean"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Spring Boot 4+ inspection that flags Spring Boot's removed test annotations \`@MockBean\` / \`@SpyBean\` (\`org.springframework.boot.test.mock.mockito.*\`) and offers a quick-fix replacing them with Spring Framework's \`@MockitoBean\` / \`@MockitoSpyBean\` (\`org.springframework.test.context.bean.override.mockito.*\`), updating the import.
- Field-level usage is covered; works for both Java and Kotlin via UAST. Reuses the existing \`RewriteAnnotationQuickFix\`.
- Only runs in a Spring Boot 4+ project (\`SpringBootUtil.isAtLeastSpringBoot4\`).
- Note: the quick-fix replaces the annotation use and adds the new import; the now-unused old import is left for the IDE's unused-import inspection.

## Tests
- \`SpringBoot4MockBeanMigrationInspectionTest\` (4 tests)

---
Note: this branch re-adds the small \`SpringBootUtil.isAtLeastSpringBoot4(...)\` helper and the \`springBoot_4_0_0\` test library, which are also added by sibling Spring Boot 4 PRs. Expect a trivial first-merge-wins conflict in \`SpringBootUtil.kt\` / \`TestLibrary.kt\`.