### PR TITLE
feat: Spring Boot 4 inspection base classes (per-file version gating)

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/Spring4LocalInspectionTool.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/Spring4LocalInspectionTool.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections
+
+import com.explyt.inspection.SpringBaseLocalInspectionTool
+import com.explyt.spring.core.util.SpringBootUtil
+import com.intellij.psi.PsiFile
+
+/**
+ * Base class for inspections that only apply to Spring Boot 4+ projects.
+ *
+ * The Spring Boot version is checked once per file in [isAvailableForFile] (instead of on every visited PSI element),
+ * so the inspection never builds a visitor or walks PSI in projects that are not on Spring Boot 4+.
+ */
+abstract class Spring4LocalInspectionTool : SpringBaseLocalInspectionTool() {
+
+    override fun isAvailableForFile(file: PsiFile): Boolean {
+        return super.isAvailableForFile(file) && SpringBootUtil.isAtLeastSpringBoot4(file)
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/Spring4UastLocalInspectionTool.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/Spring4UastLocalInspectionTool.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections
+
+import com.explyt.inspection.SpringBaseUastLocalInspectionTool
+import com.explyt.spring.core.util.SpringBootUtil
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiFile
+
+/**
+ * Base class for UAST inspections that only apply to Spring Boot 4+ projects.
+ *
+ * The Spring Boot version is checked once per file in [isAvailableForFile] (instead of on every visited PSI element),
+ * so the inspection never builds a visitor or walks PSI in projects that are not on Spring Boot 4+.
+ */
+abstract class Spring4UastLocalInspectionTool : SpringBaseUastLocalInspectionTool() {
+
+    override fun isAvailableForFile(file: PsiFile): Boolean {
+        return super.isAvailableForFile(file) && SpringBootUtil.isAtLeastSpringBoot4(file)
+    }
+
+    protected fun isClassAvailable(file: PsiFile, fqn: String): Boolean {
+        return JavaPsiFacade.getInstance(file.project).findClass(fqn, file.resolveScope) != null
+    }
+
+    protected fun isAnyClassAvailable(file: PsiFile, vararg fqns: String): Boolean {
+        return fqns.any { isClassAvailable(file, it) }
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/MigrateImportQuickFix.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/MigrateImportQuickFix.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.quickfix
+
+import com.explyt.spring.core.SpringCoreBundle.message
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.idea.base.psi.replaced
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.resolve.ImportPath
+
+/**
+ * Quick-fix that migrates an import of [oldFqName] to [newFqName] within the file containing the highlighted element.
+ *
+ * Used by the "package moved" Spring Boot 4 inspections, where the simple class name is unchanged: rewriting the
+ * import is what actually migrates every usage in the file. The problem itself is highlighted on the visible type
+ * usage (a field/parameter type), not on the import statement.
+ */
+class MigrateImportQuickFix(
+    private val oldFqName: String,
+    private val newFqName: String
+) : LocalQuickFix {
+
+    override fun getFamilyName(): String = message("explyt.spring.inspection.boot4.import.migrate.fix")
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        when (val file = descriptor.psiElement.containingFile) {
+            is KtFile -> migrateKotlinImport(project, file)
+            is PsiJavaFile -> migrateJavaImport(project, file)
+        }
+    }
+
+    private fun migrateKotlinImport(project: Project, file: KtFile) {
+        val importDirective = file.importDirectives
+            .firstOrNull { it.importedFqName?.asString() == oldFqName && !it.isAllUnder } ?: return
+        val newImport = KtPsiFactory(project).createImportDirective(ImportPath(FqName(newFqName), false))
+        importDirective.replaced(newImport)
+    }
+
+    private fun migrateJavaImport(project: Project, file: PsiJavaFile) {
+        val importStatement = file.importList?.importStatements
+            ?.firstOrNull { it.qualifiedName == oldFqName && !it.isOnDemand } ?: return
+        val psiClass = JavaPsiFacade.getInstance(project)
+            .findClass(newFqName, GlobalSearchScope.allScope(project)) ?: return
+        val newImport = JavaPsiFacade.getInstance(project).elementFactory.createImportStatement(psiClass)
+        importStatement.replace(newImport)
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/SpringBootUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/SpringBootUtil.kt
@@ -21,6 +21,7 @@ private const val SPRING_BOOT_STARTER_SUFFIX = "-starter"
 private const val SPRING_BOOT_MAIN_STARTER = "spring-boot-starter"
 private const val SPRING_BOOT_KAFKA = "spring-kafka"
 private const val SPRING_BOOT_3_VERSION = "3.0"
+private const val SPRING_BOOT_4_VERSION = "4.0"
 
 object SpringBootUtil {
 
@@ -46,6 +47,16 @@ object SpringBootUtil {
         val version = getSpringBootVersion(psiElement)
         if (version.isEmpty()) return false
         return VersionComparatorUtil.compare(version, SPRING_BOOT_3_VERSION) >= 0
+    }
+
+    /**
+     * Returns `true` when the detected Spring Boot version is 4.0 or later.
+     */
+    @RequiresReadLock
+    fun isAtLeastSpringBoot4(psiElement: PsiElement): Boolean {
+        val version = getSpringBootVersion(psiElement)
+        if (version.isEmpty()) return false
+        return VersionComparatorUtil.compare(version, SPRING_BOOT_4_VERSION) >= 0
     }
 
     @RequiresReadLock

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -228,3 +228,4 @@ explyt.spring.debugger.root.node=You can use: 'Explyt.context' or 'Explyt.getBea
 explyt.spring.debugger.property.inlay.hints=Explyt: property runtime value
 explyt.spring.properties.action.yaml=Convert Properties to YAML
 explyt.spring.properties.action.prop=Convert YAML to Properties
+explyt.spring.inspection.boot4.import.migrate.fix=Update import to the Spring Boot 4 package

--- a/modules/test-framework/src/main/kotlin/com/explyt/spring/test/TestLibrary.kt
+++ b/modules/test-framework/src/main/kotlin/com/explyt/spring/test/TestLibrary.kt
@@ -23,6 +23,7 @@ data class TestLibrary(val mavenCoordinates: String, val includeTransitiveDepend
         val springCloud_4_1_3 = TestLibrary("org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3", true)
 
         val springBoot_3_1_1: TestLibrary = TestLibrary("org.springframework.boot:spring-boot:3.1.1")
+        val springBoot_4_0_0: TestLibrary = TestLibrary("org.springframework.boot:spring-boot:4.0.0")
         val springBootAutoConfigure_3_1_1: TestLibrary = TestLibrary("org.springframework.boot:spring-boot-autoconfigure:3.1.1")
         val springBootTestAutoConfigure_3_1_1: TestLibrary =
             TestLibrary("org.springframework.boot:spring-boot-test-autoconfigure:3.1.1")


### PR DESCRIPTION
## Summary
Foundational change for the Spring Boot 4 migration inspections (#257-#264), addressing review feedback from @grisha9.

- Add \`SpringBootUtil.isAtLeastSpringBoot4(...)\` (cached per module) — single canonical home, instead of each Boot 4 PR re-adding it.
- Add base classes \`Spring4LocalInspectionTool\` and \`Spring4UastLocalInspectionTool\` that check the Spring Boot 4 version **once per file** in \`isAvailableForFile\` (extending the existing \`SpringBase*LocalInspectionTool\`). This means a Boot 4 inspection never builds a visitor or walks PSI in projects that are not on Spring Boot 4+.
- Add \`springBoot_4_0_0\` test library.

Rationale (per review): the version check was being done per PSI element inside \`buildVisitor\`/\`checkX\`; moving it to \`isAvailableForFile\` runs it once per file and short-circuits the whole inspection for non-Boot-4 projects.

## Follow-up
Each Boot 4 inspection PR (#257-#264) will be rebased onto this branch to extend \`Spring4*LocalInspectionTool\` and drop its inline \`isAtLeastSpringBoot4\` call + duplicated helper. The import-based inspections (#259/#261/#262) will additionally be reworked to highlight visible code (type references / annotation usages) instead of import statements.