### PR TITLE
fix: Replace internal plugin-manager APIs to unblock 2026.2 verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - docs: Update issue/PR templates and contributing guide
 - docs: Add AI Agent documentation
 - chore: Support IntelliJ Platform 2026.2 (262)
+- fix: Replace internal plugin-manager APIs with `PluginDetailsService` to unblock 2026.2 plugin verification
 
 ## [261.33.80] - 2026-04-28
 

--- a/modules/base/src/main/kotlin/com/explyt/base/PluginContext.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/PluginContext.kt
@@ -5,12 +5,19 @@
 
 package com.explyt.base
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginDetailsService
 import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.extensions.PluginId
 
 object PluginContext {
+    /** Plugin id declared in `spring-bootstrap/src/main/resources/META-INF/plugin.xml`. */
+    const val PLUGIN_ID = "com.explyt.spring"
+
     val pluginVersion by lazy {
-        PluginManager.getPluginByClass(SentryErrorReporter::class.java)?.version ?: "Unknown"
+        @Suppress("UnstableApiUsage")
+        PluginDetailsService.getInstance()
+            .findDetails(PluginId.getId(PLUGIN_ID))
+            ?.version ?: "Unknown"
     }
 
     /** Middle segment of the version string, e.g. "31" from "253.31.58" */

--- a/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
@@ -5,7 +5,7 @@
 
 package com.explyt.base
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginDetailsService
 import com.intellij.openapi.application.ApplicationInfo
 import io.sentry.Breadcrumb
 import io.sentry.IScope
@@ -66,10 +66,19 @@ object SentryReporter {
         }
     }
 
+    /**
+     * Third-party plugins reported as Sentry context.
+     *
+     * [PluginDetailsService.PluginDetails.isBuiltIn] covers both bundled plugins and updates of bundled ones,
+     * which is slightly broader than the previous `isBundled` check: an updated bundled plugin is no longer
+     * reported. The platform exposes no public API distinguishing the two, and the internal one fails
+     * plugin verification, so the broader filter is accepted here.
+     */
+    @Suppress("UnstableApiUsage")
     private fun collectNonBundledPlugins(): Map<String, String> =
