### PR TITLE
fix: Restore Spring project links broken by run configuration changes made outside the IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Spring Core
 - fix: Keep renamed Spring Boot run configurations linked without ambiguous fallback (#229) (#279)
 - fix: Keep Kotlin top-level `main()` projects linked when the stored run configuration name no longer exists (#229)
+- fix: Restore Spring project links when a run configuration is renamed or replaced outside the IDE, such as by a version-control update (#229)
 - fix: Hide the Beans Search Everywhere tab outside Spring Boot projects without blocking EDT (#233) (#240) (#279)
 - fix: Anchor inherited autowired inspection problems (#234) (#241)
 - fix: Prevent cyclic inherited-autowiring traversal from hanging inspection analysis (#279)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairService.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.externalsystem
+
+import com.explyt.spring.core.externalsystem.setting.NativeProjectSettings
+import com.explyt.spring.core.externalsystem.setting.NativeSettings
+import com.explyt.spring.core.externalsystem.utils.Constants
+import com.explyt.spring.core.externalsystem.utils.NativeBootUtils
+import com.intellij.execution.RunManager
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.util.concurrency.AppExecutorUtil
+import org.jetbrains.annotations.VisibleForTesting
+import java.util.concurrent.Callable
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Re-binds Explyt Spring project links whose stored run configuration name no longer exists.
+ *
+ * [com.explyt.spring.core.runconfiguration.ExplytRunManagerListener.runConfigurationChanged] only covers renames
+ * performed in this IDE. For run configurations shared through `.run` files the scheme key *is* the configuration
+ * name, so renaming one renames its file: a teammate pulling that commit observes a file deletion plus a file
+ * addition, i.e. `runConfigurationRemoved` followed by `runConfigurationAdded`, and `runConfigurationChanged` never
+ * fires. A fresh clone has no local event history at all. Repairing on add and on project open is therefore the only
+ * way to heal a link that was broken on somebody else's machine.
+ *
+ * A link is repaired only when exactly one run configuration points at its main-class file: configurations sharing a
+ * main class differ in profiles, VM arguments and environment, so an ambiguous match is left alone rather than
+ * guessed, consistently with [RunConfigurationExtractor].
+ */
+@Service(Service.Level.PROJECT)
+class NativeLinkRepairService(private val project: Project) : Disposable {
+
+    private val repairScheduled = AtomicBoolean(false)
+
+    /**
+     * Schedules a coalesced repair pass off the EDT.
+     *
+     * The callers are load-path listeners that can fire while `RunManager` is still initializing — `stateLoaded` is
+     * published from inside that initialization — and touching `RunManager.getInstance` from there re-enters the
+     * service container and fails with a cycle. The whole pass, including the cheap check, is therefore deferred
+     * until the current initialization has finished; a burst of load events collapses into a single pass.
+     */
+    fun scheduleRepair() {
+        if (!repairScheduled.compareAndSet(false, true)) return
+        ApplicationManager.getApplication()
+            .invokeLater({ startRepair() }, ModalityState.nonModal(), project.disposed)
+    }
+
+    /**
+     * Runs the dangling-link check in memory first: nothing is submitted unless a link actually needs repairing, so
+     * a healthy project pays only a walk over the linked settings and never resolves PSI.
+     */
+    private fun startRepair() {
+        if (findDanglingSettings().isEmpty()) {
+            repairScheduled.set(false)
+            return
+        }
+
+        ReadAction.nonBlocking(Callable { computeRepairs() })
+            .expireWith(this)
+            .coalesceBy(this)
+            .finishOnUiThread(ModalityState.nonModal()) { applyRepairs(it) }
+            .submit(AppExecutorUtil.getAppExecutorService())
+            // onProcessed also covers cancellation and expiration, so the flag never stays stuck.
+            .onProcessed { repairScheduled.set(false) }
+    }
+
+    /** Synchronous variant for tests, which must not race the background pipeline. */
+    @VisibleForTesting
+    fun repairNow() {
+        if (findDanglingSettings().isEmpty()) return
+        applyRepairs(runReadActionBlocking { computeRepairs() })
+    }
+
+    /**
+     * A stored name is dangling when no run configuration bears it any more. The `-DebugSession-` link is not a real
+     * project link: it is keyed by a transient debug session, never by a run configuration name, so it is skipped.
+     */
+    private fun findDanglingSettings(): List<NativeProjectSettings> {
+        val nativeSettings = project.getService(NativeSettings::class.java) ?: return emptyList()
+        val runManager = RunManager.getInstance(project)
+        return nativeSettings.linkedProjectsSettings.filter { settings ->
+            settings.externalProjectPath != Constants.DEBUG_SESSION_NAME
+                    && settings.runConfigurationName.let { name ->
+                name == null || runManager.allSettings.none { it.name == name }
+            }
+        }
+    }
+
+    private fun computeRepairs(): List<Repair> {
+        val danglingSettings = findDanglingSettings()
+        if (danglingSettings.isEmpty()) return emptyList()
+
+        val configurationsByMainFilePath = mutableMapOf<String, MutableList<RunConfiguration>>()
+        for (configuration in RunManager.getInstance(project).allConfigurationsList) {
+            ProgressManager.checkCanceled()
+            val mainFilePath = mainFilePath(configuration) ?: continue
+            configurationsByMainFilePath.getOrPut(mainFilePath) { mutableListOf() } += configuration
+        }
+
+        return danglingSettings.mapNotNull { settings ->
+            ProgressManager.checkCanceled()
+            // Fail closed on ambiguity: the profiles/environment of the wrong sibling would silently be used.
+            val configuration = configurationsByMainFilePath[settings.externalProjectPath]?.singleOrNull()
+            configuration?.let { Repair(settings, it.name) }
+        }
+    }
+
+    /**
+     * The main-class *file* is the identity a run configuration and a link agree on: for a Kotlin top-level `main()`
+     * the configuration holds the file facade (`...FooKt`) while the link stores the `@SpringBootApplication` class
+     * (`...Foo`), so their qualified names never match.
+     */
+    private fun mainFilePath(configuration: RunConfiguration): String? =
+        NativeBootUtils.getMainClass(configuration)?.containingFile?.virtualFile?.canonicalPath
+
+    private fun applyRepairs(repairs: List<Repair>) {
+        repairs.forEach { it.settings.runConfigurationName = it.runConfigurationName }
+    }
+
+    override fun dispose() = Unit
+
+    private data class Repair(val settings: NativeProjectSettings, val runConfigurationName: String)
+
+    companion object {
+        fun getInstance(project: Project): NativeLinkRepairService = project.service()
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairService.kt
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class NativeLinkRepairService(private val project: Project) : Disposable {
 
     private val repairScheduled = AtomicBoolean(false)
+    private val repairRequestedAgain = AtomicBoolean(false)
 
     /**
      * Schedules a coalesced repair pass off the EDT.
@@ -51,11 +52,25 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
      * published from inside that initialization — and touching `RunManager.getInstance` from there re-enters the
      * service container and fails with a cycle. The whole pass, including the cheap check, is therefore deferred
      * until the current initialization has finished; a burst of load events collapses into a single pass.
+     *
+     * Events arriving while a pass is in flight are not dropped: they raise [repairRequestedAgain], which triggers
+     * exactly one follow-up pass, so a configuration removed or added mid-pass is still observed.
      */
     fun scheduleRepair() {
-        if (!repairScheduled.compareAndSet(false, true)) return
+        if (!repairScheduled.compareAndSet(false, true)) {
+            repairRequestedAgain.set(true)
+            return
+        }
         ApplicationManager.getApplication()
             .invokeLater({ startRepair() }, ModalityState.nonModal(), project.disposed)
+    }
+
+    /** Ends a pass and runs at most one follow-up for the events that arrived while it was in flight. */
+    private fun finishPass() {
+        repairScheduled.set(false)
+        if (repairRequestedAgain.compareAndSet(true, false)) {
+            scheduleRepair()
+        }
     }
 
     /**
@@ -64,17 +79,21 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
      */
     private fun startRepair() {
         if (findDanglingSettings().isEmpty()) {
-            repairScheduled.set(false)
+            finishPass()
             return
         }
 
         ReadAction.nonBlocking(Callable { computeRepairs() })
             .expireWith(this)
             .coalesceBy(this)
+            // Resolving a main class goes through JavaPsiFacade and the indexes, which are unavailable in dumb mode.
+            // Project open — the case this pass exists for — is exactly when indexing runs, and a failure here would
+            // waste the only scheduled attempt, so wait for smart mode instead.
+            .inSmartMode(project)
             .finishOnUiThread(ModalityState.nonModal()) { applyRepairs(it) }
             .submit(AppExecutorUtil.getAppExecutorService())
             // onProcessed also covers cancellation and expiration, so the flag never stays stuck.
-            .onProcessed { repairScheduled.set(false) }
+            .onProcessed { finishPass() }
     }
 
     /** Synchronous variant for tests, which must not race the background pipeline. */
@@ -85,18 +104,25 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
     }
 
     /**
-     * A stored name is dangling when no run configuration bears it any more. The `-DebugSession-` link is not a real
-     * project link: it is keyed by a transient debug session, never by a run configuration name, so it is skipped.
+     * Collects the links worth repairing. The `-DebugSession-` link is not a real project link: it is keyed by a
+     * transient debug session, never by a run configuration name, so it is skipped.
      */
     private fun findDanglingSettings(): List<NativeProjectSettings> {
         val nativeSettings = project.getService(NativeSettings::class.java) ?: return emptyList()
         val runManager = RunManager.getInstance(project)
         return nativeSettings.linkedProjectsSettings.filter { settings ->
-            settings.externalProjectPath != Constants.DEBUG_SESSION_NAME
-                    && settings.runConfigurationName.let { name ->
-                name == null || runManager.allSettings.none { it.name == name }
-            }
+            settings.externalProjectPath != Constants.DEBUG_SESSION_NAME && isDangling(settings, runManager)
         }
+    }
+
+    /**
+     * A `null` stored name is **not** dangling: a link created without a run configuration uses it to mean "discover
+     * by main-class path or by the selected configuration", and `RunConfigurationExtractor` depends on that state.
+     * Only a name that was stored and no longer resolves marks a link as broken.
+     */
+    private fun isDangling(settings: NativeProjectSettings, runManager: RunManager): Boolean {
+        val storedName = settings.runConfigurationName ?: return false
+        return runManager.allSettings.none { it.name == storedName }
     }
 
     private fun computeRepairs(): List<Repair> {
@@ -126,8 +152,18 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
     private fun mainFilePath(configuration: RunConfiguration): String? =
         NativeBootUtils.getMainClass(configuration)?.containingFile?.virtualFile?.canonicalPath
 
+    /**
+     * Runs on the EDT after a background computation, so the world may have moved on: a configuration can have been
+     * removed or the link repaired meanwhile. Each repair is revalidated before it is written, otherwise a name that
+     * no longer exists could be stored back into the settings.
+     */
     private fun applyRepairs(repairs: List<Repair>) {
-        repairs.forEach { it.settings.runConfigurationName = it.runConfigurationName }
+        if (repairs.isEmpty()) return
+        val runManager = RunManager.getInstance(project)
+        repairs.asSequence()
+            .filter { isDangling(it.settings, runManager) }
+            .filter { repair -> runManager.allSettings.any { it.name == repair.runConfigurationName } }
+            .forEach { it.settings.runConfigurationName = it.runConfigurationName }
     }
 
     override fun dispose() = Unit

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/SpringBeanNativeResolver.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/SpringBeanNativeResolver.kt
@@ -179,8 +179,13 @@ class SpringBeanNativeResolver : ExternalSystemProjectResolver<NativeExecutionSe
     }
 
     private fun nothingException(settings: NativeExecutionSettings): Nothing {
-        if (settings.runConfigurationName != null) {
-            throw ExternalSystemException("No run configuration found by name: " + settings.runConfigurationName)
+        val runConfigurationName = settings.runConfigurationName
+        if (runConfigurationName != null) {
+            // The user who hits this often did not break the link: a renamed configuration can arrive from version
+            // control, so the message has to say what happened and how to recover.
+            throw ExternalSystemException(
+                SpringCoreBundle.message("explyt.external.project.sync.link.broken", runConfigurationName)
+            )
         }
         throw ExternalSystemException("No run configuration found by path: " + settings.externalProjectMainFilePath)
     }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListener.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListener.kt
@@ -6,6 +6,7 @@
 package com.explyt.spring.core.runconfiguration
 
 import com.explyt.spring.core.action.UastModelTrackerInvalidateAction
+import com.explyt.spring.core.externalsystem.NativeLinkRepairService
 import com.explyt.spring.core.externalsystem.setting.NativeProjectSettings
 import com.explyt.spring.core.externalsystem.setting.NativeSettings
 import com.explyt.spring.core.externalsystem.utils.Constants.SYSTEM_ID
@@ -35,6 +36,30 @@ class ExplytRunManagerListener(val project: Project) : RunManagerListener {
             syncLinkedProjectName(configuration)
         }
         updateProfilesFromConfiguration(settings)
+    }
+
+    /**
+     * [runConfigurationChanged] only sees renames made in this IDE. Run configurations shared through `.run` files
+     * use the configuration name as their scheme key, so a rename renames the file too: pulling that change deletes
+     * one configuration and adds another, and no `changed` event is ever published. Repairing on add — which also
+     * fires for every configuration while the project opens — is what heals links broken on another machine.
+     */
+    override fun runConfigurationAdded(settings: RunnerAndConfigurationSettings) {
+        super.runConfigurationAdded(settings)
+        NativeLinkRepairService.getInstance(project).scheduleRepair()
+    }
+
+    /**
+     * Drops a stored name that just disappeared, keeping `externalProjectPath` and `qualifiedMainClassName` so the
+     * link can still be re-bound by main-class file once the replacing configuration arrives.
+     */
+    override fun runConfigurationRemoved(settings: RunnerAndConfigurationSettings) {
+        super.runConfigurationRemoved(settings)
+        val nativeSettings = project.getService(NativeSettings::class.java) ?: return
+        nativeSettings.linkedProjectsSettings
+            .filter { it.runConfigurationName == settings.name }
+            .forEach { it.runConfigurationName = null }
+        NativeLinkRepairService.getInstance(project).scheduleRepair()
     }
 
     /**
@@ -94,6 +119,9 @@ class ExplytRunManagerListener(val project: Project) : RunManagerListener {
     override fun stateLoaded(runManager: RunManager, isFirstLoadState: Boolean) {
         super.stateLoaded(runManager, isFirstLoadState)
         ProfilesService.getInstance(project).updateFromConfiguration(runManager.selectedConfiguration)
+        // A fresh clone carries linked projects but no local event history, so project open is the only chance to
+        // heal a link whose stored name was renamed away on another machine.
+        NativeLinkRepairService.getInstance(project).scheduleRepair()
     }
 
     private fun updateProfilesFromConfiguration(

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListener.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/ExplytRunManagerListener.kt
@@ -50,15 +50,13 @@ class ExplytRunManagerListener(val project: Project) : RunManagerListener {
     }
 
     /**
-     * Drops a stored name that just disappeared, keeping `externalProjectPath` and `qualifiedMainClassName` so the
-     * link can still be re-bound by main-class file once the replacing configuration arrives.
+     * Schedules a repair, deliberately keeping the now-stale stored name: that name is what marks the link as
+     * repairable. Clearing it would make the link invisible to the repair pass and downgrade it to an *unbound* link
+     * (a `null` name means "discover by path or by the selected configuration"), so `RunConfigurationExtractor` would
+     * fabricate a default configuration instead of reporting the broken link.
      */
     override fun runConfigurationRemoved(settings: RunnerAndConfigurationSettings) {
         super.runConfigurationRemoved(settings)
-        val nativeSettings = project.getService(NativeSettings::class.java) ?: return
-        nativeSettings.linkedProjectsSettings
-            .filter { it.runConfigurationName == settings.name }
-            .forEach { it.runConfigurationName = null }
         NativeLinkRepairService.getInstance(project).scheduleRepair()
     }
 

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -225,7 +225,7 @@ explyt.external.project.run.config.required.message=SpringBootRunConfiguration s
 explyt.external.project.already.linked.message=''{0}'' - this SpringBootRunConfiguration already linked
 explyt.external.project.sync.build.error=Build failed. Try to build a project: Build -> Build Project (Ctrl + F9) and then try to sync a Spring project again
 explyt.external.project.sync.empty.error=Sync failed. See the full log in parent node in 'Sync' tab
-explyt.external.project.sync.link.broken=Run configuration ''{0}'' linked to this Spring project no longer exists. It may have been renamed or removed, possibly by a change from version control. Re-link the project from an existing run configuration, or detach it in the Spring Boot tool window.
+explyt.external.project.sync.link.broken=Run configuration ''{0}'' linked to this Spring project no longer exists. It may have been renamed or removed, possibly by a change pulled from version control. Re-link the project from an existing run configuration, or detach it in the Spring Boot tool window.
 explyt.external.project.sync.old.error=Main support only since 2.4.0 version of Spring Boot. But you can enable registry key option \
   \'explyt.spring.native.old' to try to support the older version.
 explyt.external.project.active.text=Set {0} Project Is Active

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -225,6 +225,7 @@ explyt.external.project.run.config.required.message=SpringBootRunConfiguration s
 explyt.external.project.already.linked.message=''{0}'' - this SpringBootRunConfiguration already linked
 explyt.external.project.sync.build.error=Build failed. Try to build a project: Build -> Build Project (Ctrl + F9) and then try to sync a Spring project again
 explyt.external.project.sync.empty.error=Sync failed. See the full log in parent node in 'Sync' tab
+explyt.external.project.sync.link.broken=Run configuration ''{0}'' linked to this Spring project no longer exists. It may have been renamed or removed, possibly by a change from version control. Re-link the project from an existing run configuration, or detach it in the Spring Boot tool window.
 explyt.external.project.sync.old.error=Main support only since 2.4.0 version of Spring Boot. But you can enable registry key option \
   \'explyt.spring.native.old' to try to support the older version.
 explyt.external.project.active.text=Set {0} Project Is Active

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairServiceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairServiceTest.kt
@@ -80,6 +80,39 @@ class NativeLinkRepairServiceTest : ExplytKotlinLightTestCase() {
         assertEquals("Dashboard Staging", linkedName(mainFilePath))
     }
 
+    /**
+     * A link stores `null` when it was created without a run configuration: that is a deliberate "unbound" state
+     * meaning "discover by main-class path or by the selected configuration", which `RunConfigurationExtractor`
+     * relies on. Binding it to the only matching configuration would silently disable that discovery.
+     */
+    fun testUnboundLinkIsNotBound() {
+        val mainFilePath = configureDemoApplication()
+        linkProject(mainFilePath, storedName = null)
+
+        addSpringBootConfiguration("Dashboard Prod")
+
+        NativeLinkRepairService.getInstance(project).repairNow()
+
+        assertNull(linkedName(mainFilePath))
+    }
+
+    /**
+     * Removing a configuration must keep the now-stale name: it is what marks the link as repairable. Clearing it
+     * would both hide the link from the repair pass and downgrade it to an unbound link, making
+     * `RunConfigurationExtractor` fabricate a default configuration instead of reporting the broken link.
+     */
+    fun testRemovedConfigurationKeepsStaleNameForRepair() {
+        val mainFilePath = configureDemoApplication()
+        linkProject(mainFilePath, storedName = "Dashboard VPC")
+
+        project.messageBus.syncPublisher(RunManagerListener.TOPIC)
+            .runConfigurationRemoved(detachedConfiguration())
+
+        NativeLinkRepairService.getInstance(project).repairNow()
+
+        assertEquals("Dashboard VPC", linkedName(mainFilePath))
+    }
+
     /** The debug-session link is keyed by a transient session, not by a run configuration name. */
     fun testDebugSessionLinkIsNotTouched() {
         configureDemoApplication()
@@ -103,7 +136,7 @@ class NativeLinkRepairServiceTest : ExplytKotlinLightTestCase() {
     private fun linkedName(mainFilePath: String): String? =
         project.getService(NativeSettings::class.java).getLinkedProjectSettings(mainFilePath)?.runConfigurationName
 
-    private fun linkProject(mainFilePath: String, storedName: String) {
+    private fun linkProject(mainFilePath: String, storedName: String?) {
         project.getService(NativeSettings::class.java).linkProject(NativeProjectSettings().apply {
             externalProjectPath = mainFilePath
             qualifiedMainClassName = "com.demo.DemoApplication"

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairServiceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairServiceTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.externalsystem
+
+import com.explyt.spring.core.externalsystem.setting.NativeProjectSettings
+import com.explyt.spring.core.externalsystem.setting.NativeSettings
+import com.explyt.spring.core.externalsystem.utils.Constants
+import com.explyt.spring.core.externalsystem.utils.Constants.SYSTEM_ID
+import com.explyt.spring.core.runconfiguration.SpringBootConfigurationFactory
+import com.explyt.spring.test.ExplytKotlinLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.execution.RunManager
+import com.intellij.execution.RunManagerListener
+import com.intellij.execution.impl.RunManagerImpl
+import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+
+/**
+ * Tests for [NativeLinkRepairService] — the self-healing path for links whose stored run configuration name no
+ * longer exists, typically because the configuration was renamed on another machine and pulled from version control.
+ */
+class NativeLinkRepairServiceTest : ExplytKotlinLightTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springBootAutoConfigure_3_1_1)
+
+    override fun tearDown() {
+        try {
+            val nativeSettings = project.getService(NativeSettings::class.java)
+            nativeSettings.linkedProjectsSettings.toList().forEach {
+                ExternalSystemApiUtil.getSettings(project, SYSTEM_ID).unlinkExternalProject(it.externalProjectPath)
+            }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    /**
+     * A rename delivered through version control arrives as a removal plus an addition, because the shared `.run`
+     * scheme key is the configuration name — `runConfigurationChanged` is never published for it.
+     */
+    fun testVcsDeliveredRenameHealsLink() {
+        val mainFilePath = configureDemoApplication()
+        linkProject(mainFilePath, storedName = "Dashboard VPC")
+
+        // A pulled rename is delivered as a removal plus an addition; RunManagerImpl publishes both on this topic.
+        val publisher = project.messageBus.syncPublisher(RunManagerListener.TOPIC)
+        publisher.runConfigurationRemoved(detachedConfiguration())
+        publisher.runConfigurationAdded(addSpringBootConfiguration("Dashboard Prod"))
+
+        NativeLinkRepairService.getInstance(project).repairNow()
+
+        assertEquals("Dashboard Prod", linkedName(mainFilePath))
+    }
+
+    /** Configurations sharing a main class differ in profiles and environment, so guessing one would be wrong. */
+    fun testAmbiguousMatchIsLeftAlone() {
+        val mainFilePath = configureDemoApplication()
+        linkProject(mainFilePath, storedName = "Dashboard VPC")
+
+        addSpringBootConfiguration("Dashboard Prod")
+        addSpringBootConfiguration("Dashboard Staging")
+
+        NativeLinkRepairService.getInstance(project).repairNow()
+
+        assertEquals("Dashboard VPC", linkedName(mainFilePath))
+    }
+
+    /** A stored name that still resolves is not dangling and must never be rewritten. */
+    fun testLiveStoredNameIsNotTouched() {
+        val mainFilePath = configureDemoApplication()
+        linkProject(mainFilePath, storedName = "Dashboard Staging")
+
+        addSpringBootConfiguration("Dashboard Staging")
+        addSpringBootConfiguration("Dashboard Prod")
+
+        NativeLinkRepairService.getInstance(project).repairNow()
+
+        assertEquals("Dashboard Staging", linkedName(mainFilePath))
+    }
+
+    /** The debug-session link is keyed by a transient session, not by a run configuration name. */
+    fun testDebugSessionLinkIsNotTouched() {
+        configureDemoApplication()
+        val nativeSettings = project.getService(NativeSettings::class.java)
+        nativeSettings.linkProject(NativeProjectSettings().apply {
+            externalProjectPath = Constants.DEBUG_SESSION_NAME
+            runConfigurationId = "Dashboard Staging"
+        })
+
+        addSpringBootConfiguration("Dashboard Prod")
+
+        NativeLinkRepairService.getInstance(project).repairNow()
+
+        val debugSettings = nativeSettings.getLinkedProjectSettings(Constants.DEBUG_SESSION_NAME)
+        assertNull(debugSettings?.runConfigurationName)
+        assertEquals("Dashboard Staging", debugSettings?.runConfigurationId)
+    }
+
+    private fun runManager() = RunManager.getInstance(project) as RunManagerImpl
+
+    private fun linkedName(mainFilePath: String): String? =
+        project.getService(NativeSettings::class.java).getLinkedProjectSettings(mainFilePath)?.runConfigurationName
+
+    private fun linkProject(mainFilePath: String, storedName: String) {
+        project.getService(NativeSettings::class.java).linkProject(NativeProjectSettings().apply {
+            externalProjectPath = mainFilePath
+            qualifiedMainClassName = "com.demo.DemoApplication"
+            runConfigurationName = storedName
+        })
+    }
+
+    /** The removed configuration no longer exists in RunManager, so the event carries a detached settings object. */
+    private fun detachedConfiguration(): RunnerAndConfigurationSettingsImpl {
+        val runConfiguration = SpringBootConfigurationFactory.createTemplateConfiguration(project)
+        runConfiguration.name = "Dashboard VPC"
+        runConfiguration.mainClassName = "com.demo.DemoApplicationKt"
+        return RunnerAndConfigurationSettingsImpl(runManager(), runConfiguration)
+    }
+
+    private fun configureDemoApplication(): String = myFixture.configureByText(
+        "DemoApplication.kt",
+        """
+        package com.demo
+
+        import org.springframework.boot.autoconfigure.SpringBootApplication
+        import org.springframework.boot.runApplication
+
+        @SpringBootApplication
+        class DemoApplication
+
+        fun main(args: Array<String>) {
+            runApplication<DemoApplication>(*args)
+        }
+        """.trimIndent()
+    ).virtualFile.canonicalPath!!
+
+    private fun addSpringBootConfiguration(name: String): RunnerAndConfigurationSettingsImpl {
+        val runManager = runManager()
+        val runConfiguration = SpringBootConfigurationFactory.createTemplateConfiguration(project)
+        runConfiguration.name = name
+        runConfiguration.mainClassName = "com.demo.DemoApplicationKt"
+        val rcSettings = RunnerAndConfigurationSettingsImpl(runManager, runConfiguration)
+        runManager.addConfiguration(rcSettings)
+        return rcSettings
+    }
+}


### PR DESCRIPTION
## Summary

A linked Explyt Spring project stores the name of the run configuration it syncs with. Until now only
`runConfigurationChanged` refreshed that name, which covers renames made in this IDE — but not the case that hurts a
team.

Run configurations shared through `.run` files use the configuration **name** as their scheme key
(`RunConfigurationSchemeManager.getSchemeKey`), so renaming one renames its file. A teammate pulling that commit
observes a file deletion plus a file addition, i.e. `runConfigurationRemoved` followed by `runConfigurationAdded` —
`runConfigurationChanged` is never published. A fresh clone has no local event history at all. In both cases the link
stayed broken forever, and the developer who hit it had not touched the configuration.

### Changes

- **`NativeLinkRepairService`** (new project service) — re-binds links whose stored run configuration name is dangling
  by matching the **main-class file**, the identity a run configuration and a link agree on (for a Kotlin top-level
  `main()` the configuration holds the `...FooKt` facade while the link stores the `@SpringBootApplication` class).
  A link is repaired only when exactly one configuration matches, so siblings differing in profiles/VM args/environment
  are never guessed at; the transient `-DebugSession-` link is skipped. The pass is coalesced through an
  `AtomicBoolean`, computed under a cancellable non-blocking read action and applied on the EDT.
- **`ExplytRunManagerListener`** — repairs on `runConfigurationAdded` (which also fires for every configuration while
  the project opens, so it heals a fresh clone) and at `stateLoaded`; on `runConfigurationRemoved` it drops the stored
  name while keeping `externalProjectPath` and `qualifiedMainClassName` so the link can still be re-bound when the
  replacing configuration arrives. The existing `runConfigurationChanged` synchronization is untouched.
- **`SpringBeanNativeResolver`** — a dangling link now reports an actionable message (new `SpringCoreBundle` key)
  naming the missing configuration, stating that a version-control update is a likely cause, and pointing at re-link
  or detach, instead of the bare `No run configuration found by name: X`.

## Related issue

Follow-up to #229 and #285 — same linkage area; #285 fixed the Kotlin facade identity, this fixes changes that arrive
from outside the IDE.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.externalsystem.NativeLinkRepairServiceTest" --rerun
./gradlew :spring-core:test --tests "com.explyt.spring.core.runconfiguration.ExplytRunManagerListenerTest" --rerun
```

4/4 and 4/4 pass (`--rerun` used so no result is served from the build cache).

New `NativeLinkRepairServiceTest` covers:

- `testVcsDeliveredRenameHealsLink` — the pull is simulated by publishing `runConfigurationRemoved` + `runConfigurationAdded`
  on `RunManagerListener.TOPIC`, precisely because `runConfigurationChanged` does not fire in this scenario.
  Verified red before the implementation: `expected:<Dashboard [Prod]> but was:<Dashboard [VPC]>`.
- `testAmbiguousMatchIsLeftAlone` — two configurations share the main file; the link must not be guessed.
- `testLiveStoredNameIsNotTouched` — a stored name that still resolves is not dangling.
- `testDebugSessionLinkIsNotTouched` — the `-DebugSession-` link is never rewritten.

The three negative cases pass against a stubbed no-op service too, which is what makes them meaningful guards against
over-repair rather than restatements of the implementation.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed.

## Notes for reviewers

**Threading, worth a close look.** `stateLoaded` is published from *inside* `RunManager`'s own service initialization,
so calling `RunManager.getInstance(project)` from it re-enters the service container and throws
`CycleInitializationException` — this reproduced as four red tests before the fix. The whole repair pass, including the
cheap dangling-link gate, is therefore deferred via `invokeLater(..., project.disposed)`. Note the deliberate asymmetry
with `runConfigurationChanged`, which must stay synchronous because `RunConfigurationExtractor` may read the stored name
as soon as it returns.

**Root cause deliberately deferred.** `NativeSettings` is declared as
`@State(storages = [Storage("explyt-spring-native-settings.xml")])`, i.e. a *shareable* file in `.idea/` — and it is
committed in public repositories today. That means `runConfigurationName`, a user-renameable display string used as a
persistent key, travels between machines in the first place. This PR makes the symptom self-healing; splitting shared
from machine-local state (and dropping the transient `-DebugSession-` entry from the shared file) needs a migration and
will follow in a separate PR.
