### PR TITLE
feat: Copy full property path and copy as environment variable for properties/YAML

### DIFF
--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/action/CopyPropertyKeyActions.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/action/CopyPropertyKeyActions.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.action
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.SpringIcons
+import com.explyt.spring.core.util.ActionUtil
+import com.explyt.spring.core.util.PropertyUtil
+import com.intellij.lang.properties.PropertiesFileType
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.ide.CopyPasteManager
+import java.awt.datatransfer.StringSelection
+import org.jetbrains.yaml.YAMLFileType
+
+/**
+ * Base action that copies the canonical key of the property/YAML entry under the caret to the clipboard.
+ * Concrete actions decide how the resolved key is transformed before copying.
+ */
+abstract class CopyPropertyKeyActionBase(text: String) : AnAction(text) {
+
+    init {
+        templatePresentation.icon = SpringIcons.Property
+    }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        ActionUtil.isEnabledAndVisible(e, resolveFullKey(e) != null)
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val fullKey = resolveFullKey(e) ?: return
+        CopyPasteManager.getInstance().setContents(StringSelection(transform(fullKey)))
+    }
+
+    protected abstract fun transform(fullKey: String): String
+
+    private fun resolveFullKey(e: AnActionEvent): String? {
+        val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null
+        if (virtualFile.fileType != PropertiesFileType.INSTANCE && virtualFile.fileType != YAMLFileType.YML) return null
+
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return null
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE) ?: return null
+        val offset = editor.caretModel.offset
+        val element = psiFile.findElementAt(offset)
+            ?: psiFile.findElementAt(offset - 1)
+            ?: return null
+        return PropertyUtil.getFullPropertyKey(element)?.takeIf { it.isNotBlank() }
+    }
+}
+
+/**
+ * Copies the full canonical property path (e.g. `spring.datasource.url`) of the key under the caret.
+ */
+class CopyPropertyPathAction :
+    CopyPropertyKeyActionBase(SpringCoreBundle.message("explyt.spring.properties.action.copy.path")) {
+
+    override fun transform(fullKey: String): String = fullKey
+}
+
+/**
+ * Copies the environment variable name of the key under the caret following Spring Boot relaxed binding rules
+ * (e.g. `spring.datasource.url` -> `SPRING_DATASOURCE_URL`).
+ */
+class CopyPropertyAsEnvVariableAction :
+    CopyPropertyKeyActionBase(SpringCoreBundle.message("explyt.spring.properties.action.copy.env")) {
+
+    override fun transform(fullKey: String): String = PropertyUtil.toEnvironmentVariableName(fullKey)
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -333,6 +333,41 @@ object PropertyUtil {
         return toCommonPropertyForm(propertyName).uppercase().replace(".", "_")
     }
 
+    /**
+     * Converts a canonical configuration property name to its environment variable name
+     * following Spring Boot relaxed binding rules:
+     * - replace dots with underscores,
+     * - remove any dashes,
+     * - convert to uppercase,
+     * - list indexes are surrounded with underscores (`my.list[0].name` -> `MY_LIST_0_NAME`).
+     *
+     * See "Binding From Environment Variables" in the Spring Boot reference documentation.
+     */
+    fun toEnvironmentVariableName(propertyName: String): String {
+        val builder = StringBuilder(propertyName.length)
+        for (char in propertyName) {
+            when (char) {
+                '.', '[' -> builder.append('_')
+                ']', '-' -> Unit // drop closing brackets and dashes
+                else -> builder.append(char.uppercaseChar())
+            }
+        }
+        return builder.toString()
+            .replace(UNDERSCORE_SEQUENCE_REGEX, "_")
+            .trim('_')
+    }
+
+    /**
+     * Resolves the full canonical property key for the given element (typically the element under the caret).
+     * Works both for `.properties` ([IProperty]) and YAML ([YAMLKeyValue]) files.
+     */
+    fun getFullPropertyKey(element: PsiElement?): String? {
+        if (element == null) return null
+        element.parentOfType<PropertyImpl>(withSelf = true)?.let { return it.key }
+        element.parentOfType<YAMLKeyValue>(withSelf = true)?.let { return YAMLUtil.getConfigFullName(it) }
+        return null
+    }
+
     fun toBooleanAlias(property: String, type: String?): String {
         return if (type == JavaCoreClasses.BOOLEAN || type == PrimitiveTypes.BOOLEAN) {
             val result = property.substringBeforeLast(".")
@@ -683,6 +718,7 @@ object PropertyUtil {
 
     val VALUE_REGEX = """\$\{([^:]*):?(.*)?\}""".toRegex()
     private val PROPERTY_WORDS_SEPARATOR_REGEX = """[_\-]""".toRegex()
+    private val UNDERSCORE_SEQUENCE_REGEX = "_+".toRegex()
     private val INT_REGEX = "[-+]?[0-9]+".toRegex()
     private val DOUBLE_REGEX = "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?".toRegex()
 

--- a/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
+++ b/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
@@ -818,6 +818,14 @@
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
         </action>
 
+        <action id="Explyt.CopyPropertyPathAction" class="com.explyt.spring.core.action.CopyPropertyPathAction">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
+        <action id="Explyt.CopyPropertyAsEnvVariableAction"
+                class="com.explyt.spring.core.action.CopyPropertyAsEnvVariableAction">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
+
         <group id="Explyt.SpringBootProjectRefreshActionGroup">
             <action id="Explyt.SpringBootProjectRefreshAction"
                     class="com.explyt.spring.core.externalsystem.action.SpringBootFloatingProjectRefreshAction">

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -228,3 +228,5 @@ explyt.spring.debugger.root.node=You can use: 'Explyt.context' or 'Explyt.getBea
 explyt.spring.debugger.property.inlay.hints=Explyt: property runtime value
 explyt.spring.properties.action.yaml=Convert Properties to YAML
 explyt.spring.properties.action.prop=Convert YAML to Properties
+explyt.spring.properties.action.copy.path=Copy Full Property Path
+explyt.spring.properties.action.copy.env=Copy Property as Environment Variable

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/action/CopyPropertyKeyActionsTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/action/CopyPropertyKeyActionsTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.action
+
+import com.explyt.spring.test.ExplytBaseLightTestCase
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.testFramework.TestActionEvent
+import java.awt.datatransfer.DataFlavor
+
+class CopyPropertyKeyActionsTest : ExplytBaseLightTestCase() {
+
+    fun testCopyPathFromProperties() {
+        myFixture.configureByText("application.properties", "spring.datasource.ur<caret>l=jdbc:h2:mem:test")
+        assertEquals("spring.datasource.url", performCopy(CopyPropertyPathAction()))
+    }
+
+    fun testCopyEnvFromProperties() {
+        myFixture.configureByText("application.properties", "spring.main.log-startup-in<caret>fo=true")
+        assertEquals("SPRING_MAIN_LOGSTARTUPINFO", performCopy(CopyPropertyAsEnvVariableAction()))
+    }
+
+    fun testCopyPathFromYaml() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+                spring:
+                  datasource:
+                    ur<caret>l: jdbc:h2:mem:test
+            """.trimIndent()
+        )
+        assertEquals("spring.datasource.url", performCopy(CopyPropertyPathAction()))
+    }
+
+    fun testCopyEnvFromYaml() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+                my:
+                  main-project:
+                    person:
+                      first-na<caret>me: John
+            """.trimIndent()
+        )
+        assertEquals("MY_MAINPROJECT_PERSON_FIRSTNAME", performCopy(CopyPropertyAsEnvVariableAction()))
+    }
+
+    fun testActionDisabledInNonPropertyFile() {
+        myFixture.configureByText("Sample.java", "class Sam<caret>ple {}")
+        val presentation = updatePresentation(CopyPropertyPathAction())
+        assertFalse(presentation.isEnabledAndVisible)
+    }
+
+    private fun performCopy(action: AnAction): String? {
+        val event = TestActionEvent.createTestEvent(action, dataContext())
+        action.update(event)
+        assertTrue("Action is expected to be enabled and visible", event.presentation.isEnabledAndVisible)
+        action.actionPerformed(event)
+        return CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor)
+    }
+
+    private fun updatePresentation(action: AnAction) =
+        TestActionEvent.createTestEvent(action, dataContext()).also { action.update(it) }.presentation
+
+    private fun dataContext() = SimpleDataContext.builder()
+        .add(CommonDataKeys.PROJECT, project)
+        .add(CommonDataKeys.EDITOR, myFixture.editor)
+        .add(CommonDataKeys.PSI_FILE, myFixture.file)
+        .add(CommonDataKeys.VIRTUAL_FILE, myFixture.file.virtualFile)
+        .build()
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/PropertyUtilEnvVariableTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/PropertyUtilEnvVariableTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.util
+
+import org.junit.Assert
+import org.junit.Test
+
+class PropertyUtilEnvVariableTest {
+
+    @Test
+    fun testSimpleKey() {
+        Assert.assertEquals("SPRING_DATASOURCE_URL", PropertyUtil.toEnvironmentVariableName("spring.datasource.url"))
+    }
+
+    @Test
+    fun testDashesAreRemoved() {
+        Assert.assertEquals(
+            "SPRING_MAIN_LOGSTARTUPINFO",
+            PropertyUtil.toEnvironmentVariableName("spring.main.log-startup-info")
+        )
+        Assert.assertEquals(
+            "MY_MAINPROJECT_PERSON_FIRSTNAME",
+            PropertyUtil.toEnvironmentVariableName("my.main-project.person.first-name")
+        )
+    }
+
+    @Test
+    fun testListIndexIsSurroundedWithUnderscores() {
+        Assert.assertEquals("MY_SERVICE_0_OTHER", PropertyUtil.toEnvironmentVariableName("my.service[0].other"))
+    }
+
+    @Test
+    fun testTrailingListIndex() {
+        Assert.assertEquals("MY_LIST_10", PropertyUtil.toEnvironmentVariableName("my.list[10]"))
+    }
+
+    @Test
+    fun testAlreadyUppercaseKeptStable() {
+        Assert.assertEquals("SERVER_PORT", PropertyUtil.toEnvironmentVariableName("SERVER.PORT"))
+    }
+
+    @Test
+    fun testMapKeyWithDots() {
+        Assert.assertEquals(
+            "LOGGING_LEVEL_ORG_HIBERNATE_SQL",
+            PropertyUtil.toEnvironmentVariableName("logging.level.org.hibernate.SQL")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds two editor popup-menu actions for Spring configuration files (`.properties` and `.yaml`/`.yml`), available on the key under the caret:

- **Copy Full Property Path** — copies the canonical dotted key (e.g. `spring.datasource.url`). For YAML it flattens the nested path via `YAMLUtil.getConfigFullName`.
- **Copy Property as Environment Variable** — copies the key converted using Spring Boot [relaxed binding](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties.relaxed-binding.environment-variables) rules: replace `.` with `_`, drop `-`, uppercase, and surround list indexes with underscores (e.g. `my.list[0].name` → `MY_LIST_0_NAME`).

Both actions are added to `EditorPopupMenu`, next to the existing "Convert Properties to YAML" / "Convert YAML to Properties" actions, and are enabled only inside `.properties`/YAML files when the caret is on a property key.

### Implementation notes
- New `CopyPropertyKeyActions.kt` (`spring-core`) with a shared `CopyPropertyKeyActionBase` and two concrete actions.
- New helpers in `PropertyUtil`: `toEnvironmentVariableName(String)` (relaxed-binding conversion) and `getFullPropertyKey(PsiElement?)` (resolves the full key for both `IProperty` and `YAMLKeyValue`).
- Bundle keys `explyt.spring.properties.action.copy.path` / `.copy.env` added to `SpringCoreBundle.properties`.

## Related issue

n/a

## Type of change

- [ ] Bug fix
- [x] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

New tests, all green:

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.util.PropertyUtilEnvVariableTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.action.CopyPropertyKeyActionsTest"
```

- `PropertyUtilEnvVariableTest` — unit tests for the relaxed-binding conversion (dashes, list indexes, map keys, already-uppercase).
- `CopyPropertyKeyActionsTest` — light-fixture tests that place the caret in `.properties`/YAML, invoke each action, and assert the clipboard contents; plus a negative test that the action is hidden in a `.java` file.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [ ] I updated relevant documentation (README / wiki / bundle messages) if behavior changed.
- [x] I did **not** include links to internal infrastructure in public content.