-        PluginManagerCore.loadedPlugins
-            .filter { !it.isBundled }
-            .associate { it.pluginId.idString to (it.version ?: "unknown") }
+        PluginDetailsService.getInstance().getActivePlugins()
+            .filter { !it.isBuiltIn }
+            .associate { it.id.idString to (it.version ?: "unknown") }
 
     fun addBreadcrumb(breadcrumb: Breadcrumb) {
         ensureInitialized()

--- a/modules/base/src/main/kotlin/com/explyt/plugin/PluginUtils.kt
+++ b/modules/base/src/main/kotlin/com/explyt/plugin/PluginUtils.kt
@@ -5,7 +5,7 @@
 
 package com.explyt.plugin
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginDetailsService
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.lang.Language
 import com.intellij.openapi.extensions.PluginId
@@ -20,9 +20,10 @@ enum class PluginIds(val pluginId: String) {
     SPRING_DEBUGGER_JB("com.intellij.spring.debugger"),
     CDI_JB("com.intellij.cdi"), //Jakarta EE - DI (QUARKUS SEXPLYT Conflict)
     SPRING_BOOT_JB("com.intellij.spring.boot"),
+    SH_JB("com.jetbrains.sh"),
     ;
 
-    fun findEnabled() = PluginManager.getInstance().findEnabledPlugin(PluginId.getId(pluginId))
+    fun findEnabled() = findEnabledDetails(PluginId.getId(pluginId))
 
     fun isEnabled() = findEnabled() != null
 
@@ -46,9 +47,20 @@ enum class PluginIds(val pluginId: String) {
          * In the free mode of the unified distribution this module is disabled;
          * in the OSS Community build it does not exist at all.
          */
-        fun isUltimateEnabled(): Boolean =
-            !PluginManagerCore.isDisabled(ULTIMATE_MODULE_ID)
-                    && PluginManager.getInstance().findEnabledPlugin(ULTIMATE_MODULE_ID) != null
+        fun isUltimateEnabled(): Boolean = findEnabledDetails(ULTIMATE_MODULE_ID) != null
+
+        /**
+         * Resolves an enabled plugin or plugin alias (such as `com.intellij.modules.ultimate`).
+         *
+         * `PluginDetailsService.isLoaded` matches real plugin ids only, so it never resolves an alias;
+         * `findDetails` resolves aliases but also reports plugins that are installed yet disabled.
+         * Combining it with the disabled check keeps both alias and real-id lookups correct.
+         */
+        private fun findEnabledDetails(id: PluginId): PluginDetailsService.PluginDetails? {
+            if (PluginManagerCore.isDisabled(id)) return null
+            @Suppress("UnstableApiUsage")
+            return PluginDetailsService.getInstance().findDetails(id)
+        }
     }
 }
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/SpringToolRunConfigurationConfigurable.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/SpringToolRunConfigurationConfigurable.kt
@@ -6,6 +6,7 @@
 package com.explyt.spring.core.runconfiguration
 
 //import org.intellij.plugins.intelliLang.inject.InjectedLanguage
+import com.explyt.plugin.PluginIds
 import com.explyt.spring.core.SpringCoreBundle.message
 import com.explyt.spring.core.action.UastModelTrackerInvalidateAction
 import com.explyt.spring.core.externalsystem.utils.Constants
@@ -14,7 +15,6 @@ import com.explyt.spring.core.statistic.StatisticActionId
 import com.explyt.spring.core.statistic.StatisticService
 import com.explyt.spring.core.util.ZipDownloader
 import com.intellij.ide.impl.ProjectUtil
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
 import com.intellij.openapi.actionSystem.ActionUpdateThread
@@ -22,7 +22,6 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.observable.properties.PropertyGraph
@@ -266,9 +265,7 @@ class SpringToolRunConfigurationConfigurable : SearchableConfigurable {
     companion object {
         const val ID = "com.explyt.spring.runConfigurations"
 
-        fun shellScriptEnabled(): Boolean {
-            return PluginManager.getInstance().findEnabledPlugin(PluginId.getId("com.jetbrains.sh")) != null
-        }
+        fun shellScriptEnabled(): Boolean = PluginIds.SH_JB.isEnabled()
     }
 }
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
@@ -5,15 +5,15 @@
 
 package com.explyt.spring.core.statistic
 
-import com.explyt.spring.core.runconfiguration.SpringRunConfigurationDetectService
+import com.explyt.base.PluginContext
 import com.explyt.spring.core.runconfiguration.SpringToolRunConfigurationsSettingsState
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginDetailsService
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.extensions.PluginDescriptor
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.registry.Registry
 import java.io.File
@@ -85,8 +85,8 @@ class StatisticService {
     }
 
     private fun writeStateToFile(localDate: LocalDate) {
-        val descriptor = pluginDescriptor() ?: return
-        if (skipForNonProductionMode(descriptor)) {
+        val pluginVersion = pluginVersion() ?: return
+        if (skipForNonProductionMode(pluginVersion)) {
             clearStatistic()
             return
         }
@@ -100,19 +100,19 @@ class StatisticService {
 
         val counterMap = getCurrentStatistic().takeIf { it.isNotEmpty() } ?: return
         val properties = getCurrentFilePropertiesState(resultDailyPath)
-        updateStatistic(properties, deviceId, descriptor, localDate, counterMap)
+        updateStatistic(properties, deviceId, pluginVersion, localDate, counterMap)
         saveStatisticToFile(resultDailyPath, properties, fileName)
     }
 
     private fun updateStatistic(
         properties: Properties,
         deviceId: String,
-        descriptor: PluginDescriptor,
+        pluginVersion: String,
         localDate: LocalDate,
         counterMap: Map<String, Int>
     ) {
         properties[StatisticActionId.DEVICE_ID.name] = deviceId
-        properties[StatisticActionId.PLUGIN_VERSION.name] = descriptor.version
+        properties[StatisticActionId.PLUGIN_VERSION.name] = pluginVersion
         properties[StatisticActionId.LOCAL_DATE.name] = localDate.toString()
         for (entry in counterMap) {
             val value = properties[entry.key] as? String
@@ -161,12 +161,12 @@ class StatisticService {
         ApplicationManager.getApplication().getService(StatisticState::class.java)
 
 
-    private fun skipForNonProductionMode(pluginDescriptor: PluginDescriptor): Boolean {
+    private fun skipForNonProductionMode(pluginVersion: String): Boolean {
         if (skipForUnitTestAndHeadlessMode()) return true
 
         if (Registry.`is`("explyt.statistic.debug")) return false
 
-        return pluginDescriptor.version.contains("snapshot", true)
+        return pluginVersion.contains("snapshot", true)
     }
 
     fun skipForUnitTestAndHeadlessMode() = (ApplicationManager.getApplication().isUnitTestMode
@@ -198,8 +198,11 @@ class StatisticService {
         return null
     }
 
-    private fun pluginDescriptor(): PluginDescriptor? {
-        return PluginManager.getPluginByClass(SpringRunConfigurationDetectService::class.java)
+    private fun pluginVersion(): String? {
+        @Suppress("UnstableApiUsage")
+        return PluginDetailsService.getInstance()
+            .findDetails(PluginId.getId(PluginContext.PLUGIN_ID))
+            ?.version
     }
 
     private fun createLockFile(lockFilePath: Path): Path? {

--- a/modules/spring-web/src/main/kotlin/com/explyt/spring/web/editor/openapi/OpenApiResourcesRequestHandler.kt
+++ b/modules/spring-web/src/main/kotlin/com/explyt/spring/web/editor/openapi/OpenApiResourcesRequestHandler.kt
@@ -5,8 +5,7 @@
 
 package com.explyt.spring.web.editor.openapi
 
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
+
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.JBColor
@@ -59,11 +58,8 @@ class OpenApiResourcesRequestHandler : HttpRequestHandler() {
         if (resource == "specification_file")
             return OpenApiUtils.getFile(key)
 
-        val pluginId = PluginId.findId("com.explyt.spring") ?: return null
         val mainTemplatePath = "htmlTemplates/openapi/$resource"
-        val mainTemplateUrl = PluginManagerCore.getPlugin(pluginId)
-            ?.pluginClassLoader
-            ?.getResource(mainTemplatePath) ?: return null
+        val mainTemplateUrl = javaClass.classLoader.getResource(mainTemplatePath) ?: return null
         return VfsUtil.findFileByURL(mainTemplateUrl)
     }
 


### PR DESCRIPTION
## Summary

The 2026.2 release build failed `:spring-bootstrap:verifyPlugin` with `[INTERNAL_API_USAGES]`.

The Plugin Verifier itself reported the plugin as **Compatible** — the build failed because our `failureLevel` treats internal API usages as fatal, which is intentional. Since 2026.2 the platform marks these as `@ApiStatus.Internal`:

- `PluginManager.getPluginByClass`
- `PluginManager.findEnabledPlugin`
- `PluginManagerCore.loadedPlugins`
- `PluginManagerCore.getPlugin`

This migrates all seven usages to supported APIs rather than weakening the verification policy:

- plugin metadata and version lookups go through `PluginDetailsService`
- OpenAPI editor resources resolve via the owning plugin classloader
- `PluginIds` gains `SH_JB`, so the shell-plugin check reuses the shared enum instead of an inline lookup
- the plugin id is centralized in `PluginContext.PLUGIN_ID`

### Note on the Ultimate alias (the non-obvious part)

`PluginDetailsService.isLoaded` looks like the natural replacement for `findEnabledPlugin`, but it is **not equivalent**:

```kotlin
fun isLoaded(id: PluginId): Boolean {
  val plugin = loadedPlugins.find { it.pluginId == id }   // real plugin ids only
  return plugin != null && isLoaded(plugin)
}
```

`com.intellij.modules.ultimate` is a **plugin alias**, resolved only through `PluginSet.enabledPluginAndV1ModuleMap` — which is exactly what the old `findEnabledPlugin` used. Using `isLoaded` here would make `isUltimateEnabled()` always return `false`, silently re-enabling the duplicate line markers and Related Symbol targets that #269 suppressed for Ultimate users. The verifier cannot catch this.

`findEnabledDetails` therefore combines the alias-aware `findDetails` with an explicit `isDisabled` check (`findDetails` alone also returns installed-but-disabled plugins), preserving the previous semantics for both aliases and real ids.

`PluginDetailsService` is `@ApiStatus.Experimental`, which the verifier config already excludes.

### Known behavioral change

Sentry's non-bundled plugin context now uses `PluginDetails.isBuiltIn`, which covers bundled plugins **and updates of bundled ones** — slightly broader than the previous `isBundled`. An updated bundled plugin (notably the Kotlin plugin) is no longer listed in crash context. No public API distinguishes the two cases; the internal one is what fails verification. Documented in a KDoc at the call site.

## Related issue

n/a — surfaced by the failed `release/262` verification run, no tracking issue was filed.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

- `./gradlew :spring-bootstrap:compileKotlin` — passes
- IDE inspections on all six changed Kotlin files — no errors
- Verified no internal `PluginManager` / `PluginManagerCore` usages remain (only public `isDisabled`)
- Cross-checked `isLoaded` / `findEnabledPlugin` / `PluginSet` semantics against the 2026.2 platform sources

Not verified locally: the full `verifyPlugin` run (it downloads a ~1.5 GB IDE distribution) — CI covers it.

**Reviewer note:** `isUltimateEnabled()` has no automated coverage, and this is precisely the kind of regression that fails silently. Worth a sanity check in a paid IU sandbox that Explyt line markers are still suppressed where IDEA Ultimate provides Spring support. A regression test around this is a reasonable follow-up.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. *(no new files)*
- [ ] I added or updated tests for my change (or explained why not). *(see reviewer note — plugin-loading state is not reproducible in the IntelliJ test fixture; no existing tests cover `PluginIds`)*
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed. *(CHANGELOG entry added; no user-facing behavior change intended)*
