### PR TITLE
fix: resolve property keys consumed only from a dependency module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - fix: Harden Spring Boot 3/4 migration inspections and quick-fixes for Java, Kotlin, unresolved imports, YAML sequences, and module scopes (#279)
 - fix: Resolve list/map element property keys below digit-boundary names such as `s3Logs` (#271)
 - fix: Resolve Kotlin `const val` package names in component-scan annotations
+- fix: Resolve property keys consumed only from a dependency module (#276)
 
 ### Spring Data
 - fix: Fail closed on stale PSI in SQL injector (#235) (#242)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
@@ -136,7 +136,10 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
                     //this means that the property is defined directly in the file
                     continue
                 }
-                val psiReferences = SpringSearchUtils.getAllReferencesToElement(elementFileProperty)
+                // Dependency modules must be searched too: a key may be consumed only from a
+                // module the configuration file's module depends on (issue #276).
+                val psiReferences =
+                    SpringSearchUtils.getAllReferencesToElementWithDependencies(elementFileProperty)
                 if (psiReferences.isEmpty()) {
                     problems += manager.createProblemDescriptor(
                         psiKey,

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
@@ -53,6 +53,7 @@ import com.intellij.psi.search.searches.MethodReferencesSearch
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.serviceContainer.AlreadyDisposedException
 import com.intellij.uast.UastModificationTracker
 import com.jetbrains.rd.util.getOrCreate
@@ -761,6 +762,48 @@ object SpringSearchUtils {
                 ModificationTrackerManager.getInstance(project).getUastModelAndLibraryTracker()
             )
         }
+    }
+
+    /**
+     * Finds references to [element], also looking into the modules the containing module depends on.
+     *
+     * [getAllReferencesToElement] relies on the default `ReferencesSearch` scope, which the platform
+     * intersects with the element's *use scope*. For a configuration file that use scope is the
+     * owning module plus its dependents, which deliberately excludes the modules the owner depends
+     * on. A property consumed only from a dependency module therefore looks unused (issue #276).
+     *
+     * Spring resolves placeholders against the whole application classpath, so both directions of
+     * the module graph matter: the dependents scope keeps the previous behaviour, and the
+     * dependencies scope adds the modules the configuration file's module depends on. Libraries are
+     * excluded on purpose - placeholder usages live in project sources, and this runs on-the-fly.
+     *
+     * The result is cached on [PsiModificationTracker.MODIFICATION_COUNT] rather than the narrower
+     * UAST model tracker used by [getAllReferencesToElement]: `MyUastPsiTreeChangeAdapter` only
+     * bumps that tracker for annotations whose owner is a class, field or non-variable method, so
+     * editing a placeholder in a **constructor parameter** `@Value` - the most common Spring style -
+     * would leave a stale result and keep reporting a warning the edit just fixed.
+     *
+     * Not covered by a test: the heavy fixture's word index does not pick up in-place document
+     * edits, so a reference search after such an edit returns nothing regardless of caching.
+     */
+    fun getAllReferencesToElementWithDependencies(element: PsiElement): Set<PsiReference> {
+        val project = element.project
+        val module = ModuleUtilCore.findModuleForPsiElement(element)
+            ?: return getAllReferencesToElement(element)
+
+        val key = CacheKeyStore.getInstance(project)
+            .getKey<Set<PsiReference>>("ExplytAllReferencesToElementWithDependencies")
+        return CachedValuesManager.getManager(project).getCachedValue(element, key, {
+            // Deliberately not routed through GlobalSearchScopeTestAware: that helper widens the
+            // scope to allScope() under unit tests, which would make the cross-module regression
+            // test pass without exercising the production scope.
+            val scope = GlobalSearchScope.moduleWithDependenciesScope(module)
+                .uniteWith(GlobalSearchScope.moduleWithDependentsScope(module))
+            CachedValueProvider.Result(
+                ReferencesSearch.search(element, scope, true).toSet(),
+                PsiModificationTracker.MODIFICATION_COUNT
+            )
+        }, false)
     }
 
     fun getAutowiredFieldAnnotations(module: Module): Collection<PsiClass> {

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringYamlInspectionCrossModuleTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringYamlInspectionCrossModuleTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.kotlin
+
+import com.explyt.spring.core.inspections.SpringYamlInspection
+import com.explyt.spring.test.ExplytMultiModuleTestCase
+import com.explyt.spring.test.TestLibrary
+import org.intellij.lang.annotations.Language
+
+/**
+ * Regression for issue #276.
+ *
+ * A property consumed only from a **dependency module** is still a real, resolvable property:
+ * Spring injects it at runtime, and an unresolved required `@Value` or `@Scheduled` cron
+ * placeholder would fail context startup. `SpringYamlInspection` used to report
+ * `Cannot resolve key property` for such keys, because the reference fallback in
+ * `SpringBasePropertyInspection.getProblemKey` searched a scope that excludes the modules the
+ * configuration file's module depends on.
+ *
+ * This needs a multi-module fixture: with a single module the keys resolve and the bug is invisible.
+ */
+class SpringYamlInspectionCrossModuleTest : ExplytMultiModuleTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_3_1_1
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.enableInspections(SpringYamlInspection::class.java)
+    }
+
+    fun testKeysConsumedOnlyFromDependencyModuleResolve() {
+        val library = addDependencyModule("library")
+        addFileToModule(library, "com/example/library/KnownProperties.kt", KNOWN_PROPERTIES)
+
+        @Language("kotlin") val libraryConsumers = """
+            package com.example.library
+
+            import org.springframework.beans.factory.annotation.Value
+            import org.springframework.scheduling.annotation.Scheduled
+            import org.springframework.stereotype.Component
+
+            @Component
+            class LibrarySecretConsumer(
+                @Value("\${'$'}{explyt.notifications.secret-key}") val secretKey: String
+            )
+
+            @Component
+            class LibraryCleanupJob {
+                @Scheduled(cron = "\${'$'}{explyt.cron.cleanup-notifications}")
+                fun cleanup() = Unit
+            }
+        """.trimIndent()
+        addFileToModule(library, "com/example/library/LibraryConsumers.kt", libraryConsumers)
+
+        // Control living in the application module: proves the fixture resolves same-module keys,
+        // so a failure below is really about the cross-module boundary.
+        @Language("kotlin") val applicationConsumer = """
+            package com.example.app
+
+            import org.springframework.beans.factory.annotation.Value
+            import org.springframework.stereotype.Component
+
+            @Component
+            class AppConsumer(
+                @Value("\${'$'}{explyt.local.enabled}") val enabled: String
+            )
+        """.trimIndent()
+        addFileToModule(module, "com/example/app/AppConsumer.kt", applicationConsumer)
+
+        myFixture.configureByText(
+            "application.yaml",
+            """
+explyt.known:
+  enabled: true
+explyt.local:
+  enabled: true
+explyt.notifications:
+  secret-key: my-secret-key
+explyt.cron:
+  cleanup-notifications: 0 */5 * * * *
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("application.yaml")
+    }
+
+    /**
+     * Guards the guard: if this test ever stops reporting a problem for a genuinely unknown key,
+     * the fixture has stopped exercising the inspection and
+     * [testKeysConsumedOnlyFromDependencyModuleResolve] would pass for the wrong reason.
+     */
+    fun testUnknownKeyUnderKnownPrefixIsStillReported() {
+        val library = addDependencyModule("library")
+        addFileToModule(library, "com/example/library/KnownProperties.kt", KNOWN_PROPERTIES)
+
+        myFixture.configureByText(
+            "application.yaml",
+            """
+explyt.known:
+  enabled: true
+  <warning descr="Cannot resolve key property 'explyt.known.never-declared'">never-declared</warning>: someValue
+            """.trimIndent()
+        )
+        myFixture.testHighlighting("application.yaml")
+    }
+
+    private companion object {
+        /**
+         * `@ConfigurationProperties` under the same `explyt.` base prefix is REQUIRED for these
+         * tests to be meaningful, not decoration. `checkKey` bails out entirely when the module has
+         * no configuration properties, and `getProblemKey` skips any key whose base prefix matches
+         * no known property ("defined directly in the file"). Without this class both gates short
+         * circuit and the tests pass vacuously. It also mirrors the real-world report, where a
+         * dependency-module `@ConfigurationProperties` resolved cleanly while the placeholder-only
+         * keys did not - the asymmetry that localizes the bug to placeholder discovery.
+         */
+        @Language("kotlin")
+        val KNOWN_PROPERTIES = """
+            package com.example.library
+
+            import org.springframework.boot.context.properties.ConfigurationProperties
+
+            @ConfigurationProperties(prefix = "explyt.known")
+            class KnownProperties {
+                var enabled: Boolean = false
+            }
+        """.trimIndent()
+    }
+}

--- a/modules/test-framework/src/main/kotlin/com/explyt/spring/test/ExplytMultiModuleTestCase.kt
+++ b/modules/test-framework/src/main/kotlin/com/explyt/spring/test/ExplytMultiModuleTestCase.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.test
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.module.JavaModuleType
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.DependencyScope
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.IndexingTestUtil
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
+
+/**
+ * Base class for tests that need **several** modules with real dependencies between them.
+ *
+ * The light fixtures ([ExplytBaseLightTestCase], [ExplytInspectionBaseTestCase]) always create a
+ * single module, so they cannot express "the configuration file lives in the application module
+ * while the consuming code lives in a dependency module". Anything that resolves through a
+ * module-based [com.intellij.psi.search.GlobalSearchScope] behaves differently in that layout, and
+ * a single-module fixture silently passes.
+ *
+ * This is a heavy fixture: it creates a real project on disk, so it is noticeably slower than the
+ * light ones. Prefer a light fixture and only reach for this class when the scenario genuinely
+ * needs more than one module.
+ *
+ * Typical usage:
+ * ```
+ * class MyTest : ExplytMultiModuleTestCase() {
+ *     override val libraries = arrayOf(TestLibrary.springContext_6_0_7)
+ *
+ *     fun testSomething() {
+ *         val library = addDependencyModule("library")
+ *         addFileToModule(library, "com/example/LibraryBean.kt", "...")
+ *         // `module` (the main module) already depends on `library`
+ *     }
+ * }
+ * ```
+ */
+abstract class ExplytMultiModuleTestCase : JavaCodeInsightFixtureTestCase() {
+
+    /** Libraries attached to the main module and to every module created by [addDependencyModule]. */
+    open val libraries: Array<TestLibrary> = arrayOf()
+
+    override fun setUp() {
+        super.setUp()
+        attachLibraries(module)
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+    }
+
+    /**
+     * Creates a module named [name] with a single source root and makes the main [module] depend on
+     * it, mirroring `implementation(project(":name"))`. The new module gets the same [libraries] and
+     * inherits the project SDK, so Spring annotations resolve inside it.
+     *
+     * @return the created module, to be passed to [addFileToModule].
+     */
+    protected fun addDependencyModule(name: String): Module {
+        val sourceRoot = myFixture.tempDirFixture.findOrCreateDir("$name/src")
+        val dependency = PsiTestUtil.addModule(project, JavaModuleType.getModuleType(), name, sourceRoot)
+
+        ModuleRootModificationUtil.setSdkInherited(dependency)
+        attachLibraries(dependency)
+        // `exported = true` so the main module also sees the dependency's libraries, which is what
+        // Gradle's `api`/`implementation` graph gives the application module at compile time.
+        ModuleRootModificationUtil.addDependency(module, dependency, DependencyScope.COMPILE, true)
+
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+        return dependency
+    }
+
+    /**
+     * Writes [text] to [relativePath] inside the source root of [module] and returns the created
+     * [PsiFile]. [relativePath] is relative to that source root, e.g. `com/example/Bean.kt`.
+     */
+    protected fun addFileToModule(module: Module, relativePath: String, text: String): PsiFile {
+        val sourceRoot = sourceRootOf(module)
+        val file = createFile(sourceRoot, relativePath, text)
+
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+        return PsiManager.getInstance(project).findFile(file)
+            ?: error("No PSI for '$relativePath' in module '${module.name}'")
+    }
+
+    private fun createFile(sourceRoot: VirtualFile, relativePath: String, text: String): VirtualFile =
+        WriteAction.computeAndWait<VirtualFile, Throwable> {
+            val directoryPath = relativePath.substringBeforeLast('/', "")
+            val directory = if (directoryPath.isEmpty()) {
+                sourceRoot
+            } else {
+                VfsUtil.createDirectoryIfMissing(sourceRoot, directoryPath)
+            }
+            val file = directory.createChildData(this, relativePath.substringAfterLast('/'))
+            VfsUtil.saveText(file, text)
+            file
+        }
+
+    private fun sourceRootOf(module: Module): VirtualFile =
+        ModuleRootManager.getInstance(module).sourceRoots.firstOrNull()
+            ?: error("Module '${module.name}' has no source root")
+
+    private fun attachLibraries(module: Module) {
+        if (libraries.isEmpty()) return
+
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            libraries.forEach { addFromMaven(model, it.mavenCoordinates, it.includeTransitiveDependencies) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds multi-module fixture support to `test-framework` and, on top of it, fixes the cross-module false positive from #276.

A property whose only usage is a `@Value` / `@Scheduled` placeholder in a module that the configuration file's module **depends on** was reported as `Cannot resolve key property`, although Spring injects it at runtime.

**Root cause.** `SpringBasePropertyInspection.getProblemKey` falls back to a reference search. `ReferencesSearch` intersects the requested scope with the element's *use scope*, and for a configuration file that is the owning module plus its **dependents** — deliberately excluding the modules the owner depends on. So a dependency-module-only consumer yields zero references and the key looks unused.

**Fix.** New `SpringSearchUtils.getAllReferencesToElementWithDependencies` unites the dependencies and dependents scopes and passes `ignoreAccessScope = true`. Libraries stay out of the scope: placeholder usages live in project sources and this inspection runs on-the-fly.

It caches on `PsiModificationTracker.MODIFICATION_COUNT` rather than the UAST model tracker used by `getAllReferencesToElement`. `MyUastPsiTreeChangeAdapter` only bumps that tracker for annotations whose owner is a class, field or non-variable method, so a **constructor-parameter** `@Value` edit — the most common Spring style — would leave a stale result and keep reporting a warning the edit just fixed.

### `ExplytMultiModuleTestCase`

The light fixtures always create a single module, so this class of bug was previously untestable — a single-module fixture resolves the keys and passes. The new base class creates a real dependency module (`addDependencyModule`) and writes sources into it (`addFileToModule`), mirroring `implementation(project(":library"))`. It is a heavy fixture, so the KDoc tells callers to prefer the light ones unless the scenario genuinely needs several modules.

## Related issue

Closes #276.

Independent of #277, which fixes a *different* cause of the same message (SpEL defaults in `@Value`). This branch is based on current `main`; no overlap.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [x] Other: new reusable test fixture in `test-framework`

## How was this tested?

New `SpringYamlInspectionCrossModuleTest` with three cases:

1. `testKeysConsumedOnlyFromDependencyModuleResolve` — the reported scenario: `@Value` + `@Scheduled` consumers in a dependency module, plus a same-module control key.
2. `testUnknownKeyUnderKnownPrefixIsStillReported` — negative control: a genuinely unknown key must still be flagged.
3. Both share a `@ConfigurationProperties` fixture — see the caveat below.

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.kotlin.SpringYamlInspectionCrossModuleTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.kotlin.SpringYamlInspectionTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.java.SpringYamlInspectionTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.kotlin.SpringPropertiesInspectionTest"
./gradlew :spring-core:test --tests "com.explyt.spring.core.inspections.java.SpringPropertiesInspectionTest"
```

All pass. **Red/green verified**: with only the two production files reverted to `main`, `testKeysConsumedOnlyFromDependencyModuleResolve` fails with exactly the two reported warnings; with the fix it passes.

### Two traps worth flagging for reviewers

**The test needs the `@ConfigurationProperties` fixture to be meaningful.** `checkKey` returns early when the module has no configuration properties, and `getProblemKey` skips any key whose base prefix matches no known property. My first version omitted it and **passed vacuously**. Hence the shared `KNOWN_PROPERTIES` fixture and the negative control.

**`GlobalSearchScopeTestAware.getScope` is deliberately not used here.** It widens the scope to `allScope()` under unit tests, which would make the regression test pass without exercising the production scope.

### Not covered by a test

The `MODIFICATION_COUNT` tracker change. I wrote a mutation test for it and then removed it: the heavy fixture's word index does not observe in-place document edits, so the reference search returns nothing after the edit regardless of caching (verified by instrumenting the search — `refs = 0`). The test would have asserted harness behavior, not the fix. The rationale is recorded in the KDoc instead. Suggestions welcome if there's an established pattern for this in the repo.

### Environmental caveat

A broad wildcard `:spring-core:test` run reports ~254 failures, but this is **pre-existing** — it reproduces on unmodified `main` and the classes pass individually. Looks like shared-sandbox/test-result interference in large batches.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not — see "Not covered by a test").
- [x] I updated relevant documentation. CHANGELOG entry added; no user-visible string or inspection registration changed. No Java test twin: the changed behavior is language-agnostic and the existing twins cover Java/Kotlin parsing.
