### PR TITLE
fix: Resolve @Value placeholder keys with SpEL or nested defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - fix: Harden Spring Boot 3/4 migration inspections and quick-fixes for Java, Kotlin, unresolved imports, YAML sequences, and module scopes (#279)
 - fix: Resolve list/map element property keys below digit-boundary names such as `s3Logs` (#271)
 - fix: Resolve Kotlin `const val` package names in component-scan annotations
+- fix: Resolve `@Value` placeholder keys whose default is a SpEL or nested placeholder expression, such as `${my.key:#{null}}`
 
 ### Spring Data
 - fix: Fail closed on stale PSI in SQL injector (#235) (#242)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/ValueConfigurationPropertyReferenceProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/ValueConfigurationPropertyReferenceProvider.kt
@@ -22,7 +22,22 @@ import org.jetbrains.uast.getParentOfType
 class ValueConfigurationPropertyReferenceProvider : UastInjectionHostReferenceProvider() {
 
     companion object {
-        val PROPERTIES_PATTERN = """\$\{([.A-z\d_-]+)(:[^{]*)?\s*\}""".toPattern()
+        /**
+         * The default value (everything after the first `:`) may itself contain one brace-delimited
+         * expression: a SpEL default such as `:#{null}` or a nested placeholder such as
+         * `:$\{fallback.key}`. Such a group must be consumed as a whole, otherwise the placeholder
+         * key is not extracted at all, no property reference is created, and the property looks
+         * unused - producing false "Cannot resolve key property" warnings in properties and YAML
+         * files.
+         *
+         * Only one level of nesting is supported, which covers the defaults Spring accepts here.
+         * The alternatives are mutually exclusive by their first character and quantified
+         * possessively on purpose: this provider runs while computing references for editable
+         * annotation text, and an ambiguous alternation backtracks exponentially on input such as
+         * `$\{x:` followed by many `$\{a}` groups, which would freeze highlighting.
+         */
+        val PROPERTIES_PATTERN =
+            """\$\{([.A-z\d_-]+)(:(?:[^{}$]|\$(?!\{)|\$\{[^{}]*+}|\{[^{}]*+})*+)?\s*+}""".toPattern()
     }
 
     override fun getReferencesForInjectionHost(

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringYamlInspectionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringYamlInspectionTest.kt
@@ -165,6 +165,49 @@ explyt.camel:
         myFixture.testHighlighting("application.yaml")
     }
 
+    /**
+     * A property that only ever appears in a `@Value` placeholder with a SpEL default
+     * (`:#{null}`) is still a real, resolvable property. The nested brace group used to break
+     * placeholder key extraction, so no reference was created and the key was reported as
+     * unresolved even though Spring injects it at runtime.
+     */
+    fun testKeyUsedOnlyInValueWithSpelDefault() {
+        @Language("java") val knownProperties = """
+            @org.springframework.boot.context.properties.ConfigurationProperties(prefix = "explyt.placeholder")
+            public class PlaceholderKnownProperties {
+                private String known;
+                public String getKnown() { return known; }
+                public void setKnown(String known) { this.known = known; }
+            }
+        """.trimIndent()
+        myFixture.addClass(knownProperties)
+
+        @Language("java") val consumer = """
+            import org.springframework.beans.factory.annotation.Value;
+
+            @org.springframework.stereotype.Component
+            public class PlaceholderConsumer {
+                @Value("${'$'}{explyt.placeholder.spel-default:#{null}}")
+                private String spelDefault;
+
+                @Value("${'$'}{explyt.placeholder.plain-default:someDefault}")
+                private String plainDefault;
+            }
+        """.trimIndent()
+        myFixture.addClass(consumer)
+
+        myFixture.configureByText(
+            "application.yaml",
+            """
+explyt.placeholder:
+  known: someValue
+  spel-default: someValue
+  plain-default: someValue
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("application.yaml")
+    }
+
     fun testComplexKebabCaseProperties() {
         myFixture.configureByText(
             "application.yaml",

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringYamlInspectionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringYamlInspectionTest.kt
@@ -81,7 +81,43 @@ explyt.digit:
 explyt.camel:
   camelWritten:
     items:
-      - <warning descr="Should be kebab-case">name</warning>: first
+            - <warning descr="Should be kebab-case">name</warning>: first
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("application.yaml")
+    }
+
+    /**
+     * A property that only ever appears in a `@Value` placeholder with a SpEL default
+     * (`:#{null}`) is still a real, resolvable property. The nested brace group used to break
+     * placeholder key extraction, so no reference was created and the key was reported as
+     * unresolved even though Spring injects it at runtime.
+     */
+    fun testKeyUsedOnlyInValueWithSpelDefault() {
+        @Language("kotlin") val consumer = """
+            import org.springframework.beans.factory.annotation.Value
+            import org.springframework.boot.context.properties.ConfigurationProperties
+            import org.springframework.stereotype.Component
+
+            @ConfigurationProperties(prefix = "explyt.placeholder")
+            class PlaceholderKnownProperties {
+                var known: String = ""
+            }
+
+            @Component
+            class PlaceholderConsumer(
+                @Value("\${'$'}{explyt.placeholder.spel-default:#{null}}") val spelDefault: String?,
+                @Value("\${'$'}{explyt.placeholder.plain-default:someDefault}") val plainDefault: String,
+            )
+        """.trimIndent()
+        myFixture.addFileToProject("PlaceholderConsumer.kt", consumer)
+        myFixture.configureByText(
+            "application.yaml",
+            """
+explyt.placeholder:
+  known: someValue
+  spel-default: someValue
+  plain-default: someValue
             """.trimIndent()
         )
         myFixture.testHighlighting("application.yaml")

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/kotlin/ValueConfigurationPropertyReferenceProviderTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/kotlin/ValueConfigurationPropertyReferenceProviderTest.kt
@@ -5,8 +5,12 @@
 
 package com.explyt.spring.core.properties.kotlin
 
+import com.explyt.spring.core.properties.providers.ValueConfigurationPropertyReferenceProvider
 import com.explyt.spring.test.ExplytKotlinLightTestCase
 import com.explyt.spring.test.TestLibrary
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.util.PsiTreeUtil
+import kotlin.system.measureTimeMillis
 
 class ValueConfigurationPropertyReferenceProviderTest : ExplytKotlinLightTestCase() {
 
@@ -57,5 +61,119 @@ class ValueConfigurationPropertyReferenceProviderTest : ExplytKotlinLightTestCas
 
         val ref = file.findReferenceAt(myFixture.caretOffset)
         assertNotNull("Expected a property reference for the literal placeholder", ref)
+    }
+
+    /**
+     * A SpEL default such as `:#{null}` introduces a nested brace group inside the placeholder.
+     * The key must still be extracted, otherwise no property reference is created and the property
+     * is reported as unresolved in properties/YAML files.
+     */
+    fun testValueWithSpelDefaultResolvesReference() {
+        assertPlaceholderReference("${'$'}{my.prop<caret>erty:#{null}}")
+    }
+
+    /** A nested placeholder default is also brace-delimited and must not break key extraction. */
+    fun testValueWithNestedPlaceholderDefaultResolvesReference() {
+        assertPlaceholderReference("${'$'}{my.prop<caret>erty:${'$'}{fallback.key}}")
+    }
+
+    /** Plain and empty defaults keep working. */
+    fun testValueWithPlainDefaultsResolveReference() {
+        assertPlaceholderReference("${'$'}{my.prop<caret>erty:}")
+        assertPlaceholderReference("${'$'}{my.prop<caret>erty:someDefault}")
+        assertPlaceholderReference("${'$'}{my.prop<caret>erty:VeaiGPT/}")
+    }
+
+    /** Each placeholder in a composite value contributes its own key. */
+    fun testValueWithSeveralPlaceholdersResolvesEveryKey() {
+        assertExtractedKeys(
+            "${'$'}{first.key} between ${'$'}{second.key:#{null}}",
+            "first.key", "second.key"
+        )
+    }
+
+    /** A pure SpEL value holds no property placeholder, so no property key may be extracted. */
+    fun testPureSpelValueHasNoPropertyKey() {
+        assertExtractedKeys("#{someBean.someProperty}")
+    }
+
+    /** An unterminated placeholder must not be silently treated as a resolvable key. */
+    fun testUnbalancedPlaceholderHasNoPropertyKey() {
+        assertExtractedKeys("${'$'}{my.property:#{null}")
+    }
+
+    /** The extracted key must never include the default value. */
+    fun testExtractedKeyExcludesDefaultValue() {
+        assertExtractedKeys("${'$'}{my.property:#{null}}", "my.property")
+        assertExtractedKeys("${'$'}{my.property:${'$'}{fallback.key}}", "my.property")
+        assertExtractedKeys("${'$'}{my.property:someDefault}", "my.property")
+        assertExtractedKeys("${'$'}{my.property:}", "my.property")
+        assertExtractedKeys("${'$'}{my.property}", "my.property")
+    }
+
+    /**
+     * Guards the placeholder pattern against catastrophic backtracking: an ambiguous alternation
+     * over brace groups takes exponential time on this input (~350 ms at 22 groups and minutes
+     * beyond that), which would freeze highlighting while the user edits an annotation.
+     */
+    fun testDeeplyRepeatedBraceGroupsMatchInLinearTime() {
+        val value = "${'$'}{my.property:" + "${'$'}{a}".repeat(200)
+        val elapsedMs = measureTimeMillis {
+            ValueConfigurationPropertyReferenceProvider.PROPERTIES_PATTERN.matcher(value).find()
+        }
+        assertTrue(
+            "Placeholder matching took $elapsedMs ms, expected far below the 2000 ms guard",
+            elapsedMs < 2000
+        )
+    }
+
+    /**
+     * Configures a component whose `@Value` argument is the given placeholder and asserts that a
+     * reference is offered at the caret.
+     *
+     * The fixture is Kotlin source, so every `$` must be escaped: an unescaped `${...}` would be
+     * parsed as a Kotlin string template instead of a literal placeholder, and the test would
+     * exercise template resolution rather than the provider under test.
+     */
+    private fun assertPlaceholderReference(placeholder: String) {
+        val escapedPlaceholder = placeholder.replace("$", "\\$")
+        myFixture.configureByText(
+            "TestComponent.kt",
+            """
+            import org.springframework.beans.factory.annotation.Value
+
+            class TestComponent {
+                @Value("$escapedPlaceholder")
+                private val injected: String = ""
+            }
+            """.trimIndent()
+        )
+        assertNoParseErrors(placeholder)
+
+        // The caret sits inside the key, so a reference must be offered there. The exact key
+        // boundaries are asserted separately in testExtractedKeyExcludesDefaultValue.
+        val reference = file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected a reference for placeholder '$placeholder'", reference)
+    }
+
+    /** Fails if the generated fixture does not parse, which would silently invalidate the test. */
+    private fun assertNoParseErrors(placeholder: String) {
+        val error = PsiTreeUtil.findChildOfType(file, PsiErrorElement::class.java)
+        assertNull(
+            "The fixture for placeholder '$placeholder' does not parse as Kotlin: ${error?.errorDescription}",
+            error
+        )
+    }
+
+    /** Asserts the keys the provider's placeholder pattern extracts from an annotation value. */
+    private fun assertExtractedKeys(value: String, vararg expectedKeys: String) {
+        val matcher = ValueConfigurationPropertyReferenceProvider.PROPERTIES_PATTERN.matcher(value)
+        val actualKeys = generateSequence { if (matcher.find()) matcher.group(1) else null }.toList()
+
+        assertEquals(
+            "Unexpected placeholder keys extracted from '$value'",
+            expectedKeys.toList(),
+            actualKeys
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes a false positive `Cannot resolve key property` reported by `SpringYamlInspection` / `SpringPropertiesInspection` for a property whose only usage is a `@Value` placeholder with a brace-delimited default, such as:

```kotlin
@Value("\${enterprise.common.onprem-account-ui-url:#{null}}")
private val onpremAccountUiUrl: String?
```

`ValueConfigurationPropertyReferenceProvider.PROPERTIES_PATTERN` matched the default value with `[^{]*`, which cannot cross the `{` of `#{null}`. The **whole** placeholder therefore failed to match, no `ExplytPropertyReference` was created, and the reference-based fallback in `SpringBasePropertyInspection.getProblemKey` (`SpringSearchUtils.getAllReferencesToElement`) found no usages and flagged the key — although Spring injects it fine at runtime.

The default now consumes one brace-delimited group, covering both a SpEL default (`:#{null}`) and a nested placeholder default (`:${fallback.key}`).

### Note on the regex shape

The obvious form `(:(?:[^{}]|\$?\{[^{}]*})*)?` is **ambiguous** — `${a}` can match either as one group or as `$` plus `{a}` — which backtracks exponentially. Measured on JDK 21 with the shipped IDE runtime:

| Nested `${a}` groups | Match time |
|---|---:|
| 10 | 2 ms |
| 15 | 11 ms |
| 20 | 94 ms |
| 22 | 356 ms |

This provider runs while computing references for **editable annotation text**, so that would freeze highlighting as the user types. The committed pattern makes the alternatives mutually exclusive by first character and quantified possessively: **2000 groups in ~1 ms**. A timing-guard test locks this in.

## Related issue

Refs #276 — that issue tracks a *different* cause of the same message (keys consumed only from a **dependency module**), which is **not** addressed here. It is blocked on multi-module test-fixture support in `test-framework`; see the issue for the evidence matrix.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

Each class run individually (see caveat below):

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.kotlin.SpringYamlInspectionTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.java.SpringYamlInspectionTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.properties.kotlin.ValueConfigurationPropertyReferenceProviderTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.kotlin.SpringPropertiesInspectionTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.java.SpringPropertiesInspectionTest"
```

All pass. **Red/green verified**: with only the provider file stashed, the new tests fail
(`testKeyUsedOnlyInValueWithSpelDefault`, `testExtractedKeyExcludesDefaultValue`,
`testValueWithSeveralPlaceholdersResolvesEveryKey`); with the fix they pass.

New coverage:

- `SpringYamlInspectionTest` (Java + Kotlin twins) — end-to-end: the key is no longer flagged in `application.yaml`.
- `ValueConfigurationPropertyReferenceProviderTest` — key extraction excludes the default; multiple placeholders in one value; pure `#{...}` SpEL yields no property key; unbalanced braces yield no key; plain/empty/slash defaults still work; backtracking timing guard.

Caveat worth flagging: a broad wildcard run (`--tests "*propert*" --tests "*Yaml*" ...`) reports ~254 failures, but this is **pre-existing and environmental** — it reproduces on unmodified `main`, and the same classes pass when run individually. It looks like shared-sandbox/test-result interference in large batches, unrelated to this change.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. _(no new files; existing headers untouched)_
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed. _(CHANGELOG entry added; no user-visible string or inspection registration changed)_
