### PR TITLE
fix: Navigate from indexed collection property keys to the element class member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Spring Core
 - fix: Report the `@MockBean` / `@SpyBean` migration when the legacy annotation no longer resolves after a Spring Boot 4 upgrade
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`
+- fix: Navigate from an indexed collection key such as `ingest.s3-logs.sources[0].enabled` to the member of the collection's element class
 
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationPropertyKeyReferenceProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationPropertyKeyReferenceProvider.kt
@@ -19,6 +19,7 @@ import com.explyt.spring.core.completion.properties.PropertyType
 import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
 import com.explyt.spring.core.completion.renderer.PropertyRenderer
 import com.explyt.spring.core.properties.PropertiesJavaClassReferenceSet
+import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
 import com.explyt.spring.core.properties.references.MetaConfigurationKeyReference
 import com.explyt.spring.core.properties.references.PropertiesKeyMapValueReference
 import com.explyt.spring.core.properties.references.YamlKeyMapValueReference
@@ -75,10 +76,16 @@ class SpringConfigurationPropertyKeyReferenceProvider : PsiReferenceProvider() {
         }
         if (keyHint == null) {
             val property = PropertyUtil.configurationProperty(module, propertyKey)
-            return if (property?.isMap() == true) {
-                getMapValueReferences(element, module, propertyKey, property)
-            } else {
-                arrayOf(
+            return when {
+                property?.isMap() == true -> getMapValueReferences(element, module, propertyKey, property)
+
+                propertyKey.contains(ConfigurationPropertyListElementReference.INDEX_START) -> arrayOf(
+                    ConfigurationPropertyListElementReference(element, module, propertyKey),
+                    ConfigurationPropertyKeyReference(element, module, propertyKey),
+                    MetaConfigurationKeyReference(element, module, propertyKey)
+                )
+
+                else -> arrayOf(
                     ConfigurationPropertyKeyReference(element, module, propertyKey),
                     MetaConfigurationKeyReference(element, module, propertyKey)
                 )

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ConfigurationPropertyListElementReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ConfigurationPropertyListElementReference.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.references
+
+import com.explyt.spring.core.completion.properties.ConfigurationProperty
+import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
+import com.explyt.spring.core.util.PropertyUtil
+import com.intellij.openapi.module.Module
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+
+/**
+ * Resolves an indexed collection key such as `ingest.s3-logs.sources[0].enabled`.
+ *
+ * The configuration property model registers the collection itself (`...sources`) but not the members of its
+ * element type, so [com.explyt.spring.core.properties.providers.ConfigurationPropertyKeyReference] cannot
+ * resolve anything below the index. The element member is therefore looked up in the collection's element
+ * class by the key part that follows the index.
+ *
+ * Soft on purpose: a key this reference cannot resolve is left to the other key references instead of being
+ * reported as an unresolved reference.
+ */
+class ConfigurationPropertyListElementReference(
+    element: PsiElement,
+    private val module: Module,
+    private val propertyKey: String
+) : PsiReferenceBase.Poly<PsiElement>(element, null, true) {
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        val collectionProperty = findCollectionProperty() ?: return emptyArray()
+
+        val elementKey = propertyKey.substringAfter(INDEX_END, "")
+        if (elementKey.isEmpty()) return resolveCollection(collectionProperty)
+
+        val elementType = PropertyUtil.getCollectionElementType(collectionProperty) ?: return emptyArray()
+        return PropertyUtil.getMembersOfType(module, elementType, elementKey)
+            .firstOrNull { PropertyUtil.isNameSetMethod(it.name, elementKey) }
+            ?.let { PropertyUtil.resolveResults(it) }
+            ?: emptyArray()
+    }
+
+    /**
+     * The collection is looked up by the exact key preceding the FIRST index, so a shorter parent key can never
+     * win: [SpringConfigurationPropertiesSearch.getAllProperties] has no defined order, which makes a
+     * `startsWith` search over all properties ambiguous for nested keys.
+     */
+    private fun findCollectionProperty(): ConfigurationProperty? {
+        val indexStart = propertyKey.indexOf(INDEX_START)
+        if (indexStart < 0) return null
+
+        val collectionKey = propertyKey.substring(0, indexStart)
+        return SpringConfigurationPropertiesSearch.getInstance(module.project)
+            .findProperty(module, collectionKey)
+            ?.takeIf { it.isList() || it.isArray() }
+    }
+
+    private fun resolveCollection(collectionProperty: ConfigurationProperty): Array<ResolveResult> {
+        val sourceType = collectionProperty.sourceType ?: return emptyArray()
+        val sourceMember = PropertyUtil
+            .findSourceMember(collectionProperty.name, sourceType, element.project) ?: return emptyArray()
+        return PropertyUtil.resolveResults(sourceMember)
+    }
+
+    companion object {
+        const val INDEX_START = '['
+        private const val INDEX_END = "]."
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/PropertiesKeyMapValueReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/PropertiesKeyMapValueReference.kt
@@ -51,7 +51,7 @@ class PropertiesKeyMapValueReference(
         val valueType = PropertyUtil.getValueClassNameInMap(property.type) ?: return emptyArray()
         val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return emptyArray()
 
-        val methodsTypeByMap = PropertyUtil.getMethodsTypeByMap(module, valueType, propertyMapValue)
+        val methodsTypeByMap = PropertyUtil.getMembersOfType(module, valueType, propertyMapValue)
         if (methodsTypeByMap.isEmpty()) {
             return baseMapResolve(project)
         }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/YamlKeyMapValueReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/YamlKeyMapValueReference.kt
@@ -54,7 +54,7 @@ class YamlKeyMapValueReference(
         val valueType = PropertyUtil.getValueClassNameInMap(property.type) ?: return emptyArray()
         val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return emptyArray()
 
-        return PropertyUtil.getMethodsTypeByMap(module, valueType, keyValuePair.second)
+        return PropertyUtil.getMembersOfType(module, valueType, keyValuePair.second)
             .firstOrNull { PropertyUtil.isNameSetMethod(it.name, keyValuePair.second) }
             ?.let { PropertyUtil.resolveResults(it) }
             ?: emptyArray()

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -403,6 +403,22 @@ object PropertyUtil {
         return null
     }
 
+    /**
+     * The element type of a list or array property, or `null` for any other property.
+     *
+     * A Kotlin `List<T>` reaches us as a wildcard light type (`java.util.List<? extends T>`), so the variance
+     * keyword is dropped to keep the result a plain qualified name.
+     */
+    fun getCollectionElementType(property: ConfigurationProperty): String? {
+        val propertyType = property.type ?: return null
+        val elementType = when {
+            property.isArray() -> propertyType.substringBefore("[]")
+            property.isList() -> propertyType.substringAfter("<", "").substringBeforeLast(">")
+            else -> return null
+        }
+        return elementType.substringAfterLast(' ').takeIf { it.isNotBlank() }
+    }
+
     private fun getClassNameFromInnerTypeInMap(propertyType: String): String? {
         val keyType = propertyType.substringAfter(",").substringBeforeLast(">")
         if (keyType != propertyType) {
@@ -657,7 +673,7 @@ object PropertyUtil {
         }
     }
 
-    fun getMethodsTypeByMap(module: Module, valueType: String, prefix: String): List<PsiMember> {
+    fun getMembersOfType(module: Module, valueType: String, prefix: String): List<PsiMember> {
         val result = hashMapOf<String, ConfigurationProperty>()
         val project = module.project
         val qualifiedName = valueType.substringBeforeLast('#').replace('$', '.')

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/java/PropertiesReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/java/PropertiesReferenceTest.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.reference.java
 
 import com.explyt.spring.core.properties.providers.ConfigKeyPsiElement
 import com.explyt.spring.core.properties.providers.ConfigurationPropertyKeyReference
+import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
 import com.explyt.spring.core.properties.references.PropertiesKeyMapValueReference
 import com.explyt.spring.core.properties.references.ValueHintReference
 import com.explyt.spring.test.ExplytJavaLightTestCase
@@ -364,5 +365,37 @@ logging.level.org.hibernate.SQL=deb<caret>ug
         val resolveResult = multiResolve[0]
         val name = (resolveResult.element as? JsonPropertyImpl)?.name
         assertEquals(name, "value")
+    }
+
+    fun testRefKeyListElementMember() {
+        myFixture.copyFileToProject("S3LogsProperties.java")
+        myFixture.configureByText(
+            "application.properties",
+            "ingest.s3-logs.sources[0].ena<caret>bled=true"
+        )
+
+        assertEquals("setEnabled", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementCollectionItself() {
+        myFixture.copyFileToProject("S3LogsProperties.java")
+        myFixture.configureByText(
+            "application.properties",
+            "ingest.s3-logs.sour<caret>ces[0]=first"
+        )
+
+        assertEquals("setSources", resolveListElementReferenceName())
+    }
+
+    private fun resolveListElementReferenceName(): String? {
+        val reference = (file.findReferenceAt(myFixture.caretOffset) as? PsiMultiReference)
+            ?.references
+            ?.filterIsInstance<ConfigurationPropertyListElementReference>()
+            ?.singleOrNull()
+        assertNotNull("list element reference must be contributed", reference)
+
+        return reference!!.multiResolve(true)
+            .singleOrNull()
+            ?.let { (it.element as? ConfigKeyPsiElement)?.name }
     }
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/java/YamlReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/java/YamlReferenceTest.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.reference.java
 
 import com.explyt.spring.core.properties.providers.ConfigKeyPsiElement
 import com.explyt.spring.core.properties.providers.ConfigurationPropertyKeyReference
+import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
 import com.explyt.spring.core.properties.references.ValueHintReference
 import com.explyt.spring.core.properties.references.YamlKeyMapValueReference
 import com.explyt.spring.test.ExplytJavaLightTestCase
@@ -559,6 +560,83 @@ logging:
         val resolveResult = multiResolve[0]
         val name = (resolveResult.element as? JsonPropertyImpl)?.name
         assertEquals(name, "value")
+    }
+
+    fun testRefKeyListElementMember() {
+        myFixture.copyFileToProject("S3LogsProperties.java")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3-logs:
+    sources:
+      - ena<caret>bled: true
+            """.trimIndent()
+        )
+
+        assertEquals("setEnabled", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementMemberCamelCaseWritten() {
+        myFixture.copyFileToProject("S3LogsProperties.java")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3Logs:
+    sources:
+      - ena<caret>bled: true
+            """.trimIndent()
+        )
+
+        assertEquals("setEnabled", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementPicksTheMatchingMember() {
+        myFixture.copyFileToProject("S3LogsProperties.java")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3-logs:
+    sources:
+      - na<caret>me: first
+        enabled: true
+            """.trimIndent()
+        )
+
+        assertEquals("setName", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementUnknownMemberIsNotResolved() {
+        myFixture.copyFileToProject("S3LogsProperties.java")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3-logs:
+    sources:
+      - unkn<caret>own: first
+            """.trimIndent()
+        )
+
+        // The reference is still contributed, so the empty result proves the member lookup rejected the key
+        // rather than the reference never having been created.
+        assertEmpty(listElementReference().multiResolve(true).toList())
+    }
+
+    private fun resolveListElementReferenceName(): String? = listElementReference()
+        .multiResolve(true)
+        .singleOrNull()
+        ?.let { (it.element as? ConfigKeyPsiElement)?.name }
+
+    private fun listElementReference(): ConfigurationPropertyListElementReference {
+        val reference = (file.findReferenceAt(myFixture.caretOffset) as? PsiMultiReference)
+            ?.references
+            ?.filterIsInstance<ConfigurationPropertyListElementReference>()
+            ?.singleOrNull()
+        assertNotNull("list element reference must be contributed", reference)
+        return reference!!
     }
 
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/kotlin/PropertiesReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/kotlin/PropertiesReferenceTest.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.reference.kotlin
 
 import com.explyt.spring.core.properties.providers.ConfigKeyPsiElement
 import com.explyt.spring.core.properties.providers.ConfigurationPropertyKeyReference
+import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
 import com.explyt.spring.core.properties.references.ValueHintReference
 import com.explyt.spring.test.ExplytKotlinLightTestCase
 import com.explyt.spring.test.TestLibrary
@@ -103,6 +104,38 @@ main.enum-value-additional=TUE<caret>SDAY
         val resolveResult = multiResolve[0]
         val name = (resolveResult.element as? PsiEnumConstant)?.name
         assertEquals(name, "TUESDAY")
+    }
+
+    fun testRefKeyListElementMember() {
+        myFixture.copyFileToProject("S3LogsProperties.kt")
+        myFixture.configureByText(
+            "application.properties",
+            "ingest.s3-logs.sources[0].ena<caret>bled=true"
+        )
+
+        assertEquals("setEnabled", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementCollectionItself() {
+        myFixture.copyFileToProject("S3LogsProperties.kt")
+        myFixture.configureByText(
+            "application.properties",
+            "ingest.s3-logs.sour<caret>ces[0]=first"
+        )
+
+        assertEquals("setSources", resolveListElementReferenceName())
+    }
+
+    private fun resolveListElementReferenceName(): String? {
+        val reference = (file.findReferenceAt(myFixture.caretOffset) as? PsiMultiReference)
+            ?.references
+            ?.filterIsInstance<ConfigurationPropertyListElementReference>()
+            ?.singleOrNull()
+        assertNotNull("list element reference must be contributed", reference)
+
+        return reference!!.multiResolve(true)
+            .singleOrNull()
+            ?.let { (it.element as? ConfigKeyPsiElement)?.name }
     }
 
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/kotlin/YamlReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/reference/kotlin/YamlReferenceTest.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.reference.kotlin
 
 import com.explyt.spring.core.properties.providers.ConfigKeyPsiElement
 import com.explyt.spring.core.properties.providers.ConfigurationPropertyKeyReference
+import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
 import com.explyt.spring.core.properties.references.ValueHintReference
 import com.explyt.spring.test.ExplytKotlinLightTestCase
 import com.explyt.spring.test.TestLibrary
@@ -141,6 +142,83 @@ main:
         val resolveResult = multiResolve[0]
         val name = (resolveResult.element as? PsiEnumConstant)?.name
         assertEquals(name, "TUESDAY")
+    }
+
+    fun testRefKeyListElementMember() {
+        myFixture.copyFileToProject("S3LogsProperties.kt")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3-logs:
+    sources:
+      - ena<caret>bled: true
+            """.trimIndent()
+        )
+
+        assertEquals("setEnabled", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementMemberCamelCaseWritten() {
+        myFixture.copyFileToProject("S3LogsProperties.kt")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3Logs:
+    sources:
+      - ena<caret>bled: true
+            """.trimIndent()
+        )
+
+        assertEquals("setEnabled", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementPicksTheMatchingMember() {
+        myFixture.copyFileToProject("S3LogsProperties.kt")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3-logs:
+    sources:
+      - na<caret>me: first
+        enabled: true
+            """.trimIndent()
+        )
+
+        assertEquals("setName", resolveListElementReferenceName())
+    }
+
+    fun testRefKeyListElementUnknownMemberIsNotResolved() {
+        myFixture.copyFileToProject("S3LogsProperties.kt")
+        myFixture.configureByText(
+            "application.yaml",
+            """
+ingest:
+  s3-logs:
+    sources:
+      - unkn<caret>own: first
+            """.trimIndent()
+        )
+
+        // The reference is still contributed, so the empty result proves the member lookup rejected the key
+        // rather than the reference never having been created.
+        assertEmpty(listElementReference().multiResolve(true).toList())
+    }
+
+    private fun resolveListElementReferenceName(): String? = listElementReference()
+        .multiResolve(true)
+        .singleOrNull()
+        ?.let { (it.element as? ConfigKeyPsiElement)?.name }
+
+    private fun listElementReference(): ConfigurationPropertyListElementReference {
+        val reference = (file.findReferenceAt(myFixture.caretOffset) as? PsiMultiReference)
+            ?.references
+            ?.filterIsInstance<ConfigurationPropertyListElementReference>()
+            ?.singleOrNull()
+        assertNotNull("list element reference must be contributed", reference)
+        return reference!!
     }
 
 }

--- a/modules/spring-core/testdata/java/reference/properties/S3LogsProperties.java
+++ b/modules/spring-core/testdata/java/reference/properties/S3LogsProperties.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package src;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "ingest")
+@Configuration
+public class S3LogsProperties {
+
+    private S3Logs s3Logs = new S3Logs();
+
+    private List<String> addresses;
+
+    public S3Logs getS3Logs() {
+        return s3Logs;
+    }
+
+    public void setS3Logs(S3Logs s3Logs) {
+        this.s3Logs = s3Logs;
+    }
+
+    public List<String> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<String> addresses) {
+        this.addresses = addresses;
+    }
+
+    public static class S3Logs {
+        private List<S3Source> sources;
+
+        public List<S3Source> getSources() {
+            return sources;
+        }
+
+        public void setSources(List<S3Source> sources) {
+            this.sources = sources;
+        }
+    }
+
+    public static class S3Source {
+        private String name;
+
+        private Boolean enabled = true;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+}

--- a/modules/spring-core/testdata/kotlin/reference/properties/S3LogsProperties.kt
+++ b/modules/spring-core/testdata/kotlin/reference/properties/S3LogsProperties.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package src
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@ConfigurationProperties(prefix = "ingest")
+@Configuration
+open class S3LogsProperties {
+
+    var s3Logs: S3Logs = S3Logs()
+
+    var addresses: List<String> = emptyList()
+
+    class S3Logs {
+        var sources: List<S3Source> = emptyList()
+    }
+
+    class S3Source {
+        var name: String = ""
+
+        var enabled: Boolean = true
+    }
+}


### PR DESCRIPTION
## Summary

Ctrl+Click on a key inside an indexed collection, such as `ingest.s3-logs.sources[0].enabled`, had no navigation target.

The key reference provider had a dedicated branch for **map** properties but none for **lists and arrays**, and `ConfigurationPropertyKeyReference` cannot cover the gap: the property model registers the collection itself (`...sources`) but not the members of its element type. So for `...sources[0].enabled` the found property is the list, the key neither equals its name nor is a boolean alias of it, and resolution returns empty.

This PR adds `ConfigurationPropertyListElementReference`, which resolves the part of the key that follows the index against the collection's element class. It reuses the member lookup the map path already had — `getMethodsTypeByMap`, renamed to `getMembersOfType` because it was never map-specific.

Two design notes worth reviewing:

- **The collection is matched by the exact key preceding the first index**, via `SpringConfigurationPropertiesSearch.findProperty`, not by a `startsWith` scan over all properties. `getAllProperties` has no defined order, so a `startsWith` search can non-deterministically match a shorter parent property for a nested key. Going through `findProperty` keeps relaxed binding (`s3Logs` written literally still resolves) while making the match unambiguous.
- **The reference is soft.** A key it cannot resolve is still left to the other key references instead of being reported as an unresolved reference.

Complements #271, which fixed the *inspection* side of the same shape (`Cannot resolve key property` on list elements under digit-boundary keys such as `s3Logs`). That fix silenced the false warning; this one restores navigation.

Real-world reproduction: a `@ConfigurationProperties` class with `S3Logs.sources: List<S3Source>` bound from `application.yml` — binding works at runtime, only the IDE could not navigate.

## Related issue

n/a — found while investigating the navigation half of the defect fixed in #271.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

New tests in all four Java/Kotlin × YAML/properties twins, plus `S3LogsProperties` fixtures:

- `testRefKeyListElementMember` — canonical `s3-logs` resolves to `setEnabled`
- `testRefKeyListElementMemberCamelCaseWritten` — literal `s3Logs` resolves too (relaxed binding)
- `testRefKeyListElementPicksTheMatchingMember` — `name` resolves to `setName`, not `setEnabled`
- `testRefKeyListElementUnknownMemberIsNotResolved` — the reference **is** contributed but resolves to nothing, so the empty result proves the member lookup rejected the key rather than the reference never being created
- `testRefKeyListElementCollectionItself` — `sources[0]` resolves to `setSources` (properties twins)

```bash
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.reference.kotlin.YamlReferenceTest"        # 9/9
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.reference.java.YamlReferenceTest"          # 28/28
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.reference.kotlin.PropertiesReferenceTest"  # 6/6
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.reference.java.PropertiesReferenceTest"    # 22/22
```

Regression guard for the `getMembersOfType` rename and the map-branch refactor:

```bash
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.properties.java.SpringConfigurationPropertyKeyReferenceProviderTest"  # 3/3
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.inspections.kotlin.SpringYamlInspectionTest"                          # 4/4
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.inspections.java.SpringYamlInspectionTest"                            # 12/12
./gradlew :spring-core:test --rerun --tests "com.explyt.spring.core.inspections.java.SpringPropertiesInspectionTest"                      # 6/6
```

**Red-green verification.** Two independent mutations, each isolating a different link in the chain:

| Mutation | Result |
|---|---|
| Provider branch disabled | 2 tests fail — `expected:<setEnabled> but was:<null>` |
| Element type replaced with a non-existent class | 3 tests fail — `setEnabled`, `setName`, `setEnabled` |

The second is the stronger one: it leaves the reference contributed, so only the member lookup is under test. In both phases the pre-existing tests and the negative test stayed green.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed.

Changelog-only documentation: this is an isolated correctness fix with no new user-facing surface, so per the repository's documentation-audience split it does not belong in `README.md` or `PLUGIN-DESCRIPTION.md`.
