### PR TITLE
feat: Remove linemarkers for paid ultimate

### DIFF
--- a/modules/base/src/main/kotlin/com/explyt/plugin/PluginUtils.kt
+++ b/modules/base/src/main/kotlin/com/explyt/plugin/PluginUtils.kt
@@ -6,6 +6,7 @@
 package com.explyt.plugin
 
 import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.lang.Language
 import com.intellij.openapi.extensions.PluginId
 
@@ -26,6 +27,29 @@ enum class PluginIds(val pluginId: String) {
     fun isEnabled() = findEnabled() != null
 
     fun isNotEnabled() = !isEnabled()
+
+    /**
+     * The plugin is enabled and paid Ultimate functionality is unlocked.
+     *
+     * Since the unified IntelliJ IDEA distribution, JetBrains plugins like [SPRING_JB] and [SPRING_BOOT_JB]
+     * are bundled and enabled even in the free mode, but their paid features (line markers, inspections, etc.)
+     * are cut: content modules requiring `com.intellij.modules.ultimate` are not loaded.
+     * The OSS Community build does not bundle them at all.
+     */
+    fun isEnabledWithUltimate() = isEnabled() && isUltimateEnabled()
+
+    companion object {
+        private val ULTIMATE_MODULE_ID = PluginId.getId("com.intellij.modules.ultimate")
+
+        /**
+         * Paid Ultimate mode: the `com.intellij.modules.ultimate` module exists and is not disabled.
+         * In the free mode of the unified distribution this module is disabled;
+         * in the OSS Community build it does not exist at all.
+         */
+        fun isUltimateEnabled(): Boolean =
+            !PluginManagerCore.isDisabled(ULTIMATE_MODULE_ID)
+                    && PluginManager.getInstance().findEnabledPlugin(ULTIMATE_MODULE_ID) != null
+    }
 }
 
 enum class PluginSqlLanguage(val langId: String) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/ConfigurationPropertyLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/ConfigurationPropertyLineMarkerProvider.kt
@@ -5,6 +5,7 @@
 
 package com.explyt.spring.core.providers
 
+import com.explyt.plugin.PluginIds
 import com.explyt.spring.core.SpringCoreBundle
 import com.explyt.spring.core.SpringIcons
 import com.explyt.spring.core.SpringProperties.COLON
@@ -35,6 +36,7 @@ class ConfigurationPropertyLineMarkerProvider : RelatedItemLineMarkerProvider() 
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
         if (!SpringCoreUtil.isSpringProject(element.project)) return
         val uParent = getUParentForIdentifier(element) ?: return
         val dataRetriever = ConfigurationPropertyDataRetrieverFactory.createFor(uParent) ?: return

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/EventListenerLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/EventListenerLineMarkerProvider.kt
@@ -6,6 +6,7 @@
 package com.explyt.spring.core.providers
 
 import com.explyt.base.LibraryClassCache
+import com.explyt.plugin.PluginIds
 import com.explyt.spring.core.SpringCoreBundle
 import com.explyt.spring.core.SpringCoreClasses.APPLICATION_LISTENER
 import com.explyt.spring.core.SpringCoreClasses.EVENT_LISTENER
@@ -47,6 +48,7 @@ class EventListenerLineMarkerProvider : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
+        if (PluginIds.SPRING_JB.isEnabledWithUltimate()) return
         val uParent = getUParentForIdentifier(element)
         if (uParent is UMethod) {
             val psiMethod = uParent.javaPsi

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
@@ -5,6 +5,7 @@
 
 package com.explyt.spring.core.providers
 
+import com.explyt.plugin.PluginIds
 import com.explyt.spring.core.SpringCoreBundle
 import com.explyt.spring.core.SpringIcons
 import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
@@ -29,6 +30,7 @@ class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
         if (!SpringCoreUtil.isConfigurationPropertyFile(element.containingFile)) {
             return
         }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/SpringBeanLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/SpringBeanLineMarkerProvider.kt
@@ -54,6 +54,7 @@ class SpringBeanLineMarkerProvider : RelatedItemLineMarkerProvider() {
         elements: MutableList<out PsiElement>,
         result: MutableCollection<in LineMarkerInfo<*>>
     ) {
+        if (PluginIds.SPRING_JB.isEnabledWithUltimate()) return
         val module = getModule(elements)
         if (module == null) {
             SpringBeanLineMarkerProviderNativeLibrary().collectSlowLineMarkers(elements, result)


### PR DESCRIPTION
## Summary

This PR disables Explyt Spring line markers when JetBrains paid Ultimate Spring/Spring Boot functionality is available, preventing duplicate or overlapping gutter markers in paid IntelliJ IDEA Ultimate.

At the same time, it keeps Explyt line markers enabled in free unified IntelliJ IDEA mode and OSS Community cases, where JetBrains Spring plugins are either cut by the missing `com.intellij.modules.ultimate` module or absent entirely.

Main changes:
- Added centralized Ultimate-aware plugin detection in `PluginUtils`.
- Replaced plain JetBrains Spring/Spring Boot plugin checks in line marker providers with [isEnabledWithUltimate](isEnabledWithUltimate).
- Updated Spring bean, event listener, configuration property, and property line marker providers to skip Explyt markers only when the corresponding JetBrains Ultimate functionality is actually available.

## Related issue

n/a

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

Not run.

No tests were added because this is a small platform/environment guard change around IntelliJ plugin availability checks. The behavior depends on IDE distribution/plugin state:
- paid IntelliJ IDEA Ultimate: JetBrains Spring/Spring Boot markers should be used instead of Explyt duplicates;
- free unified IntelliJ IDEA: Explyt markers should remain available because JetBrains paid functionality is disabled;
- OSS Community: Explyt markers should remain available when JetBrains Spring plugins are absent.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed.