### PR TITLE
fix: Keep Kotlin top-level main() projects linked when the stored run configuration name is dangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Spring Core
 - fix: Keep renamed Spring Boot run configurations linked without ambiguous fallback (#229) (#279)
+- fix: Keep Kotlin top-level `main()` projects linked when the stored run configuration name no longer exists (#229)
 - fix: Hide the Beans Search Everywhere tab outside Spring Boot projects without blocking EDT (#233) (#240) (#279)
 - fix: Anchor inherited autowired inspection problems (#234) (#241)
 - fix: Prevent cyclic inherited-autowiring traversal from hanging inspection analysis (#279)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/RunConfigurationExtractor.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/RunConfigurationExtractor.kt
@@ -14,8 +14,13 @@ import com.intellij.execution.RunManager
 import com.intellij.execution.application.ApplicationConfiguration
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiClassOwner
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiMethodUtil
 import org.jetbrains.kotlin.idea.run.KotlinRunConfiguration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.uast.UClass
@@ -58,17 +63,24 @@ object RunConfigurationExtractor {
         }
         // If the stored name doesn't match (e.g. user renamed/replaced the run config),
         // fall back to matching a SpringBootRunConfiguration by main-class file path.
-        // Configurations sharing a main class can still differ in profiles, VM args or environment,
-        // so an ambiguous match is treated as no match instead of guessing.
+        // Configurations sharing a main class can still differ in profiles, VM args or environment, so when the
+        // path match is ambiguous the user's current selection is the only honest tie-breaker.
+        val matchingByPath = allConfigurationsList.filter { checkRunConfiguration(it, projectPath) }
         val runConfig = runConfigByName
-            ?: allConfigurationsList.singleOrNull { checkRunConfiguration(it, projectPath) }
+            ?: matchingByPath.singleOrNull()
+            ?: RunManager.getInstance(settings.project).selectedConfiguration?.configuration
+                ?.takeIf { selected -> matchingByPath.any { it === selected } }
         if (runConfig is SpringBootRunConfiguration) {
             if (isJavaAgent) {
                 return RunConfigurationHolder(agentRunConfiguration = runConfig.clone())
             }
             return RunConfigurationHolder(runConfig.clone() as SpringBootRunConfiguration)
         }
-        return createDefaultRunConfiguration(settings)?.let { RunConfigurationHolder(agentRunConfiguration = it) }
+        // A stored-but-missing name means a dangling link: fabricating a configuration would silently sync with
+        // default profiles/env and hide the real cause, so report it instead (SpringBeanNativeResolver.nothingException).
+        if (settings.runConfigurationName != null) return null
+        return createDefaultRunConfiguration(settings)
+            ?.let { if (isJavaAgent) RunConfigurationHolder(agentRunConfiguration = it) else RunConfigurationHolder(it) }
     }
 
     private fun checkRunConfiguration(runConfiguration: RunConfiguration, projectPath: String): Boolean {
@@ -109,19 +121,33 @@ object RunConfigurationExtractor {
     }
 
     private fun createDefaultRunConfiguration(settings: NativeExecutionSettings): SpringBootRunConfiguration? {
-        val qualifiedMainClassName = settings.qualifiedMainClassName ?: return null
         val externalProjectMainFilePath = settings.externalProjectMainFilePath ?: return null
         val virtualFile = VfsUtil.findFile(Path(externalProjectMainFilePath), false) ?: return null
         val module = ModuleUtilCore.findModuleForFile(virtualFile, settings.project) ?: return null
+        // The stored qualified name is the `@SpringBootApplication` class, which for a Kotlin top-level `main()` is
+        // not the launchable class: running it fails with "Main method not found in class ...". Resolve the class that
+        // actually declares `main` from the linked file and keep the stored name only as a last resort.
+        val mainClassName = findRunnableMainClassName(virtualFile, settings.project)
+            ?: settings.qualifiedMainClassName
+            ?: return null
 
         val runConfiguration = SpringBootConfigurationFactory
             .createTemplateConfiguration(settings.project)
             .apply {
                 setModule(module)
-                mainClassName = qualifiedMainClassName
+                this.mainClassName = mainClassName
                 setGeneratedName()
             }
         return runConfiguration
+    }
+
+    /**
+     * `KtFile` is a [PsiClassOwner] too, so a single branch covers Java and Kotlin: for Kotlin the reported classes
+     * include the `...Kt` file facade that actually holds a top-level `main()`.
+     */
+    private fun findRunnableMainClassName(virtualFile: VirtualFile, project: Project): String? {
+        val classOwner = PsiManager.getInstance(project).findFile(virtualFile) as? PsiClassOwner ?: return null
+        return classOwner.classes.firstOrNull { PsiMethodUtil.hasMainMethod(it) }?.qualifiedName
     }
 
     private fun mapToSpringBootRunConfiguration(

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListener.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListener.kt
@@ -44,9 +44,15 @@ class ExplytRunManagerListener(val project: Project) : RunManagerListener {
      * would fail to locate it during sync.
      *
      * This callback may run on EDT and while run configurations are being loaded, so the cheap checks come first:
-     * the main class is resolved only for a link that predates [NativeProjectSettings.qualifiedMainClassName] and
-     * actually needs renaming. The update stays synchronous, because `RunConfigurationExtractor` may look the name
-     * up as soon as this callback returns.
+     * the main class is resolved only for a link whose stored name is dangling and actually needs renaming.
+     * The update stays synchronous, because `RunConfigurationExtractor` may look the name up as soon as this
+     * callback returns.
+     *
+     * Kotlin needs the file-path fallback even for links that do store [NativeProjectSettings.qualifiedMainClassName]:
+     * for a top-level `main()` the configuration's main class is the file facade (`...FooKt`), while the link stores
+     * the `@SpringBootApplication` class (`...Foo`), so those two identities can never match. The main-class *file*
+     * is what both sides agree on. Renaming is then guarded by [isDanglingName]: several configurations may share one
+     * main class, and a stored name that still belongs to a live configuration must survive a sibling's change.
      */
     private fun syncLinkedProjectName(configuration: SpringBootRunConfiguration) {
         val nativeSettings = project.getService(NativeSettings::class.java) ?: return
@@ -64,19 +70,25 @@ class ExplytRunManagerListener(val project: Project) : RunManagerListener {
             return
         }
 
-        // Projects linked before the main class name was stored can only be matched by the main-class file path,
-        // which requires resolving PSI. Reaching this point means such a link exists and its name is stale, so the
-        // resolution cost is now paid only in that case instead of on every configuration change.
-        val legacySettings = outdatedSettings.filter { it.qualifiedMainClassName == null }
-        if (legacySettings.isEmpty()) return
+        // Links that cannot be matched by the stored class name are matched by the main-class file path, which
+        // requires resolving PSI. Only a dangling stored name is repaired this way, so the resolution cost is paid
+        // in that case alone instead of on every configuration change.
+        val danglingSettings = outdatedSettings.filter { isDanglingName(it.runConfigurationName) }
+        if (danglingSettings.isEmpty()) return
 
         val mainFilePath = runReadActionBlocking {
             configuration.mainClass?.containingFile?.virtualFile?.canonicalPath
         } ?: return
         val linked = nativeSettings.getLinkedProjectSettings(mainFilePath)
-            ?.takeIf { it in legacySettings }
+            ?.takeIf { it in danglingSettings }
             ?: return
         linked.runConfigurationName = newName
+    }
+
+    /** A stored name is dangling when no run configuration bears it any more, so claiming it cannot steal a live link. */
+    private fun isDanglingName(storedName: String?): Boolean {
+        storedName ?: return true
+        return RunManager.getInstance(project).allSettings.none { it.name == storedName }
     }
 
     override fun stateLoaded(runManager: RunManager, isFirstLoadState: Boolean) {

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListenerTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListenerTest.kt
@@ -84,6 +84,85 @@ class ExplytRunManagerListenerTest : ExplytKotlinLightTestCase() {
         )
     }
 
+    /**
+     * Production repro: for a Kotlin top-level `main()` the configuration's main class is the file facade
+     * (`...DemoApplicationKt`), while the link stores the `@SpringBootApplication` class (`...DemoApplication`).
+     * Those identities never match, so a dangling stored name has to be repaired through the main-class file.
+     */
+    fun testKotlinFacadeLinkFollowsRenameWhenStoredNameIsDangling() {
+        val mainFilePath = configureDemoApplication()
+
+        val nativeSettings = project.getService(NativeSettings::class.java)
+        nativeSettings.linkProject(NativeProjectSettings().apply {
+            externalProjectPath = mainFilePath
+            qualifiedMainClassName = "com.demo.DemoApplication"
+            runConfigurationName = "DemoApplicationKt"
+        })
+
+        val rcSettings = addSpringBootConfiguration("Dashboard VPC")
+
+        runManager().fireRunConfigurationChanged(rcSettings)
+
+        assertEquals(
+            "Dashboard VPC",
+            nativeSettings.getLinkedProjectSettings(mainFilePath)?.runConfigurationName
+        )
+    }
+
+    /**
+     * Configurations sharing one main class differ in profiles, VM args and environment, so a stored name that
+     * still belongs to a live configuration must not be overwritten when a sibling configuration changes.
+     */
+    fun testLinkNameIsKeptWhenStoredNameBelongsToAnotherLiveConfiguration() {
+        val mainFilePath = configureDemoApplication()
+
+        val nativeSettings = project.getService(NativeSettings::class.java)
+        nativeSettings.linkProject(NativeProjectSettings().apply {
+            externalProjectPath = mainFilePath
+            qualifiedMainClassName = "com.demo.DemoApplication"
+            runConfigurationName = "Dashboard Staging"
+        })
+
+        addSpringBootConfiguration("Dashboard Staging")
+        val vpcSettings = addSpringBootConfiguration("Dashboard VPC")
+
+        runManager().fireRunConfigurationChanged(vpcSettings)
+
+        assertEquals(
+            "Dashboard Staging",
+            nativeSettings.getLinkedProjectSettings(mainFilePath)?.runConfigurationName
+        )
+    }
+
+    private fun runManager() = RunManager.getInstance(project) as RunManagerImpl
+
+    private fun configureDemoApplication(): String = myFixture.configureByText(
+        "DemoApplication.kt",
+        """
+        package com.demo
+
+        import org.springframework.boot.autoconfigure.SpringBootApplication
+        import org.springframework.boot.runApplication
+
+        @SpringBootApplication
+        class DemoApplication
+
+        fun main(args: Array<String>) {
+            runApplication<DemoApplication>(*args)
+        }
+        """.trimIndent()
+    ).virtualFile.canonicalPath!!
+
+    private fun addSpringBootConfiguration(name: String): RunnerAndConfigurationSettingsImpl {
+        val runManager = runManager()
+        val runConfiguration = SpringBootConfigurationFactory.createTemplateConfiguration(project)
+        runConfiguration.name = name
+        runConfiguration.mainClassName = "com.demo.DemoApplicationKt"
+        val rcSettings = RunnerAndConfigurationSettingsImpl(runManager, runConfiguration)
+        runManager.addConfiguration(rcSettings)
+        return rcSettings
+    }
+
     fun testNoLinkedProjectIsLeftUntouched() {
         val mainFile = myFixture.configureByText(
             "Other.kt",


### PR DESCRIPTION
## Summary

Syncing an Explyt Spring project for a Kotlin application with a top-level `main()` could fail with:

```
Error: Main method not found in class com.example.DemoApplication, please define the main method as:
   public static void main(String[] args)
```

Kotlin has **two** main-class identities, and the plugin stored one while comparing against the other:

- `AttachSpringBootProjectAction` persists `NativeProjectSettings.qualifiedMainClassName` as the `@SpringBootApplication` class (`...DemoApplication`) via `NativeBootUtils.getMainClass`.
- `ApplicationConfiguration.mainClassName` holds the file facade (`...DemoApplicationKt`), which is what actually declares `main`.

Three code paths then failed together:

1. `ExplytRunManagerListener.syncLinkedProjectName` compared those two identities in its fast path — for Kotlin they can never be equal — and its path-based fallback was restricted to links with `qualifiedMainClassName == null`. A Kotlin link with a stale stored name was therefore never repaired.
2. `RunConfigurationExtractor.findRunConfiguration` failed the by-name lookup (dangling name) and then dropped its `singleOrNull` path fallback because two run configurations shared the same main class.
3. `createDefaultRunConfiguration` fabricated a configuration with `mainClassName = qualifiedMainClassName`, i.e. the application class with no `main`, and returned it as `agentRunConfiguration` unconditionally — so `SpringBeanNativeResolver` took `patchJavaAgent` instead of `patchClasspath` and launched that class directly, producing the error above.

### Changes

- **`ExplytRunManagerListener`** — the main-class-file fallback now applies to any stale link rather than only links predating `qualifiedMainClassName`, guarded by a new `isDanglingName` check so several configurations sharing one main class cannot steal each other's stored name. The update stays synchronous, preserving the callback-visibility contract covered by the existing tests.
- **`RunConfigurationExtractor`** — resolves the class that actually declares `main` from the linked file (`PsiClassOwner` + `PsiMethodUtil.hasMainMethod`, one branch covering Java and Kotlin); disambiguates an ambiguous path match via the selected configuration; returns `null` for a dangling stored name so the existing `nothingException` reports it instead of silently syncing a fabricated configuration; and respects agent vs. classpath mode in the fallback.

## Related issue

Follow-up to #229 — same linkage area, Kotlin file-facade case not covered there.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.runconfiguration.ExplytRunManagerListenerTest"
```

4/4 tests pass (run with `--rerun` to defeat the Gradle build cache).

Two tests added to `ExplytRunManagerListenerTest`:

- `testKotlinFacadeLinkFollowsRenameWhenStoredNameIsDangling` — the production repro. Verified red before the fix, failing with `expected:<Dashboard VPC> but was:<DemoApplicationKt>`, and green after.
- `testLinkNameIsKeptWhenStoredNameBelongsToAnotherLiveConfiguration` — two configurations sharing one main class; a sibling's change must not overwrite a stored name that still belongs to a live configuration.

Both pre-existing tests in the class continue to pass unchanged.

Not covered by tests: the `RunConfigurationExtractor` changes. Exercising them needs `NativeExecutionSettings`, a real module and `SpringToolRunConfigurationsSettingsState` agent-mode wiring, which the light fixture does not provide cleanly; adding a fragile fixture seemed worse than stating the gap.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. *(no new files)*
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed. *(CHANGELOG only — isolated correctness fix, no user-facing docs change)*

## Note for reviewers

While diagnosing this, a broader issue surfaced that is deliberately **not** in this PR: `NativeSettings` declares `@State(storages = [Storage("explyt-spring-native-settings.xml")])`, which makes the file shareable in `.idea/` — and it is committed in public repositories today. That means a locally renamed run configuration name travels to teammates through VCS, and a VCS-delivered rename arrives as remove+add (`runConfigurationChanged` never fires), so no local repair path applies. That will be filed and addressed separately.
