### PR TITLE
fix: Avoid PSI resolution in Spring Boot toolbar action update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - fix: Resolve Kotlin `const val` package names in component-scan annotations
 - fix: Resolve `@Value` placeholder keys whose default is a SpEL or nested placeholder expression, such as `${my.key:#{null}}`
 - fix: Resolve property keys consumed only from a dependency module (#276)
+- fix: Stop resolving PSI in the Spring Boot toolbar action update, which caused multi-second action-update delays
 
 ### Spring Data
 - fix: Fail closed on stale PSI in SQL injector (#235) (#242)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootProjectAction.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootProjectAction.kt
@@ -71,9 +71,17 @@ class AttachSpringBootProjectAction : DumbAwareAction() {
 
             val mainClass = ApplicationManager.getApplication().runReadAction(
                 Computable { NativeBootUtils.getMainClass(selectedRunConfiguration) }
-            ) ?: return
-            val mainFile = mainClass.containingFile?.virtualFile ?: return
-            val canonicalPath = mainFile.canonicalPath ?: return
+            )
+            val mainFile = mainClass?.containingFile?.virtualFile
+            val canonicalPath = mainFile?.canonicalPath
+            if (mainClass == null || mainFile == null || canonicalPath == null) {
+                // The toolbar action is enabled from a cheap stored-name check, so an unresolvable main class must be
+                // reported here instead of failing silently.
+                ApplicationManager.getApplication().invokeLater {
+                    externalSystemNotification(message("explyt.external.project.run.config.required.message"), project)
+                }
+                return
+            }
             if (ExternalSystemApiUtil.getSettings(project, SYSTEM_ID).getLinkedProjectSettings(canonicalPath) != null) {
                 ExternalProjectsManagerImpl.getInstance(project).runWhenInitialized {
                     ExternalSystemUtil.refreshProject(canonicalPath, ImportSpecBuilder(project, SYSTEM_ID))

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectAction.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectAction.kt
@@ -7,11 +7,14 @@ package com.explyt.spring.core.externalsystem.action
 
 import com.explyt.spring.core.SpringCoreBundle.message
 import com.explyt.spring.core.SpringIcons
-import com.explyt.spring.core.externalsystem.utils.NativeBootUtils
 import com.intellij.execution.RunManager
+import com.intellij.execution.application.ApplicationConfiguration
+import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.DumbService
+import org.jetbrains.kotlin.idea.run.KotlinRunConfiguration
 
 class AttachSpringBootToolbarProjectAction : DumbAwareAction() {
     init {
@@ -23,15 +26,31 @@ class AttachSpringBootToolbarProjectAction : DumbAwareAction() {
         return ActionUpdateThread.BGT
     }
 
+    /**
+     * Runs on every main-toolbar refresh, so it must stay a cheap in-memory check: resolving the configuration's main
+     * class here means PSI and index access, which produced multi-second `ActionUpdater` warnings. Exact validation
+     * happens in [actionPerformed] instead.
+     */
     override fun update(e: AnActionEvent) {
         val presentation = e.presentation
         val project = e.project ?: return
         val selectedConfiguration = RunManager.getInstance(project).selectedConfiguration?.configuration
-        presentation.isEnabledAndVisible = NativeBootUtils.isSupportRunConfiguration(selectedConfiguration)
+        presentation.isVisible = selectedConfiguration.supportsSpringBootAttach()
+        // Attaching resolves the main class through indexes, so keep the button in place but inert while indexing.
+        presentation.isEnabled = presentation.isVisible && !DumbService.isDumb(project)
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         AttachSpringBootProjectAction.attachProject(project)
+    }
+
+    private fun RunConfiguration?.supportsSpringBootAttach(): Boolean {
+        val mainClassName = when (this) {
+            is ApplicationConfiguration -> mainClassName
+            is KotlinRunConfiguration -> mainClassName
+            else -> null
+        }
+        return !mainClassName.isNullOrBlank()
     }
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/utils/NativeBootUtils.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/utils/NativeBootUtils.kt
@@ -80,10 +80,6 @@ object NativeBootUtils {
         return result
     }
 
-    fun isSupportRunConfiguration(runConfiguration: RunConfiguration?): Boolean {
-        return runConfiguration?.let { getMainClass(it) != null } ?: false
-    }
-
     fun getMainClass(runConfiguration: RunConfiguration): PsiClass? {
         val psiClassList = RunConfigurationUtil.getRunPsiClass(runConfiguration)
         if (psiClassList.size == 1) return psiClassList.first()

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectActionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectActionTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.externalsystem.action
+
+import com.explyt.spring.core.runconfiguration.SpringBootConfigurationFactory
+import com.explyt.spring.test.ExplytKotlinLightTestCase
+import com.intellij.execution.RunManager
+import com.intellij.execution.application.ApplicationConfiguration
+import com.intellij.execution.application.ApplicationConfigurationType
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.impl.RunManagerImpl
+import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.testFramework.DumbModeTestUtils
+import com.intellij.testFramework.TestActionEvent
+
+class AttachSpringBootToolbarProjectActionTest : ExplytKotlinLightTestCase() {
+
+    fun testUpdateEnablesJavaApplicationConfigurationWithoutResolvingPsi() {
+        val configuration = ApplicationConfiguration(
+            "Java application",
+            project,
+            ApplicationConfigurationType.getInstance()
+        ).apply {
+            mainClassName = "missing.Application"
+        }
+        assertUpdateVisible(configuration)
+    }
+
+    fun testUpdateEnablesSpringBootConfigurationWithoutResolvingPsi() {
+        val configuration = SpringBootConfigurationFactory.createTemplateConfiguration(project).apply {
+            mainClassName = "missing.Application"
+        }
+        assertUpdateVisible(configuration)
+    }
+
+    fun testUpdateHidesConfigurationWithoutMainClass() {
+        val configuration = SpringBootConfigurationFactory.createTemplateConfiguration(project)
+        assertFalse(updatePresentation(configuration).isVisible)
+    }
+
+    /**
+     * Attaching resolves the main class through indexes, so during indexing the button must stay in place and only
+     * become inert: a main-toolbar button that disappears on every indexing pass shifts the whole toolbar.
+     */
+    fun testUpdateKeepsButtonVisibleButDisabledInDumbMode() {
+        val configuration = SpringBootConfigurationFactory.createTemplateConfiguration(project).apply {
+            mainClassName = "missing.Application"
+        }
+        DumbModeTestUtils.runInDumbModeSynchronously(project) {
+            val presentation = updatePresentation(configuration)
+            assertTrue(presentation.isVisible)
+            assertFalse(presentation.isEnabled)
+        }
+    }
+
+    private fun assertUpdateVisible(configuration: RunConfiguration) {
+        assertTrue(updatePresentation(configuration).isEnabledAndVisible)
+    }
+
+    private fun updatePresentation(configuration: RunConfiguration) = run {
+        val manager = RunManager.getInstance(project) as RunManagerImpl
+        val settings = RunnerAndConfigurationSettingsImpl(manager, configuration)
+        manager.addConfiguration(settings)
+        manager.selectedConfiguration = settings
+        try {
+            TestActionEvent.createTestEvent(
+                AttachSpringBootToolbarProjectAction(),
+                SimpleDataContext.builder().add(CommonDataKeys.PROJECT, project).build()
+            ).also { AttachSpringBootToolbarProjectAction().update(it) }.presentation
+        } finally {
+            manager.selectedConfiguration = null
+            manager.removeConfiguration(settings)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The main-toolbar `AttachSpringBootToolbarProjectAction` resolved the selected run configuration to PSI on every `update()` call:

```
update()
 -> NativeBootUtils.isSupportRunConfiguration()
 -> NativeBootUtils.getMainClass()
 -> RunConfigurationUtil.getRunPsiClass()   // index-backed, under a read action
```

Both branches are index-backed — the Kotlin path resolves the main file and its light classes, the Java path calls `ApplicationConfiguration.mainClass` — and `getMainClass` additionally runs a `@SpringBootApplication` meta-annotation check when several classes are found. Because the action sits in `ToolbarMakeGroup` and `MainToolbarRight`, `update()` runs on every toolbar refresh, so a 2025.3 sandbox IDE logged repeated warnings, especially during Gradle import and indexing:

```
WARN - #c.i.o.a.i.ActionUpdater - 10301 ms to call on BGT
AttachSpringBootToolbarProjectAction#presentation@MainToolbar
```

`ActionUpdateThread.BGT` keeps this off the EDT, but it does not make a multi-second update acceptable — it still delays action-update processing.

`update()` is now a cheap in-memory check of the configuration type and its stored main-class name; exact validation stays in `actionPerformed`. Two consequences of that are handled explicitly rather than left implicit:

- **Dumb mode.** The action stays a `DumbAwareAction` so the button keeps its toolbar position instead of disappearing on every indexing pass, but it is disabled while indexing because attaching resolves the main class through indexes.
- **Wider acceptance.** A cheap `update()` admits configurations that the old PSI-resolving predicate rejected, so `attachProject` now reports an unresolvable main class through the existing external-system notification instead of silently returning. This reuses the existing `explyt.external.project.run.config.required.message` bundle key; no new message was added.

`NativeBootUtils.isSupportRunConfiguration` had no remaining callers and was removed via Safe Delete.

## Related issue

n/a — found in `idea.log` while running a 253 dev instance.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

New test class `AttachSpringBootToolbarProjectActionTest` (4 tests, all passing):

```
./gradlew :spring-core:test --tests "com.explyt.spring.core.externalsystem.action.AttachSpringBootToolbarProjectActionTest"
```

- `testUpdateEnablesJavaApplicationConfigurationWithoutResolvingPsi` and `testUpdateEnablesSpringBootConfigurationWithoutResolvingPsi` use a deliberately unresolvable `missing.Application` main class, so they fail if `update()` ever resolves PSI again.
- `testUpdateHidesConfigurationWithoutMainClass` covers the blank-name case.
- `testUpdateKeepsButtonVisibleButDisabledInDumbMode` uses `DumbModeTestUtils.runInDumbModeSynchronously` to pin the visible-but-disabled contract.

IDE inspections report no warnings or errors on the changed files.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed. — CHANGELOG entry added under Spring Core; no user-facing strings changed.
