### PR TITLE
fix: Resolve Kotlin const val package names in component-scan annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fix: Close the quoted placeholder in the Spring Boot 4 property migration message (#272)
 - feat: Add Jakarta namespace migration inspection (`javax` to `jakarta`) (#253)
 - fix: Resolve list/map element property keys below digit-boundary names such as `s3Logs` (#271)
+- fix: Resolve Kotlin `const val` package names in component-scan annotations
 
 ### Spring Data
 - fix: Fail closed on stale PSI in SQL injector (#235) (#242)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringComponentScanInvalidPackageInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringComponentScanInvalidPackageInspection.kt
@@ -18,6 +18,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.ElementManipulators
 import org.jetbrains.uast.UClass
+import org.jetbrains.uast.ULiteralExpression
 
 class SpringComponentScanInvalidPackageInspection : SpringBaseUastLocalInspectionTool() {
     override fun checkClass(
@@ -35,22 +36,26 @@ class SpringComponentScanInvalidPackageInspection : SpringBaseUastLocalInspectio
                         COMPONENT_SCAN, CONFIGURATION_PROPERTIES_SCAN -> setOf("value", SpringCoreUtil.BASE_PACKAGES)
                         else -> setOf(SpringCoreUtil.BASE_PACKAGES, SpringCoreUtil.SCAN_BASE_PACKAGES)
                     }
-                val attributesAsPsiLiteral = ExplytAnnotationUtil.getAttributeValues(annotation, attributesName)
+                val attributeValues = ExplytAnnotationUtil.getAttributeValues(annotation, attributesName)
 
-                attributesAsPsiLiteral.mapNotNull { it.sourcePsi }.forEach attributes@{ sourcePsi ->
-                    val text = ElementManipulators.getValueText(sourcePsi)
-                    val range = ElementManipulators.getValueTextRange(sourcePsi)
-                    val words = text.split(".")
+                attributeValues.forEach attributes@{ expression ->
+                    val packageName = expression.evaluate() as? String ?: return@attributes
+                    val sourcePsi = expression.sourcePsi ?: return@attributes
+                    val sourceRange = ElementManipulators.getValueTextRange(sourcePsi)
+                    val isPlainLiteral = expression is ULiteralExpression
+                            && ElementManipulators.getValueText(sourcePsi) == packageName
+                    val words = packageName.split(".")
 
                     var path = ""
                     for (word in words) {
                         path += word
 
                         if (!packageFqnSearcher.isPackageExist(path)) {
-                            val curTextRange = TextRange(
-                                0,
-                                path.length
-                            ).shiftRight(range.startOffset)
+                            val curTextRange = if (isPlainLiteral) {
+                                TextRange(0, path.length).shiftRight(sourceRange.startOffset)
+                            } else {
+                                sourceRange
+                            }
 
                             problems.add(
                                 manager.createProblemDescriptor(

--- a/modules/spring-core/testdata/java/inspection/componentScan/expected.xml
+++ b/modules/spring-core/testdata/java/inspection/componentScan/expected.xml
@@ -285,4 +285,79 @@
         <length>7</length>
     </problem>
 
+    <problem>
+        <file>TestComponentScan.java</file>
+        <line>60</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.ConstPackageComponentScan.InvalidScalar"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>JAVA</language>
+        <offset>19</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.java</file>
+        <line>64</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.ConstPackageComponentScan.InvalidArray"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>JAVA</language>
+        <offset>35</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.java</file>
+        <line>65</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.ConstPackageComponentScan.InvalidArray"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>JAVA</language>
+        <offset>93</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.java</file>
+        <line>66</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.ConstPackageComponentScan.InvalidArray"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>JAVA</language>
+        <offset>47</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.java</file>
+        <line>72</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.CrossFileConstPackageComponentScan"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>ScanConstants.INVALID_BASE_PACKAGE</highlighted_element>
+        <language>JAVA</language>
+        <offset>31</offset>
+        <length>34</length>
+    </problem>
+
 </problems>

--- a/modules/spring-core/testdata/java/inspection/componentScan/src/com/component/scan/ScanConstants.java
+++ b/modules/spring-core/testdata/java/inspection/componentScan/src/com/component/scan/ScanConstants.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.component.scan;
+
+public final class ScanConstants {
+    public static final String BASE_PACKAGE = "com.component.scan";
+    public static final String INVALID_BASE_PACKAGE = "com.component.invalid";
+
+    private ScanConstants() {
+    }
+}

--- a/modules/spring-core/testdata/java/inspection/componentScan/src/com/component/scan/TestComponentScan.java
+++ b/modules/spring-core/testdata/java/inspection/componentScan/src/com/component/scan/TestComponentScan.java
@@ -42,3 +42,44 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication("**.4")
 public class TestComponentScan {
 }
+
+class ConstPackageComponentScan {
+    static final String BASE_PACKAGE = "com.component.scan";
+    static final String INVALID_BASE_PACKAGE = "com.component.invalid";
+
+    @ComponentScan(BASE_PACKAGE)
+    static class ValidScalar {
+    }
+
+    @ComponentScan(basePackages = {BASE_PACKAGE})
+    @org.springframework.boot.context.properties.ConfigurationPropertiesScan(basePackages = {BASE_PACKAGE})
+    @SpringBootApplication(scanBasePackages = {BASE_PACKAGE})
+    static class ValidArray {
+    }
+
+    @ComponentScan(INVALID_BASE_PACKAGE)
+    static class InvalidScalar {
+    }
+
+    @ComponentScan(basePackages = {INVALID_BASE_PACKAGE})
+    @org.springframework.boot.context.properties.ConfigurationPropertiesScan(basePackages = {INVALID_BASE_PACKAGE})
+    @SpringBootApplication(scanBasePackages = {INVALID_BASE_PACKAGE})
+    static class InvalidArray {
+    }
+}
+
+@ComponentScan(ScanConstants.BASE_PACKAGE)
+@ComponentScan(basePackages = {ScanConstants.INVALID_BASE_PACKAGE})
+class CrossFileConstPackageComponentScan {
+}
+
+class NonConstPackageComponentScan {
+    static String nonConstPackage() {
+        return "com.component.invalid";
+    }
+
+    // Not a compile-time constant: the inspection must stay silent instead of parsing the source text.
+    @ComponentScan(nonConstPackage())
+    static class NonConstArgument {
+    }
+}

--- a/modules/spring-core/testdata/kotlin/inspection/componentScan/expected.xml
+++ b/modules/spring-core/testdata/kotlin/inspection/componentScan/expected.xml
@@ -241,4 +241,79 @@
         <length>6</length>
     </problem>
 
+    <problem>
+        <file>TestComponentScan.kt</file>
+        <line>56</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.InvalidConstPackageComponentScan"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>kotlin</language>
+        <offset>15</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.kt</file>
+        <line>57</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.InvalidConstPackageComponentScan"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>kotlin</language>
+        <offset>31</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.kt</file>
+        <line>58</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.InvalidConstPackageComponentScan"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>kotlin</language>
+        <offset>89</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.kt</file>
+        <line>59</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.InvalidConstPackageComponentScan"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>INVALID_BASE_PACKAGE</highlighted_element>
+        <language>kotlin</language>
+        <offset>43</offset>
+        <length>20</length>
+    </problem>
+
+    <problem>
+        <file>TestComponentScan.kt</file>
+        <line>63</line>
+        <module>light_idea_test_case</module>
+        <package>com.component.scan</package>
+        <entry_point TYPE="class" FQNAME="com.component.scan.CrossFileConstPackageComponentScan"/>
+        <problem_class id="SpringComponentScanInvalidPackage" severity="ERROR"
+                       attribute_key="WRONG_REFERENCES_ATTRIBUTES"/>
+        <description>Can't find package</description>
+        <highlighted_element>CROSS_FILE_INVALID_BASE_PACKAGE</highlighted_element>
+        <language>kotlin</language>
+        <offset>31</offset>
+        <length>31</length>
+    </problem>
+
 </problems>

--- a/modules/spring-core/testdata/kotlin/inspection/componentScan/src/com/component/scan/ScanConstants.kt
+++ b/modules/spring-core/testdata/kotlin/inspection/componentScan/src/com/component/scan/ScanConstants.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.component.scan
+
+const val CROSS_FILE_BASE_PACKAGE = "com.component.scan"
+const val CROSS_FILE_INVALID_BASE_PACKAGE = "com.component.invalid"

--- a/modules/spring-core/testdata/kotlin/inspection/componentScan/src/com/component/scan/TestComponentScan.kt
+++ b/modules/spring-core/testdata/kotlin/inspection/componentScan/src/com/component/scan/TestComponentScan.kt
@@ -43,3 +43,28 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication("**.4")
 public class TestComponentScan {
 }
+
+const val BASE_PACKAGE = "com.component.scan"
+const val INVALID_BASE_PACKAGE = "com.component.invalid"
+
+@ComponentScan(BASE_PACKAGE)
+@ComponentScan(basePackages = [BASE_PACKAGE])
+@org.springframework.boot.context.properties.ConfigurationPropertiesScan(basePackages = [BASE_PACKAGE])
+@SpringBootApplication(scanBasePackages = [BASE_PACKAGE])
+class ConstPackageComponentScan
+
+@ComponentScan(INVALID_BASE_PACKAGE)
+@ComponentScan(basePackages = [INVALID_BASE_PACKAGE])
+@org.springframework.boot.context.properties.ConfigurationPropertiesScan(basePackages = [INVALID_BASE_PACKAGE])
+@SpringBootApplication(scanBasePackages = [INVALID_BASE_PACKAGE])
+class InvalidConstPackageComponentScan
+
+@ComponentScan(CROSS_FILE_BASE_PACKAGE)
+@ComponentScan(basePackages = [CROSS_FILE_INVALID_BASE_PACKAGE])
+class CrossFileConstPackageComponentScan
+
+fun nonConstPackage() = "com.component.invalid"
+
+// Not a compile-time constant: the inspection must stay silent instead of parsing the source text.
+@ComponentScan(nonConstPackage())
+class NonConstPackageComponentScan


### PR DESCRIPTION
## Summary

Fixes the `SpringComponentScanInvalidPackageInspection` ("Can't find package") false positive when the scan package is supplied via a compile-time constant instead of a string literal, e.g. `@ComponentScan(basePackages = [BASE_PACKAGE])` with a Kotlin `const val` or a Java `static final String`.

The inspection now validates the evaluated value of the annotation argument via `UExpression.evaluate()` instead of parsing the source text. Plain string literals keep the existing partial-prefix highlighting; constant references are highlighted whole at the annotation site; non-constant (non-evaluable) expressions are intentionally left silent.

## Related issue

n/a — no issue filed yet

## Type of change

- [x] Bug fix

## How was this tested?

Extended both fixtures: valid and invalid constants (same-file and cross-file), `@ComponentScan` scalar/array, `@ConfigurationPropertiesScan` and `@SpringBootApplication` arrays, plus non-constant expressions asserting silence. Run sequentially:

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.kotlin.SpringComponentScanInspectionTest.testComponentScan"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.java.SpringComponentScanInspectionTest.testComponentScan"
```
Both pass (BUILD SUCCESSFUL).

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed. (CHANGELOG entry added)
