### PR TITLE
fix: Resolve MCP call-chain failure on PSI without a source range (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Spring MCP
 - fix: Paginate `explyt_get_spring_http_endpoints` results and preserve total-count metadata (#244) (#279)
+- fix: Keep MCP tools working on Kotlin light and synthetic PSI without a source range, omitting `line` when no declaration can be pointed at (#281)
 
 ### Other
 - ci: Pin the Sentry release action and restrict release-job permissions (#230) (#279)

--- a/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
+++ b/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
@@ -37,6 +37,7 @@ import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import com.intellij.psi.search.searches.MethodReferencesSearch
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.kotlin.idea.base.psi.getLineNumber
 import org.jetbrains.kotlin.idea.base.util.projectScope
 import org.jetbrains.uast.UCallExpression
@@ -192,15 +193,10 @@ class SpringBootApplicationMcpToolset : McpToolset {
     private fun toEndpointJson(endpoint: EndpointElement, project: Project): EndpointJson {
         val psiMethod = endpoint.psiElement as? PsiMethod
         val controllerClass = endpoint.containingClass ?: psiMethod?.containingClass
-        val basePath = project.basePath?.let { "$it/" }
-        val filePath = (endpoint.containingFile ?: endpoint.psiElement.containingFile)?.virtualFile?.path
-        val relativePath = if (basePath != null && filePath != null && filePath.startsWith(basePath)) {
-            filePath.removePrefix(basePath)
-        } else {
-            filePath
-        }
-        val rawLine = endpoint.psiElement.getLineNumber(start = true)
-        val lineNumber = if (rawLine >= 0) rawLine + 1 else 1
+        val position = sourcePositionOf(endpoint.psiElement, project)
+        // A loader may know the declaring file of an endpoint whose element has no source position of its own.
+        val filePath = position.filePath
+            ?: endpoint.containingFile?.let { relativePathOf(it, project) }
 
         val parameters = if (psiMethod != null) extractParameters(psiMethod) else emptyList()
         val returnType = psiMethod?.returnType?.canonicalText
@@ -210,8 +206,8 @@ class SpringBootApplicationMcpToolset : McpToolset {
             fullPath = endpoint.path,
             controllerClass = controllerClass?.qualifiedName,
             methodName = psiMethod?.name,
-            filePath = relativePath,
-            line = lineNumber,
+            filePath = filePath,
+            line = position.line,
             parameters = parameters,
             returnType = returnType,
             endpointType = endpoint.type.readable,
@@ -387,14 +383,15 @@ class SpringBootApplicationMcpToolset : McpToolset {
                 line = lineOf(callee),
             )
         }
+        val position = sourcePositionOf(psiMethod, project)
 
         return EndpointContractJson(
             httpMethods = endpoint.requestMethods.ifEmpty { listOf("ALL") },
             fullPath = endpoint.path,
             controllerClass = controllerClass?.qualifiedName,
             methodName = psiMethod.name,
-            filePath = relativePathOf(psiMethod, project),
-            line = lineOf(psiMethod),
+            filePath = position.filePath,
+            line = position.line,
             parameters = parameters,
             returnType = returnTypeFqn,
             responseSchema = responseSchema,
@@ -537,12 +534,13 @@ class SpringBootApplicationMcpToolset : McpToolset {
             )
         }
 
+        val position = sourcePositionOf(psiMethod, project)
         val node = CallChainNodeJson(
             layer = containingClass?.let { detectSpringLayer(it) },
             className = containingClass?.qualifiedName ?: containingClass?.name,
             methodName = psiMethod.name,
-            filePath = relativePathOf(psiMethod, project),
-            line = lineOf(psiMethod),
+            filePath = position.filePath,
+            line = position.line,
             parameters = psiMethod.parameterList.parameters.map { it.name },
             callsInto = callsInto,
         )
@@ -582,8 +580,9 @@ class SpringBootApplicationMcpToolset : McpToolset {
             val refs = MethodReferencesSearch.search(method, testScope, true).findAll()
             for (ref in refs) {
                 val refElement = ref.element
-                val refFile = relativePathOf(refElement, project) ?: continue
-                val refLine = lineOf(refElement)
+                val position = sourcePositionOf(refElement, project)
+                val refFile = position.filePath ?: continue
+                val refLine = position.line ?: continue
                 val methodKey = "${method.containingClass?.name ?: "?"}.${method.name}"
                 byFile.getOrPut(refFile) { mutableMapOf() }
                     .getOrPut(methodKey) { mutableListOf() }
@@ -651,11 +650,12 @@ class SpringBootApplicationMcpToolset : McpToolset {
         val fields = collectEntityFields(psiClass)
         val indexes = collectEntityIndexes(psiClass)
 
+        val position = sourcePositionOf(psiClass, project)
         return SpringDataEntityJson(
             name = simpleName,
             className = qualifiedName,
-            filePath = relativePathOf(psiClass, project),
-            line = lineOf(psiClass),
+            filePath = position.filePath,
+            line = position.line,
             tableName = tableName,
             fields = fields,
             indexes = indexes,
@@ -746,10 +746,40 @@ class SpringBootApplicationMcpToolset : McpToolset {
         return if (filePath.startsWith(basePath)) filePath.removePrefix(basePath) else filePath
     }
 
-    private fun lineOf(element: PsiElement): Int {
-        val raw = element.getLineNumber(start = true)
-        return if (raw >= 0) raw + 1 else 1
+    /**
+     * File path and line of a single source anchor. Both are `null` when the reported element has no
+     * physical declaration to point at, so a caller never gets a path and a line taken from different files.
+     */
+    private data class SourcePosition(val filePath: String?, val line: Int?)
+
+    private fun sourcePositionOf(element: PsiElement, project: Project): SourcePosition {
+        val anchor = sourceAnchorOf(element) ?: return SourcePosition(null, null)
+        return SourcePosition(relativePathOf(anchor, project), lineOfAnchor(anchor))
     }
+
+    /**
+     * Physical element a source position may be reported for.
+     *
+     * Light and synthetic members - a Kotlin `data class` `copy()`, an enum `values()`, or any light method
+     * whose origin declaration is absent - have no text range, and reading a line number from them fails.
+     * Such a member is reported through its declaring class, and through nothing at all when that class is
+     * synthetic too.
+     */
+    private fun sourceAnchorOf(element: PsiElement): PsiElement? =
+        element.withSourcePosition()
+            ?: (element as? PsiMember)?.containingClass?.withSourcePosition()
+
+    private fun PsiElement.withSourcePosition(): PsiElement? =
+        takeIf { it.hasSourcePosition() } ?: navigationElement?.takeIf { it.hasSourcePosition() }
+
+    private fun PsiElement.hasSourcePosition(): Boolean = textRange != null && containingFile != null
+
+    private fun lineOfAnchor(anchor: PsiElement): Int? =
+        anchor.getLineNumber(start = true).takeIf { it >= 0 }?.plus(1)
+
+    /** 1-based line of [element], or `null` when it has no physical declaration to point at. */
+    @VisibleForTesting
+    internal fun lineOf(element: PsiElement): Int? = sourceAnchorOf(element)?.let(::lineOfAnchor)
 
     companion object {
         // Guard cap for single-target lookups (find / contract): a URL pattern is not
@@ -835,7 +865,8 @@ data class EndpointJson(
     val controllerClass: String?,
     val methodName: String?,
     val filePath: String?,
-    val line: Int,
+    /** `null` when the endpoint element has no physical declaration to point at. */
+    val line: Int?,
     val parameters: List<EndpointParameterJson>,
     val returnType: String?,
     val endpointType: String,
@@ -866,14 +897,16 @@ data class CallChainNodeJson(
     val className: String?,
     val methodName: String,
     val filePath: String?,
-    val line: Int,
+    /** `null` for a light or synthetic method with no physical declaration, e.g. a generated `copy()`. */
+    val line: Int?,
     val parameters: List<String>,
     val callsInto: List<CallTargetJson>,
 )
 
 data class CallTargetJson(
     val target: String,
-    val line: Int,
+    /** `null` for a light or synthetic call target with no physical declaration. */
+    val line: Int?,
 )
 
 data class TestReferenceJson(
@@ -892,7 +925,8 @@ data class EndpointContractJson(
     val controllerClass: String?,
     val methodName: String?,
     val filePath: String?,
-    val line: Int,
+    /** `null` when the endpoint method has no physical declaration to point at. */
+    val line: Int?,
     val parameters: List<EndpointParameterJson>,
     val returnType: String?,
     val responseSchema: DtoSchemaJson?,
@@ -918,7 +952,8 @@ data class SpringDataEntityJson(
     val name: String,
     val className: String,
     val filePath: String?,
-    val line: Int,
+    /** `null` when the entity class has no physical declaration to point at. */
+    val line: Int?,
     val tableName: String,
     val fields: List<EntityFieldJson>,
     val indexes: List<EntityIndexJson>,

--- a/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
+++ b/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
@@ -9,6 +9,12 @@ import com.explyt.spring.test.ExplytJavaLightTestCase
 import com.explyt.spring.test.TestLibrary
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.FakePsiElement
+import com.intellij.psi.impl.light.LightMethod
+import com.intellij.psi.util.PsiTreeUtil
 import kotlinx.coroutines.runBlocking
 
 class SpringBootApplicationMcpToolsetTest : ExplytJavaLightTestCase() {
@@ -197,6 +203,73 @@ class SpringBootApplicationMcpToolsetTest : ExplytJavaLightTestCase() {
         } catch (_: Exception) {
             // expected: mcpFail("file not found: ...")
         }
+    }
+
+    fun testLineOfElementWithoutTextRange() {
+        val physicalElement = PsiTreeUtil.findChildOfType(
+            myFixture.configureByText("Controller.java", "\n\nclass Controller {}"),
+            PsiClass::class.java
+        )!!
+        val elementWithoutTextRange = object : FakePsiElement() {
+            override fun getParent(): PsiElement = physicalElement
+            override fun getName(): String = "Controller"
+            override fun getNavigationElement(): PsiElement = physicalElement
+        }
+
+        assertNull(elementWithoutTextRange.textRange)
+        assertEquals(3, toolset.lineOf(physicalElement))
+        assertEquals(3, toolset.lineOf(elementWithoutTextRange))
+    }
+
+    fun testLineOfLightMethodUsesNavigationTarget() {
+        // A light method without a text range still resolves through the physical method it navigates to.
+        val declaringClass = physicalClass()
+        val physicalMethod = declaringClass.methods.single()
+        val lightMethod = object : LightMethod(psiManager, physicalMethod, declaringClass) {
+            override fun getTextRange(): TextRange? = null
+            override fun getNavigationElement(): PsiElement = physicalMethod
+        }
+
+        assertNull("Expected a light method without a text range", lightMethod.textRange)
+        assertEquals(3, toolset.lineOf(lightMethod))
+    }
+
+    fun testLineOfSyntheticMethodFallsBackToContainingClass() {
+        // Reproduces issue #281: a synthetic member - a generated `copy()`, an enum `values()`, or a Kotlin
+        // light method whose origin declaration is absent - has no text range and navigates to itself, so it
+        // has no source position at all. Its declaring class is the closest physical anchor.
+        val declaringClass = physicalClass()
+        val syntheticMethod = object : LightMethod(psiManager, declaringClass.methods.single(), declaringClass) {
+            override fun getTextRange(): TextRange? = null
+            override fun getNavigationElement(): PsiElement = this
+        }
+
+        assertNull("Expected a synthetic method without a text range", syntheticMethod.textRange)
+        assertSame(
+            "Expected a synthetic method navigating to itself",
+            syntheticMethod, syntheticMethod.navigationElement
+        )
+        assertEquals(3, toolset.lineOf(syntheticMethod))
+    }
+
+    private fun physicalClass(): PsiClass = PsiTreeUtil.findChildOfType(
+        myFixture.configureByText("Controller.java", "\n\nclass Controller { void handle() {} }"),
+        PsiClass::class.java
+    )!!
+
+    fun testLineOfElementWithoutSourceRangeIsUnknown() {
+        // The fixture class sits on line 3, so a genuine lookup could never return `null`.
+        val physicalElement = myFixture.configureByText("Controller.java", "\n\nclass Controller {}")
+        val elementWithoutSourceRange = object : FakePsiElement() {
+            override fun getParent(): PsiElement = physicalElement
+            override fun getName(): String = "Controller"
+        }
+
+        assertNull(elementWithoutSourceRange.textRange)
+        assertNull(
+            "Expected an unknown line rather than a fabricated one",
+            toolset.lineOf(elementWithoutSourceRange)
+        )
     }
 
     fun testGetSpringDataEntities() = runBlocking<Unit> {

--- a/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTraceCallChainTest.kt
+++ b/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTraceCallChainTest.kt
@@ -12,10 +12,19 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiMethod
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.kotlin.asJava.elements.KtLightMethod
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+import org.jetbrains.uast.toUElement
 import java.io.File
 
 /**
@@ -41,7 +50,7 @@ class SpringBootApplicationMcpToolsetTraceCallChainTest : JavaCodeInsightFixture
 
         // Controller -> Service -> Repository, single compilation unit so no cross-file
         // resolution is required. All calls are qualified, which is the realistic Spring style.
-        writeJava(
+        writeSource(
             sourcesRoot, "com/example/app/App.java",
             """
             package com.example.app;
@@ -152,7 +161,154 @@ class SpringBootApplicationMcpToolsetTraceCallChainTest : JavaCodeInsightFixture
         )
     }
 
-    private fun writeJava(sourcesRoot: File, relativePath: String, content: String) {
+    fun testTraceKotlinLightCallee() = runBlocking {
+        val basePath = project.basePath!!
+        val sourcesRoot = File(basePath, "kotlinSrc").apply { mkdirs() }
+        val relativePath = "kotlinSrc/com/example/app/Controller.kt"
+        val source = """
+            package com.example.app
+
+            class DemoService {
+                fun findById(id: Long): String = id.toString()
+            }
+
+            class DemoController(private val service: DemoService) {
+                fun getItem(id: Long): String {
+                    return service.findById(id)
+                }
+            }
+        """.trimIndent()
+        writeSource(sourcesRoot, "com/example/app/Controller.kt", source)
+        registerSourceRoot(sourcesRoot)
+
+        val appVf = LocalFileSystem.getInstance().findFileByPath("$basePath/$relativePath")
+            ?: error("Kotlin source not registered in VFS")
+        val appPsi = PsiManager.getInstance(project).findFile(appVf) as? KtFile
+            ?: error("Kotlin PSI not available")
+        val controllerMethod = appPsi.declarations
+            .filterIsInstance<KtClass>()
+            .first { it.name == "DemoController" }
+            .declarations
+            .filterIsInstance<KtNamedFunction>()
+            .single { it.name == "getItem" }
+        val resolvedCallee = resolvedCalls(controllerMethod.toUElement() as UMethod)
+            .single { it.name == "findById" }
+
+        assertTrue(
+            "Expected Kotlin UAST callee to be a light method, got ${resolvedCallee.javaClass.name}",
+            resolvedCallee is KtLightMethod
+        )
+        assertNotNull("Expected Kotlin light method to have a source range in this fixture", resolvedCallee.textRange)
+        assertNotNull("Expected light method to navigate to source PSI", resolvedCallee.navigationElement.textRange)
+
+        val document = PsiDocumentManager.getInstance(project).getDocument(appPsi)!!
+        val callLine = document.getLineNumber(source.indexOf("return service.findById(id)")) + 1
+        val declarationLine = document.getLineNumber(source.indexOf("fun findById")) + 1
+        val result = mapper.readTree(
+            toolset.traceCallChain(
+                filePath = relativePath,
+                line = callLine,
+                projectPath = basePath,
+                depth = 2,
+                includeTests = false,
+            )
+        )
+
+        val head = result["chain"].first { it["methodName"].asText() == "getItem" }
+        val callee = result["chain"].first { it["methodName"].asText() == "findById" }
+        assertEquals(
+            declarationLine,
+            head["callsInto"].single { it["target"].asText().endsWith("DemoService.findById") }["line"].asInt()
+        )
+        assertEquals(declarationLine, callee["line"].asInt())
+    }
+
+    fun testTraceGeneratedDataClassCalleeLine() = runBlocking {
+        // Generated `copy()` of a Kotlin data class: a light callee whose reported line must stay inside the
+        // declaring file rather than being fabricated. See the unit tests for the null-range fallback itself.
+        val basePath = project.basePath!!
+        val sourcesRoot = File(basePath, "syntheticSrc").apply { mkdirs() }
+        val relativePath = "syntheticSrc/com/example/app/Synthetic.kt"
+        val source = """
+            package com.example.app
+
+            data class Item(val id: Long, val title: String)
+
+            class ItemController {
+                fun rename(item: Item): Item {
+                    return item.copy(title = "renamed")
+                }
+            }
+        """.trimIndent()
+        writeSource(sourcesRoot, "com/example/app/Synthetic.kt", source)
+        registerSourceRoot(sourcesRoot)
+
+        val appVf = LocalFileSystem.getInstance().findFileByPath("$basePath/$relativePath")
+            ?: error("Kotlin source not registered in VFS")
+        val appPsi = PsiManager.getInstance(project).findFile(appVf) as? KtFile
+            ?: error("Kotlin PSI not available")
+        val renameFunction = appPsi.declarations
+            .filterIsInstance<KtClass>()
+            .first { it.name == "ItemController" }
+            .declarations
+            .filterIsInstance<KtNamedFunction>()
+            .single { it.name == "rename" }
+        val syntheticCallee = resolvedCalls(renameFunction.toUElement() as UMethod)
+            .single { it.name == "copy" }
+
+        // In this fixture `copy()` resolves to a light method that still carries a range, so the chain must
+        // report the generated member at its declaring `data class`.
+        assertTrue("Expected copy() to resolve to a light method", syntheticCallee is KtLightMethod)
+
+        val document = PsiDocumentManager.getInstance(project).getDocument(appPsi)!!
+        val callLine = document.getLineNumber(source.indexOf("return item.copy(")) + 1
+        val itemClassLine = document.getLineNumber(source.indexOf("data class Item")) + 1
+        val result = mapper.readTree(
+            toolset.traceCallChain(
+                filePath = relativePath,
+                line = callLine,
+                projectPath = basePath,
+                depth = 2,
+                includeTests = false,
+            )
+        )
+
+        val head = result["chain"].first { it["methodName"].asText() == "rename" }
+        val copyTarget = head["callsInto"].single { it["target"].asText().endsWith("Item.copy") }
+        assertEquals(
+            "Expected the generated copy() to be reported at its declaring data class",
+            itemClassLine, copyTarget["line"].asInt()
+        )
+    }
+
+    private fun resolvedCalls(method: UMethod): List<PsiMethod> {
+        val result = mutableListOf<PsiMethod>()
+        method.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                node.resolve()?.let(result::add)
+                return false
+            }
+        })
+        return result
+    }
+
+    private fun registerSourceRoot(sourcesRoot: File) {
+        WriteAction.runAndWait<Throwable> {
+            LocalFileSystem.getInstance().refresh(false)
+        }
+        val sourcesRootVf = VfsUtil.findFile(sourcesRoot.toPath(), true)
+            ?: error("Sources root not visible in VFS: ${sourcesRoot.absolutePath}")
+        ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
+            model.addContentEntry(sourcesRootVf).addSourceFolder(sourcesRootVf, true)
+        }
+        WriteAction.runAndWait<Throwable> {
+            LocalFileSystem.getInstance().refresh(false)
+        }
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+    }
+
+    private fun writeSource(sourcesRoot: File, relativePath: String, content: String) {
         val target = File(sourcesRoot, relativePath)
         target.parentFile.mkdirs()
         target.writeText(content)


### PR DESCRIPTION
## Summary

`explyt_trace_spring_call_chain` consistently failed on Kotlin controllers with:

```
Cannot invoke "com.intellij.openapi.util.TextRange.getStartOffset()" because the return value of "com.intellij.psi.PsiElement.getTextRange()" is null
```

**Root cause.** `SpringBootApplicationMcpToolset.lineOf` called Kotlin's `PsiElement.getLineNumber(start = true)` unconditionally. That extension reads `startOffset`, which dereferences `textRange`, and it also dereferences `containingFile.viewProvider`. Kotlin light and synthetic PSI — for example a `KtLightMethod` whose origin declaration is absent — has neither, so every call chain containing such a callee aborted with an NPE.

**Fix.** A source position is now resolved from a single physical anchor before any line is read:

- `sourceAnchorOf(element)` resolves `element` → `navigationElement` → `PsiMember.containingClass`, so a synthetic member is reported at its declaring class instead of crashing.
- `hasSourcePosition()` requires both a non-null `textRange` **and** a non-null `containingFile`, matching what `getLineNumber` actually dereferences.
- `sourcePositionOf` returns one `SourcePosition(filePath, line)` so `filePath` and `line` can never be derived from different elements — previously `relativePathOf` used `element.containingFile` while a line could come from the navigation target's file.
- `lineOf` now returns `Int?`. When nothing physical can be pointed at, the response omits the line instead of fabricating `1`, which the issue explicitly asked for ("or skips call targets without a physical source range").

The same unguarded `getLineNumber` call in `toEndpointJson` was routed through the shared helper, so `explyt_find_spring_endpoint` and `explyt_get_spring_http_endpoints` can no longer hit the identical NPE. `findTestReferences` now skips a reference whose line cannot be resolved rather than recording line `1`.

**Behavior note.** `line` became nullable in the MCP JSON responses (`CallTargetJson`, `CallChainNodeJson`, `EndpointJson`, `EndpointContractJson`, `SpringDataEntityJson`). A consumer that assumed a non-null integer now sees `null` for a target with no physical declaration; the field is documented with KDoc and no in-repo consumer relies on it. This is deliberate: a fabricated line `1` with no file path is indistinguishable from a real declaration at line 1.

## Related issue

Closes #281

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

Both `spring-ai` MCP test classes were run **sequentially** (never concurrently — the IntelliJ fixture shares its sandbox and test-result files):

```bash
./gradlew :spring-ai:test --tests "com.explyt.spring.ai.mcp.SpringBootApplicationMcpToolsetTest"
./gradlew :spring-ai:test --tests "com.explyt.spring.ai.mcp.SpringBootApplicationMcpToolsetTraceCallChainTest"
```

Both are `BUILD SUCCESSFUL`. Tests added:

- `testLineOfLightMethodUsesNavigationTarget` — a platform `LightMethod` subclass with `getTextRange() = null` that navigates to physical PSI resolves to the real declaration line.
- `testLineOfSyntheticMethodFallsBackToContainingClass` — a range-less method navigating to itself falls back to its declaring class.
- `testLineOfElementWithoutSourceRangeIsUnknown` — a range-less element with no source anchor yields `null`; the fixture class is offset to line 3 so the expectation cannot be satisfied by a real lookup.
- `testTraceGeneratedDataClassCalleeLine` — end-to-end trace where the callee is a generated Kotlin `data class` `copy()`.
- The existing Kotlin call-chain test now asserts `resolvedCallee is KtLightMethod` instead of matching an implementation class name.

**Coverage caveat, stated plainly.** The exact runtime state from the report — a Kotlin light method whose `textRange` is genuinely `null` on IntelliJ 2026.2 — is **not reproducible under the current 2026.1 test fixture**. A data-class `copy()` retains its range there, and a test asserting `assertNull(textRange)` on it fails. Rather than ship an integration test that passes with or without the fix, the null-range contract is covered by the platform `LightMethod` unit tests above, which do fail against the previous implementation. The Kotlin trace tests remain as honest happy-path coverage.

IDE inspections on the changed ranges report no findings, and `git diff --check` is clean.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. (No new files; existing headers untouched.)
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed. (`CHANGELOG.md` under **Spring MCP**; no user-visible strings or README/wiki content affected.)
