### PR TITLE
fix: Report Boot 4 migrations when the legacy symbol does not resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Spring Core
+- fix: Report the `BootstrapRegistry`, `@JsonComponent`/`@JsonMixin` and `@EntityScan` migrations when the legacy symbol no longer resolves after a Spring Boot 4 upgrade
 - fix: Report the `@MockBean` / `@SpyBean` migration when the legacy annotation no longer resolves after a Spring Boot 4 upgrade
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/Spring4UastLocalInspectionTool.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/Spring4UastLocalInspectionTool.kt
@@ -8,13 +8,23 @@ package com.explyt.spring.core.inspections
 import com.explyt.inspection.SpringBaseUastLocalInspectionTool
 import com.explyt.spring.core.util.SpringBootUtil
 import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaFile
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.uast.UAnnotation
 
 /**
  * Base class for UAST inspections that only apply to Spring Boot 4+ projects.
  *
  * The Spring Boot version is checked once per file in [isAvailableForFile] (instead of on every visited PSI element),
  * so the inspection never builds a visitor or walks PSI in projects that are not on Spring Boot 4+.
+ *
+ * Migration inspections must gate on the **replacement** being resolvable, never on the legacy symbol: the upgrade
+ * that makes them relevant is what removes the legacy artifact. The `legacy*Fqn` helpers below recognise a symbol
+ * that no longer resolves, so the stale source is still reported.
  */
 abstract class Spring4UastLocalInspectionTool : SpringBaseUastLocalInspectionTool() {
 
@@ -28,5 +38,76 @@ abstract class Spring4UastLocalInspectionTool : SpringBaseUastLocalInspectionToo
 
     protected fun isAnyClassAvailable(file: PsiFile, vararg fqns: String): Boolean {
         return fqns.any { isClassAvailable(file, it) }
+    }
+
+    /**
+     * The FQN from [legacyFqns] that [annotation] denotes, or `null` when it denotes none of them.
+     *
+     * A resolved annotation is matched by its own qualified name. An annotation whose declaring artifact the Boot 4
+     * upgrade removed does not resolve, and is matched by the name as written plus the file's imports.
+     */
+    protected fun legacyAnnotationFqn(annotation: UAnnotation, legacyFqns: Collection<String>): String? {
+        annotation.qualifiedName?.takeIf { it in legacyFqns }?.let { return it }
+        if (annotation.resolve() != null) return null
+
+        val sourcePsi = annotation.sourcePsi ?: return null
+        return legacyFqn(sourcePsi.containingFile, writtenAnnotationName(annotation), legacyFqns)
+    }
+
+    /**
+     * The legacy FQN that the type at [typeSourcePsi] denotes, or `null` when the type is unrelated or already
+     * migrated. [migrations] maps every legacy FQN to its replacement.
+     */
+    protected fun legacyTypeFqn(
+        typeSourcePsi: PsiElement,
+        canonicalText: String?,
+        migrations: Map<String, String>
+    ): String? {
+        if (canonicalText != null) {
+            if (canonicalText in migrations.keys) return canonicalText
+            // A usage that resolves to the replacement is already migrated.
+            if (canonicalText in migrations.values) return null
+        }
+        val writtenName = typeSourcePsi.text?.substringBefore('<')?.trim()
+        return legacyFqn(typeSourcePsi.containingFile, writtenName, migrations.keys)
+    }
+
+    /** The name of [annotation] as spelled in the source, which is all that survives when it does not resolve. */
+    protected fun writtenAnnotationName(annotation: UAnnotation): String? =
+        when (val sourcePsi = annotation.sourcePsi) {
+            is PsiAnnotation -> sourcePsi.nameReferenceElement?.text
+            is KtAnnotationEntry -> sourcePsi.typeReference?.text
+            else -> null
+        }?.substringBefore('<')?.trim()
+
+    private fun legacyFqn(file: PsiFile?, writtenName: String?, legacyFqns: Collection<String>): String? {
+        if (writtenName == null) return null
+        // A fully qualified usage carries the FQN itself and needs no import.
+        legacyFqns.firstOrNull { it == writtenName }?.let { return it }
+        if (file == null) return null
+        return legacyFqns.firstOrNull { importsAs(file, it, writtenName) }
+    }
+
+    /** Whether [file] imports [fqn] under the name [writtenName]: explicitly, on demand, or via a Kotlin alias. */
+    private fun importsAs(file: PsiFile, fqn: String, writtenName: String): Boolean {
+        val packageName = fqn.substringBeforeLast('.')
+        val shortName = fqn.substringAfterLast('.')
+        return when (file) {
+            is KtFile -> file.importDirectives.any { directive ->
+                val importedFqName = directive.importedFqName?.asString()
+                when {
+                    directive.isAllUnder -> importedFqName == packageName && writtenName == shortName
+                    importedFqName != fqn -> false
+                    else -> writtenName == (directive.aliasName ?: shortName)
+                }
+            }
+
+            is PsiJavaFile -> writtenName == shortName && file.importList?.importStatements?.any {
+                val qualifiedName = it.qualifiedName
+                if (it.isOnDemand) qualifiedName == packageName else qualifiedName == fqn
+            } == true
+
+            else -> false
+        }
     }
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4BootstrapPackageInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4BootstrapPackageInspection.kt
@@ -28,7 +28,9 @@ import org.jetbrains.uast.UMethod
 class SpringBoot4BootstrapPackageInspection : Spring4UastLocalInspectionTool() {
 
     override fun isAvailableForFile(file: PsiFile): Boolean {
-        return super.isAvailableForFile(file) && isAnyClassAvailable(file, *MOVED_TYPES.keys.toTypedArray())
+        // Only the replacements have to be resolvable: the Boot 4 upgrade relocates the legacy types, and the stale
+        // source that still references the old package is exactly what must be reported.
+        return super.isAvailableForFile(file) && isAnyClassAvailable(file, *MOVED_TYPES.values.toTypedArray())
     }
 
     override fun checkField(field: UField, manager: InspectionManager, isOnTheFly: Boolean): Array<ProblemDescriptor> {
@@ -53,14 +55,15 @@ class SpringBoot4BootstrapPackageInspection : Spring4UastLocalInspectionTool() {
         manager: InspectionManager,
         isOnTheFly: Boolean
     ): ProblemDescriptor? {
-        if (typeSourcePsi == null || canonicalText == null) return null
-        val target = MOVED_TYPES[canonicalText] ?: return null
+        if (typeSourcePsi == null) return null
+        val legacyFqn = legacyTypeFqn(typeSourcePsi, canonicalText, MOVED_TYPES) ?: return null
+        val target = MOVED_TYPES[legacyFqn] ?: return null
 
         return manager.createProblemDescriptor(
             typeSourcePsi,
             message("explyt.spring.inspection.boot4.bootstrap"),
             isOnTheFly,
-            arrayOf<LocalQuickFix>(MigrateImportQuickFix(canonicalText, target)),
+            arrayOf<LocalQuickFix>(MigrateImportQuickFix(legacyFqn, target)),
             ProblemHighlightType.LIKE_DEPRECATED
         )
     }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4EntityScanPackageInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4EntityScanPackageInspection.kt
@@ -6,15 +6,12 @@
 package com.explyt.spring.core.inspections
 
 import com.explyt.spring.core.SpringCoreBundle.message
-import com.explyt.spring.core.inspections.quickfix.RewriteAnnotationQuickFix
+import com.explyt.spring.core.inspections.quickfix.ReplaceAnnotationQuickFix
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.psi.JavaPsiFacade
-import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiNameValuePair
 import org.jetbrains.uast.UClass
 
 /**
@@ -43,32 +40,15 @@ class SpringBoot4EntityScanPackageInspection : Spring4UastLocalInspectionTool() 
             .firstOrNull { legacyAnnotationFqn(it, LEGACY_FQNS) != null } ?: return emptyArray()
         val highlightElement = uAnnotation.sourcePsi ?: return emptyArray()
 
-        val attributes = reconstructAttributes(uClass, uAnnotation.javaPsi)
         return arrayOf(
             manager.createProblemDescriptor(
                 highlightElement,
                 message("explyt.spring.inspection.boot4.entityscan"),
                 isOnTheFly,
-                arrayOf<LocalQuickFix>(RewriteAnnotationQuickFix(NEW_ENTITY_SCAN, uClass.javaPsi, attributes, OLD_ENTITY_SCAN)),
+                arrayOf<LocalQuickFix>(ReplaceAnnotationQuickFix(NEW_ENTITY_SCAN)),
                 ProblemHighlightType.LIKE_DEPRECATED
             )
         )
-    }
-
-    /**
-     * The annotation's own `javaPsi` is used rather than a lookup by FQN on the owner, which a relocated legacy class
-     * cannot match once it no longer resolves.
-     */
-    private fun reconstructAttributes(uClass: UClass, oldAnnotation: PsiAnnotation?): Array<PsiNameValuePair> {
-        val argsText = oldAnnotation?.parameterList?.attributes
-            ?.takeIf { it.isNotEmpty() }
-            ?.joinToString(", ") { it.text }
-            ?: return PsiNameValuePair.EMPTY_ARRAY
-        return runCatching {
-            JavaPsiFacade.getInstance(uClass.javaPsi.project).elementFactory
-                .createAnnotationFromText("@$NEW_ENTITY_SCAN($argsText)", uClass.javaPsi)
-                .parameterList.attributes
-        }.getOrDefault(PsiNameValuePair.EMPTY_ARRAY)
     }
 
     companion object {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4EntityScanPackageInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4EntityScanPackageInspection.kt
@@ -45,7 +45,7 @@ class SpringBoot4EntityScanPackageInspection : Spring4UastLocalInspectionTool() 
                 highlightElement,
                 message("explyt.spring.inspection.boot4.entityscan"),
                 isOnTheFly,
-                arrayOf<LocalQuickFix>(ReplaceAnnotationQuickFix(NEW_ENTITY_SCAN)),
+                arrayOf<LocalQuickFix>(ReplaceAnnotationQuickFix(NEW_ENTITY_SCAN, oldFqn = OLD_ENTITY_SCAN)),
                 ProblemHighlightType.LIKE_DEPRECATED
             )
         )

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4EntityScanPackageInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4EntityScanPackageInspection.kt
@@ -12,6 +12,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNameValuePair
 import org.jetbrains.uast.UClass
@@ -28,7 +29,9 @@ import org.jetbrains.uast.UClass
 class SpringBoot4EntityScanPackageInspection : Spring4UastLocalInspectionTool() {
 
     override fun isAvailableForFile(file: PsiFile): Boolean {
-        return super.isAvailableForFile(file) && isClassAvailable(file, OLD_ENTITY_SCAN)
+        // Only the replacement has to be resolvable: the Boot 4 upgrade relocates the legacy annotation, and the
+        // stale source that still references the old package is exactly what must be reported.
+        return super.isAvailableForFile(file) && isClassAvailable(file, NEW_ENTITY_SCAN)
     }
 
     override fun checkClass(
@@ -36,11 +39,11 @@ class SpringBoot4EntityScanPackageInspection : Spring4UastLocalInspectionTool() 
         manager: InspectionManager,
         isOnTheFly: Boolean
     ): Array<out ProblemDescriptor?> {
-        val uAnnotation = uClass.uAnnotations.firstOrNull { it.qualifiedName == OLD_ENTITY_SCAN } ?: return emptyArray()
+        val uAnnotation = uClass.uAnnotations
+            .firstOrNull { legacyAnnotationFqn(it, LEGACY_FQNS) != null } ?: return emptyArray()
         val highlightElement = uAnnotation.sourcePsi ?: return emptyArray()
-        if (!isTargetResolvable(uClass)) return emptyArray()
 
-        val attributes = reconstructAttributes(uClass)
+        val attributes = reconstructAttributes(uClass, uAnnotation.javaPsi)
         return arrayOf(
             manager.createProblemDescriptor(
                 highlightElement,
@@ -52,13 +55,11 @@ class SpringBoot4EntityScanPackageInspection : Spring4UastLocalInspectionTool() 
         )
     }
 
-    private fun isTargetResolvable(uClass: UClass): Boolean {
-        return JavaPsiFacade.getInstance(uClass.javaPsi.project)
-            .findClass(NEW_ENTITY_SCAN, uClass.javaPsi.resolveScope) != null
-    }
-
-    private fun reconstructAttributes(uClass: UClass): Array<PsiNameValuePair> {
-        val oldAnnotation = uClass.javaPsi.modifierList?.findAnnotation(OLD_ENTITY_SCAN)
+    /**
+     * The annotation's own `javaPsi` is used rather than a lookup by FQN on the owner, which a relocated legacy class
+     * cannot match once it no longer resolves.
+     */
+    private fun reconstructAttributes(uClass: UClass, oldAnnotation: PsiAnnotation?): Array<PsiNameValuePair> {
         val argsText = oldAnnotation?.parameterList?.attributes
             ?.takeIf { it.isNotEmpty() }
             ?.joinToString(", ") { it.text }
@@ -73,5 +74,7 @@ class SpringBoot4EntityScanPackageInspection : Spring4UastLocalInspectionTool() 
     companion object {
         const val OLD_ENTITY_SCAN = "org.springframework.boot.autoconfigure.domain.EntityScan"
         const val NEW_ENTITY_SCAN = "org.springframework.boot.persistence.autoconfigure.EntityScan"
+
+        private val LEGACY_FQNS = setOf(OLD_ENTITY_SCAN)
     }
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4JacksonAnnotationInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4JacksonAnnotationInspection.kt
@@ -28,7 +28,9 @@ import org.jetbrains.uast.UClass
 class SpringBoot4JacksonAnnotationInspection : Spring4UastLocalInspectionTool() {
 
     override fun isAvailableForFile(file: PsiFile): Boolean {
-        return super.isAvailableForFile(file) && isAnyClassAvailable(file, *RENAMES.keys.toTypedArray())
+        // Only the replacements have to be resolvable: the Boot 4 upgrade renames the legacy annotations, and the
+        // stale source that still uses them is exactly what must be reported.
+        return super.isAvailableForFile(file) && isAnyClassAvailable(file, *RENAMES.values.toTypedArray())
     }
 
     override fun checkClass(
@@ -37,14 +39,15 @@ class SpringBoot4JacksonAnnotationInspection : Spring4UastLocalInspectionTool() 
         isOnTheFly: Boolean
     ): Array<out ProblemDescriptor?> {
         val problems = mutableListOf<ProblemDescriptor>()
-        for ((oldFqn, newFqn) in RENAMES) {
-            val uAnnotation = uClass.uAnnotations.firstOrNull { it.qualifiedName == oldFqn } ?: continue
+        for (uAnnotation in uClass.uAnnotations) {
+            val oldFqn = legacyAnnotationFqn(uAnnotation, RENAMES.keys) ?: continue
+            val newFqn = RENAMES[oldFqn] ?: continue
             val highlightElement = uAnnotation.sourcePsi ?: continue
             val newShortName = newFqn.substringAfterLast('.')
 
-            // Preserve the declared attributes by reconstructing them on the new annotation.
-            val javaAnnotation = uClass.javaPsi.modifierList?.findAnnotation(oldFqn)
-            val attributes = reconstructAttributes(uClass.javaPsi, newFqn, javaAnnotation)
+            // Preserve the declared attributes by reconstructing them on the new annotation. The annotation's own
+            // `javaPsi` is used rather than a lookup by FQN on the owner, which a removed legacy class cannot match.
+            val attributes = reconstructAttributes(uClass.javaPsi, newFqn, uAnnotation.javaPsi)
             val fix = RewriteAnnotationQuickFix(newFqn, uClass.javaPsi, attributes, oldFqn)
 
             problems += manager.createProblemDescriptor(

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4JacksonAnnotationInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4JacksonAnnotationInspection.kt
@@ -43,7 +43,7 @@ class SpringBoot4JacksonAnnotationInspection : Spring4UastLocalInspectionTool() 
             val highlightElement = uAnnotation.sourcePsi ?: continue
             val newShortName = newFqn.substringAfterLast('.')
 
-            val fix = ReplaceAnnotationQuickFix(newFqn)
+            val fix = ReplaceAnnotationQuickFix(newFqn, oldFqn = oldFqn)
 
             problems += manager.createProblemDescriptor(
                 highlightElement,

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4JacksonAnnotationInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4JacksonAnnotationInspection.kt
@@ -6,13 +6,11 @@
 package com.explyt.spring.core.inspections
 
 import com.explyt.spring.core.SpringCoreBundle.message
-import com.explyt.spring.core.inspections.quickfix.RewriteAnnotationQuickFix
+import com.explyt.spring.core.inspections.quickfix.ReplaceAnnotationQuickFix
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.psi.PsiAnnotation
-import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 import org.jetbrains.uast.UClass
 
@@ -45,10 +43,7 @@ class SpringBoot4JacksonAnnotationInspection : Spring4UastLocalInspectionTool() 
             val highlightElement = uAnnotation.sourcePsi ?: continue
             val newShortName = newFqn.substringAfterLast('.')
 
-            // Preserve the declared attributes by reconstructing them on the new annotation. The annotation's own
-            // `javaPsi` is used rather than a lookup by FQN on the owner, which a removed legacy class cannot match.
-            val attributes = reconstructAttributes(uClass.javaPsi, newFqn, uAnnotation.javaPsi)
-            val fix = RewriteAnnotationQuickFix(newFqn, uClass.javaPsi, attributes, oldFqn)
+            val fix = ReplaceAnnotationQuickFix(newFqn)
 
             problems += manager.createProblemDescriptor(
                 highlightElement,
@@ -59,21 +54,6 @@ class SpringBoot4JacksonAnnotationInspection : Spring4UastLocalInspectionTool() 
             )
         }
         return problems.toTypedArray()
-    }
-
-    private fun reconstructAttributes(
-        owner: PsiClass,
-        newFqn: String,
-        oldAnnotation: PsiAnnotation?
-    ): Array<com.intellij.psi.PsiNameValuePair> {
-        val argsText = oldAnnotation?.parameterList?.attributes
-            ?.takeIf { it.isNotEmpty() }
-            ?.joinToString(", ") { it.text }
-            ?: return com.intellij.psi.PsiNameValuePair.EMPTY_ARRAY
-        return runCatching {
-            val factory = com.intellij.psi.JavaPsiFacade.getInstance(owner.project).elementFactory
-            factory.createAnnotationFromText("@$newFqn($argsText)", owner).parameterList.attributes
-        }.getOrDefault(com.intellij.psi.PsiNameValuePair.EMPTY_ARRAY)
     }
 
     companion object {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4MockBeanMigrationInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4MockBeanMigrationInspection.kt
@@ -11,11 +11,7 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiJavaFile
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UField
@@ -60,41 +56,8 @@ class SpringBoot4MockBeanMigrationInspection : Spring4UastLocalInspectionTool() 
         return problems.toTypedArray()
     }
 
-    private fun replacementFor(annotation: UAnnotation): Replacement? {
-        REPLACEMENTS[annotation.qualifiedName]?.let { return it }
-        // A resolved annotation is identified by its FQN above. Once the Boot 4 upgrade removed the legacy artifact
-        // the annotation no longer resolves, and the source that still uses it is what has to be migrated.
-        if (annotation.resolve() != null) return null
-
-        val writtenName = writtenAnnotationName(annotation) ?: return null
-        REPLACEMENTS[writtenName]?.let { return it }
-
-        val file = annotation.sourcePsi?.containingFile ?: return null
-        val legacyFqn = REPLACEMENTS.keys
-            .firstOrNull { it.substringAfterLast('.') == writtenName && importsLegacyAnnotation(file, it) }
-            ?: return null
-        return REPLACEMENTS[legacyFqn]
-    }
-
-    private fun writtenAnnotationName(annotation: UAnnotation): String? = when (val sourcePsi = annotation.sourcePsi) {
-        is PsiAnnotation -> sourcePsi.nameReferenceElement?.text
-        is KtAnnotationEntry -> sourcePsi.typeReference?.text
-        else -> null
-    }?.substringBefore('<')?.trim()
-
-    private fun importsLegacyAnnotation(file: PsiFile, fqn: String): Boolean = when (file) {
-        is KtFile -> file.importDirectives.any {
-            val importedFqName = it.importedFqName?.asString()
-            if (it.isAllUnder) importedFqName == LEGACY_PACKAGE else importedFqName == fqn
-        }
-
-        is PsiJavaFile -> file.importList?.importStatements?.any {
-            val qualifiedName = it.qualifiedName
-            if (it.isOnDemand) qualifiedName == LEGACY_PACKAGE else qualifiedName == fqn
-        } == true
-
-        else -> false
-    }
+    private fun replacementFor(annotation: UAnnotation): Replacement? =
+        legacyAnnotationFqn(annotation, REPLACEMENTS.keys)?.let { REPLACEMENTS[it] }
 
     private fun createProblem(
         annotation: UAnnotation,
@@ -132,9 +95,8 @@ class SpringBoot4MockBeanMigrationInspection : Spring4UastLocalInspectionTool() 
     private class Replacement(val newFqn: String, val attributeRenames: Map<String, String>)
 
     companion object {
-        private const val LEGACY_PACKAGE = "org.springframework.boot.test.mock.mockito"
-        private const val MOCK_BEAN = "$LEGACY_PACKAGE.MockBean"
-        private const val SPY_BEAN = "$LEGACY_PACKAGE.SpyBean"
+        private const val MOCK_BEAN = "org.springframework.boot.test.mock.mockito.MockBean"
+        private const val SPY_BEAN = "org.springframework.boot.test.mock.mockito.SpyBean"
         private const val MOCKITO_BEAN = "org.springframework.test.context.bean.override.mockito.MockitoBean"
         private const val MOCKITO_SPY_BEAN = "org.springframework.test.context.bean.override.mockito.MockitoSpyBean"
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4TestRestTemplatePackageInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBoot4TestRestTemplatePackageInspection.kt
@@ -13,8 +13,6 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiJavaFile
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.uast.UField
 import org.jetbrains.uast.UMethod
 
@@ -60,7 +58,7 @@ class SpringBoot4TestRestTemplatePackageInspection : Spring4UastLocalInspectionT
         isOnTheFly: Boolean
     ): ProblemDescriptor? {
         if (typeSourcePsi == null) return null
-        if (!isLegacyTestRestTemplate(typeSourcePsi, canonicalText)) return null
+        if (legacyTypeFqn(typeSourcePsi, canonicalText, MIGRATIONS) == null) return null
 
         return manager.createProblemDescriptor(
             typeSourcePsi,
@@ -71,40 +69,10 @@ class SpringBoot4TestRestTemplatePackageInspection : Spring4UastLocalInspectionT
         )
     }
 
-    /**
-     * A resolved usage is recognised by its canonical FQN. When the legacy artifact is already gone the usage no
-     * longer resolves and UAST reports the written name instead, so the legacy import still present in the file
-     * identifies it.
-     */
-    private fun isLegacyTestRestTemplate(typeSourcePsi: PsiElement, canonicalText: String?): Boolean {
-        if (canonicalText == OLD_TEST_REST_TEMPLATE) return true
-        if (canonicalText == NEW_TEST_REST_TEMPLATE) return false
-        return when (typeSourcePsi.text?.substringBefore('<')?.trim()) {
-            OLD_TEST_REST_TEMPLATE -> true
-            SIMPLE_NAME -> importsLegacyTestRestTemplate(typeSourcePsi.containingFile)
-            else -> false
-        }
-    }
-
-    private fun importsLegacyTestRestTemplate(file: PsiFile?): Boolean = when (file) {
-        is KtFile -> file.importDirectives.any {
-            val importedFqName = it.importedFqName?.asString()
-            if (it.isAllUnder) importedFqName == OLD_PACKAGE else importedFqName == OLD_TEST_REST_TEMPLATE
-        }
-
-        is PsiJavaFile -> file.importList?.importStatements?.any {
-            val qualifiedName = it.qualifiedName
-            if (it.isOnDemand) qualifiedName == OLD_PACKAGE else qualifiedName == OLD_TEST_REST_TEMPLATE
-        } == true
-
-        else -> false
-    }
-
     companion object {
         const val OLD_TEST_REST_TEMPLATE = "org.springframework.boot.test.web.client.TestRestTemplate"
         const val NEW_TEST_REST_TEMPLATE = "org.springframework.boot.resttestclient.TestRestTemplate"
 
-        private const val OLD_PACKAGE = "org.springframework.boot.test.web.client"
-        private const val SIMPLE_NAME = "TestRestTemplate"
+        private val MIGRATIONS: Map<String, String> = mapOf(OLD_TEST_REST_TEMPLATE to NEW_TEST_REST_TEMPLATE)
     }
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/ReplaceAnnotationQuickFix.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/ReplaceAnnotationQuickFix.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import org.jetbrains.kotlin.idea.base.codeInsight.ShortenReferencesFacility
 import org.jetbrains.kotlin.idea.base.psi.replaced
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.uast.UAnnotation
 
@@ -37,7 +38,8 @@ import org.jetbrains.uast.UAnnotation
 class ReplaceAnnotationQuickFix(
     private val newFqn: String,
     @FileModifier.SafeFieldForPreview
-    private val attributeRenames: Map<String, String> = emptyMap()
+    private val attributeRenames: Map<String, String> = emptyMap(),
+    private val oldFqn: String? = null
 ) : LocalQuickFix {
 
     override fun getName(): String =
@@ -71,6 +73,7 @@ class ReplaceAnnotationQuickFix(
 
     private fun replaceKotlinAnnotation(project: Project, entry: KtAnnotationEntry) {
         val newAnnotationClass = JavaPsiFacade.getInstance(project).findClass(newFqn, entry.resolveScope)
+        migrateKotlinImport(entry)
 
         val positional = mutableListOf<String>()
         val named = mutableListOf<String>()
@@ -97,6 +100,16 @@ class ReplaceAnnotationQuickFix(
         val useSiteTarget = entry.useSiteTarget?.text?.removeSuffix(":")?.let { "$it:" }.orEmpty()
         val newEntry = KtPsiFactory(project).createAnnotationEntry(annotationText(arguments, useSiteTarget))
         ShortenReferencesFacility.getInstance().shorten(entry.replaced(newEntry))
+    }
+
+    private fun migrateKotlinImport(entry: KtAnnotationEntry) {
+        val legacyFqn = oldFqn ?: return
+        val file = entry.containingFile as? KtFile ?: return
+        val importDirective = file.importDirectives.firstOrNull {
+            !it.isAllUnder && it.importedFqName?.asString() == legacyFqn
+        } ?: return
+        val importedReference = importDirective.importedReference ?: return
+        importedReference.replace(KtPsiFactory(entry.project).createExpression(newFqn))
     }
 
     private fun annotationText(arguments: List<String>, useSiteTarget: String = ""): String {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/ReplaceAnnotationQuickFix.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/ReplaceAnnotationQuickFix.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiArrayType
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import org.jetbrains.kotlin.idea.base.codeInsight.ShortenReferencesFacility
 import org.jetbrains.kotlin.idea.base.psi.replaced
@@ -61,8 +62,11 @@ class ReplaceAnnotationQuickFix(
         }
         val newAnnotation = JavaPsiFacade.getElementFactory(project)
             .createAnnotationFromText(annotationText(arguments), annotation)
+        val styleManager = JavaCodeStyleManager.getInstance(project)
+        val javaFile = annotation.containingFile as? PsiJavaFile
         val replaced = annotation.replace(newAnnotation)
-        JavaCodeStyleManager.getInstance(project).shortenClassReferences(replaced)
+        styleManager.shortenClassReferences(replaced)
+        javaFile?.let(styleManager::optimizeImports)
     }
 
     private fun replaceKotlinAnnotation(project: Project, entry: KtAnnotationEntry) {

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4BootstrapPackageUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4BootstrapPackageUnresolvedImportTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringBoot4BootstrapPackageInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * The realistic post-upgrade state: Spring Boot 4 relocated the bootstrap types, so the legacy FQNs no longer
+ * resolve. Only the replacement is added to the fixture.
+ *
+ * Highlighting is asserted by filtering the reported problems instead of comparing against inline markup: an
+ * unresolved type always produces "Cannot resolve symbol" errors, which markup comparison would demand be spelled
+ * out and which are irrelevant here.
+ */
+class SpringBoot4BootstrapPackageUnresolvedImportTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass("package org.springframework.boot.bootstrap; public interface BootstrapRegistry { }")
+        myFixture.enableInspections(SpringBoot4BootstrapPackageInspection::class.java)
+    }
+
+    fun testUnresolvedLegacyFieldTypeReported() {
+        assertReported(
+            """
+            import org.springframework.boot.BootstrapRegistry;
+            
+            public class MyConfig {
+                BootstrapRegistry registry;
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedLegacyParameterTypeReported() {
+        assertReported(
+            """
+            import org.springframework.boot.BootstrapRegistry;
+            
+            public class MyConfig {
+                void run(BootstrapRegistry registry) { }
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedOnDemandImportReported() {
+        assertReported(
+            """
+            import org.springframework.boot.*;
+            
+            public class MyConfig {
+                BootstrapRegistry registry;
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedFullyQualifiedTypeReported() {
+        assertReported(
+            """
+            public class MyConfig {
+                org.springframework.boot.BootstrapRegistry registry;
+            }
+            """
+        )
+    }
+
+    fun testMigratedTypeNotReported() {
+        val messages = migrationMessages(
+            """
+            import org.springframework.boot.bootstrap.BootstrapRegistry;
+            
+            public class MyConfig {
+                BootstrapRegistry registry;
+            }
+            """
+        )
+        assertEmpty("already migrated code must stay clean: $messages", messages)
+    }
+
+    fun testUnrelatedUnresolvedTypeNotReported() {
+        val messages = migrationMessages(
+            """
+            import com.example.BootstrapRegistry;
+            
+            public class MyConfig {
+                BootstrapRegistry registry;
+            }
+            """
+        )
+        assertEmpty("an unrelated type must not be reported: $messages", messages)
+    }
+
+    fun testQuickFixMigratesUnresolvedImport() {
+        myFixture.configureByText(
+            "MyConfig.java",
+            """
+            import org.springframework.boot.BootstrapRegistry;
+            
+            public class MyConfig {
+                Bootstrap<caret>Registry registry;
+            }
+            """.trimIndent()
+        )
+        val intention = myFixture.availableIntentions.firstOrNull { it.text.contains("Spring Boot 4") }
+        requireNotNull(intention) {
+            "Import migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue(
+            "import should be migrated:\n$result",
+            result.contains("import org.springframework.boot.bootstrap.BootstrapRegistry;")
+        )
+    }
+
+    private fun assertReported(code: String) {
+        val messages = migrationMessages(code)
+        assertTrue("expected '$MESSAGE', got: $messages", messages.contains(MESSAGE))
+    }
+
+    private fun migrationMessages(code: String): List<String> {
+        myFixture.configureByText("MyConfig.java", code.trimIndent())
+        return myFixture.doHighlighting()
+            .mapNotNull { it.description }
+            .filter { it.contains("Spring Boot 4") }
+    }
+
+    private companion object {
+        val MESSAGE: String = SpringCoreBundle.message("explyt.spring.inspection.boot4.bootstrap")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringBoot4EntityScanPackageInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * The realistic post-upgrade state: Spring Boot 4 relocated `@EntityScan`, so the legacy FQN no longer resolves.
+ * Only the replacement is added to the fixture.
+ */
+class SpringBoot4EntityScanPackageUnresolvedImportTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package org.springframework.boot.persistence.autoconfigure;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+            public @interface EntityScan { String[] value() default {}; }
+            """.trimIndent()
+        )
+        myFixture.enableInspections(SpringBoot4EntityScanPackageInspection::class.java)
+    }
+
+    fun testUnresolvedLegacyAnnotationReported() {
+        assertReported(
+            """
+            import org.springframework.boot.autoconfigure.domain.EntityScan;
+            
+            @EntityScan("com.example.domain")
+            public class AppConfig { }
+            """
+        )
+    }
+
+    fun testUnresolvedOnDemandImportReported() {
+        assertReported(
+            """
+            import org.springframework.boot.autoconfigure.domain.*;
+            
+            @EntityScan("com.example.domain")
+            public class AppConfig { }
+            """
+        )
+    }
+
+    fun testUnresolvedFullyQualifiedAnnotationReported() {
+        assertReported(
+            """
+            @org.springframework.boot.autoconfigure.domain.EntityScan("com.example.domain")
+            public class AppConfig { }
+            """
+        )
+    }
+
+    fun testMigratedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import org.springframework.boot.persistence.autoconfigure.EntityScan;
+            
+            @EntityScan("com.example.domain")
+            public class AppConfig { }
+            """
+        )
+        assertEmpty("already migrated code must stay clean: $messages", messages)
+    }
+
+    fun testUnrelatedUnresolvedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import com.example.EntityScan;
+            
+            @EntityScan("com.example.domain")
+            public class AppConfig { }
+            """
+        )
+        assertEmpty("an unrelated annotation must not be reported: $messages", messages)
+    }
+
+    private fun assertReported(code: String) {
+        val messages = migrationMessages(code)
+        assertTrue("expected '$MESSAGE', got: $messages", messages.contains(MESSAGE))
+    }
+
+    private fun migrationMessages(code: String): List<String> {
+        myFixture.configureByText("AppConfig.java", code.trimIndent())
+        return myFixture.doHighlighting()
+            .mapNotNull { it.description }
+            .filter { it.contains("Spring Boot 4") }
+    }
+
+    private companion object {
+        val MESSAGE: String = SpringCoreBundle.message("explyt.spring.inspection.boot4.entityscan")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
@@ -88,6 +88,32 @@ class SpringBoot4EntityScanPackageUnresolvedImportTest : ExplytInspectionJavaTes
         assertEmpty("an unrelated annotation must not be reported: $messages", messages)
     }
 
+    fun testQuickFixReplacesUnresolvedAnnotation() {
+        myFixture.configureByText(
+            "AppConfig.java",
+            """
+            import org.springframework.boot.autoconfigure.domain.EntityScan;
+
+            @Entity<caret>Scan("com.example.domain")
+            public class AppConfig { }
+            """.trimIndent()
+        )
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.replace.annotation.fix", "EntityScan")
+        val intention = myFixture.availableIntentions.firstOrNull { it.text == fixName }
+        requireNotNull(intention) {
+            "EntityScan migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue(
+            "new annotation should be applied:\n$result",
+            result.contains("@EntityScan") || result.contains("@org.springframework.boot.persistence.autoconfigure.EntityScan")
+        )
+        assertTrue("new import should be added:\n$result", result.contains("org.springframework.boot.persistence.autoconfigure.EntityScan"))
+        assertTrue("attribute should be preserved:\n$result", result.contains("\"com.example.domain\""))
+        assertFalse("old annotation should be replaced:\n$result", result.contains("org.springframework.boot.autoconfigure.domain.EntityScan"))
+    }
+
     private fun assertReported(code: String) {
         val messages = migrationMessages(code)
         assertTrue("expected '$MESSAGE', got: $messages", messages.contains(MESSAGE))

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
@@ -111,6 +111,56 @@ class SpringBoot4JacksonAnnotationUnresolvedImportTest : ExplytInspectionJavaTes
         assertEmpty("an unrelated annotation must not be reported: $messages", messages)
     }
 
+    fun testQuickFixReplacesUnresolvedJsonComponent() {
+        myFixture.configureByText(
+            "MyComponent.java",
+            """
+            import org.springframework.boot.jackson.JsonComponent;
+
+            @Json<caret>Component(String.class)
+            public class MyComponent { }
+            """.trimIndent()
+        )
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.replace.annotation.fix", "JacksonComponent")
+        val intention = myFixture.availableIntentions.firstOrNull { it.text == fixName }
+        requireNotNull(intention) {
+            "JacksonComponent migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue(
+            "new annotation should be applied:\n$result",
+            result.contains("@JacksonComponent") || result.contains("@org.springframework.boot.jackson.JacksonComponent")
+        )
+        assertTrue("attribute should be preserved:\n$result", result.contains("String.class"))
+        assertFalse("old annotation should be replaced:\n$result", result.contains("@JsonComponent"))
+    }
+
+    fun testQuickFixReplacesUnresolvedJsonMixin() {
+        myFixture.configureByText(
+            "MyMixin.java",
+            """
+            import org.springframework.boot.jackson.JsonMixin;
+
+            @Json<caret>Mixin(String.class)
+            public class MyMixin { }
+            """.trimIndent()
+        )
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.replace.annotation.fix", "JacksonMixin")
+        val intention = myFixture.availableIntentions.firstOrNull { it.text == fixName }
+        requireNotNull(intention) {
+            "JacksonMixin migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue(
+            "new annotation should be applied:\n$result",
+            result.contains("@JacksonMixin") || result.contains("@org.springframework.boot.jackson.JacksonMixin")
+        )
+        assertTrue("attribute should be preserved:\n$result", result.contains("String.class"))
+        assertFalse("old annotation should be replaced:\n$result", result.contains("@JsonMixin"))
+    }
+
     private fun assertReported(code: String, expectedMessage: String) {
         val messages = migrationMessages(code)
         assertTrue("expected '$expectedMessage', got: $messages", messages.contains(expectedMessage))

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringBoot4JacksonAnnotationInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * The realistic post-upgrade state: Spring Boot 4 renamed the Jackson annotations, so the legacy ones no longer
+ * resolve. Only the replacements are added to the fixture.
+ */
+class SpringBoot4JacksonAnnotationUnresolvedImportTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package org.springframework.boot.jackson;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+            public @interface JacksonComponent { Class<?>[] value() default {}; }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.boot.jackson;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+            public @interface JacksonMixin { Class<?>[] value() default {}; }
+            """.trimIndent()
+        )
+        myFixture.enableInspections(SpringBoot4JacksonAnnotationInspection::class.java)
+    }
+
+    fun testUnresolvedJsonComponentReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.JsonComponent;
+            
+            @JsonComponent
+            public class MyComponent { }
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testUnresolvedJsonMixinReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.JsonMixin;
+            
+            @JsonMixin(String.class)
+            public class MyComponent { }
+            """,
+            mixinMessage()
+        )
+    }
+
+    fun testUnresolvedOnDemandImportReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.*;
+            
+            @JsonComponent
+            public class MyComponent { }
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testUnresolvedFullyQualifiedAnnotationReported() {
+        assertReported(
+            """
+            @org.springframework.boot.jackson.JsonComponent
+            public class MyComponent { }
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testMigratedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import org.springframework.boot.jackson.JacksonComponent;
+            
+            @JacksonComponent
+            public class MyComponent { }
+            """
+        )
+        assertEmpty("already migrated code must stay clean: $messages", messages)
+    }
+
+    fun testUnrelatedUnresolvedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import com.example.JsonComponent;
+            
+            @JsonComponent
+            public class MyComponent { }
+            """
+        )
+        assertEmpty("an unrelated annotation must not be reported: $messages", messages)
+    }
+
+    private fun assertReported(code: String, expectedMessage: String) {
+        val messages = migrationMessages(code)
+        assertTrue("expected '$expectedMessage', got: $messages", messages.contains(expectedMessage))
+    }
+
+    private fun migrationMessages(code: String): List<String> {
+        myFixture.configureByText("MyComponent.java", code.trimIndent())
+        return myFixture.doHighlighting()
+            .mapNotNull { it.description }
+            .filter { it.contains("Spring Boot 4") }
+    }
+
+    private companion object {
+        fun componentMessage(): String =
+            SpringCoreBundle.message("explyt.spring.inspection.boot4.jackson", "JacksonComponent")
+
+        fun mixinMessage(): String =
+            SpringCoreBundle.message("explyt.spring.inspection.boot4.jackson", "JacksonMixin")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4BootstrapPackageUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4BootstrapPackageUnresolvedImportTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.kotlin
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringBoot4BootstrapPackageInspection
+import com.explyt.spring.test.ExplytInspectionKotlinTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * Kotlin twin of the Java test: covers the `KtFile` branch of the shared legacy-symbol lookup, including the star
+ * import and the import alias, which have no Java counterpart.
+ *
+ * Highlighting is asserted by filtering the reported problems instead of comparing against inline markup: an
+ * unresolved type always produces "Cannot resolve" errors, which markup comparison would demand be spelled out.
+ */
+class SpringBoot4BootstrapPackageUnresolvedImportTest : ExplytInspectionKotlinTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass("package org.springframework.boot.bootstrap; public interface BootstrapRegistry { }")
+        myFixture.enableInspections(SpringBoot4BootstrapPackageInspection::class.java)
+    }
+
+    fun testUnresolvedLegacyPropertyTypeReported() {
+        assertReported(
+            """
+            import org.springframework.boot.BootstrapRegistry
+            
+            class MyConfig {
+                lateinit var registry: BootstrapRegistry
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedLegacyParameterTypeReported() {
+        assertReported(
+            """
+            import org.springframework.boot.BootstrapRegistry
+            
+            class MyConfig {
+                fun run(registry: BootstrapRegistry) { }
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedStarImportReported() {
+        assertReported(
+            """
+            import org.springframework.boot.*
+            
+            class MyConfig {
+                lateinit var registry: BootstrapRegistry
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedImportAliasReported() {
+        assertReported(
+            """
+            import org.springframework.boot.BootstrapRegistry as BR
+            
+            class MyConfig {
+                lateinit var registry: BR
+            }
+            """
+        )
+    }
+
+    fun testUnresolvedFullyQualifiedTypeReported() {
+        assertReported(
+            """
+            class MyConfig {
+                lateinit var registry: org.springframework.boot.BootstrapRegistry
+            }
+            """
+        )
+    }
+
+    fun testMigratedTypeNotReported() {
+        val messages = migrationMessages(
+            """
+            import org.springframework.boot.bootstrap.BootstrapRegistry
+            
+            class MyConfig {
+                lateinit var registry: BootstrapRegistry
+            }
+            """
+        )
+        assertEmpty("already migrated code must stay clean: $messages", messages)
+    }
+
+    fun testUnrelatedUnresolvedTypeNotReported() {
+        val messages = migrationMessages(
+            """
+            import com.example.BootstrapRegistry
+            
+            class MyConfig {
+                lateinit var registry: BootstrapRegistry
+            }
+            """
+        )
+        assertEmpty("an unrelated type must not be reported: $messages", messages)
+    }
+
+    private fun assertReported(code: String) {
+        val messages = migrationMessages(code)
+        assertTrue("expected '$MESSAGE', got: $messages", messages.contains(MESSAGE))
+    }
+
+    private fun migrationMessages(code: String): List<String> {
+        myFixture.configureByText("MyConfig.kt", code.trimIndent())
+        return myFixture.doHighlighting()
+            .mapNotNull { it.description }
+            .filter { it.contains("Spring Boot 4") }
+    }
+
+    private companion object {
+        val MESSAGE: String = SpringCoreBundle.message("explyt.spring.inspection.boot4.bootstrap")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.kotlin
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringBoot4EntityScanPackageInspection
+import com.explyt.spring.test.ExplytInspectionKotlinTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * Kotlin twin of the Java test: covers the `KtFile` branch of the shared legacy-symbol lookup, including the star
+ * import and the import alias, which have no Java counterpart.
+ */
+class SpringBoot4EntityScanPackageUnresolvedImportTest : ExplytInspectionKotlinTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package org.springframework.boot.persistence.autoconfigure;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+            public @interface EntityScan { String[] value() default {}; }
+            """.trimIndent()
+        )
+        myFixture.enableInspections(SpringBoot4EntityScanPackageInspection::class.java)
+    }
+
+    fun testUnresolvedLegacyAnnotationReported() {
+        assertReported(
+            """
+            import org.springframework.boot.autoconfigure.domain.EntityScan
+            
+            @EntityScan("com.example.domain")
+            class AppConfig
+            """
+        )
+    }
+
+    fun testUnresolvedStarImportReported() {
+        assertReported(
+            """
+            import org.springframework.boot.autoconfigure.domain.*
+            
+            @EntityScan("com.example.domain")
+            class AppConfig
+            """
+        )
+    }
+
+    fun testUnresolvedImportAliasReported() {
+        assertReported(
+            """
+            import org.springframework.boot.autoconfigure.domain.EntityScan as LegacyEntityScan
+            
+            @LegacyEntityScan("com.example.domain")
+            class AppConfig
+            """
+        )
+    }
+
+    fun testUnresolvedFullyQualifiedAnnotationReported() {
+        assertReported(
+            """
+            @org.springframework.boot.autoconfigure.domain.EntityScan("com.example.domain")
+            class AppConfig
+            """
+        )
+    }
+
+    fun testMigratedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import org.springframework.boot.persistence.autoconfigure.EntityScan
+            
+            @EntityScan("com.example.domain")
+            class AppConfig
+            """
+        )
+        assertEmpty("already migrated code must stay clean: $messages", messages)
+    }
+
+    fun testUnrelatedUnresolvedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import com.example.EntityScan
+            
+            @EntityScan("com.example.domain")
+            class AppConfig
+            """
+        )
+        assertEmpty("an unrelated annotation must not be reported: $messages", messages)
+    }
+
+    /**
+     * `RewriteAnnotationQuickFix` rejects a `LightElement` owner, and a Kotlin class reaches it as `KtLightClass`,
+     * so the reported problem carries no applicable fix. The test pins the current behaviour: if a Kotlin-aware fix
+     * is added later this assertion fails and has to be replaced by a result assertion.
+     *
+     * The fix is identified by the "Annotate" wording of `AddAnnotationPsiFix`; matching on the annotation name
+     * instead would also catch the platform's own `Import class` / `Create annotation` intentions.
+     */
+    fun testQuickFixUnavailableOnKotlin() {
+        myFixture.configureByText(
+            "AppConfig.kt",
+            """
+            import org.springframework.boot.autoconfigure.domain.EntityScan
+            
+            @Entity<caret>Scan("com.example.domain")
+            class AppConfig
+            """.trimIndent()
+        )
+        val migrationIntentions = myFixture.availableIntentions
+            .map { it.text }
+            .filter { it.contains("Annotate") }
+        assertEmpty(
+            "unexpected migration fix on Kotlin - the LightElement limitation may be gone: $migrationIntentions",
+            migrationIntentions
+        )
+    }
+
+    private fun assertReported(code: String) {
+        val messages = migrationMessages(code)
+        assertTrue("expected '$MESSAGE', got: $messages", messages.contains(MESSAGE))
+    }
+
+    private fun migrationMessages(code: String): List<String> {
+        myFixture.configureByText("AppConfig.kt", code.trimIndent())
+        return myFixture.doHighlighting()
+            .mapNotNull { it.description }
+            .filter { it.contains("Spring Boot 4") }
+    }
+
+    private companion object {
+        val MESSAGE: String = SpringCoreBundle.message("explyt.spring.inspection.boot4.entityscan")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4EntityScanPackageUnresolvedImportTest.kt
@@ -99,31 +99,27 @@ class SpringBoot4EntityScanPackageUnresolvedImportTest : ExplytInspectionKotlinT
         assertEmpty("an unrelated annotation must not be reported: $messages", messages)
     }
 
-    /**
-     * `RewriteAnnotationQuickFix` rejects a `LightElement` owner, and a Kotlin class reaches it as `KtLightClass`,
-     * so the reported problem carries no applicable fix. The test pins the current behaviour: if a Kotlin-aware fix
-     * is added later this assertion fails and has to be replaced by a result assertion.
-     *
-     * The fix is identified by the "Annotate" wording of `AddAnnotationPsiFix`; matching on the annotation name
-     * instead would also catch the platform's own `Import class` / `Create annotation` intentions.
-     */
-    fun testQuickFixUnavailableOnKotlin() {
+    fun testQuickFixReplacesUnresolvedAnnotation() {
         myFixture.configureByText(
             "AppConfig.kt",
             """
             import org.springframework.boot.autoconfigure.domain.EntityScan
-            
+
             @Entity<caret>Scan("com.example.domain")
             class AppConfig
             """.trimIndent()
         )
-        val migrationIntentions = myFixture.availableIntentions
-            .map { it.text }
-            .filter { it.contains("Annotate") }
-        assertEmpty(
-            "unexpected migration fix on Kotlin - the LightElement limitation may be gone: $migrationIntentions",
-            migrationIntentions
-        )
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.replace.annotation.fix", "EntityScan")
+        val intention = myFixture.availableIntentions.firstOrNull { it.text == fixName }
+        requireNotNull(intention) {
+            "EntityScan migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue("new annotation should be applied:\n$result", result.contains("@EntityScan"))
+        assertTrue("new import should be added:\n$result", result.contains("org.springframework.boot.persistence.autoconfigure.EntityScan"))
+        assertTrue("attribute should be preserved:\n$result", result.contains("\"com.example.domain\""))
+        assertFalse("old annotation should be replaced:\n$result", result.contains("org.springframework.boot.autoconfigure.domain.EntityScan"))
     }
 
     private fun assertReported(code: String) {

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.kotlin
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringBoot4JacksonAnnotationInspection
+import com.explyt.spring.test.ExplytInspectionKotlinTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * Kotlin twin of the Java test: covers the `KtFile` branch of the shared legacy-symbol lookup, including the star
+ * import and the import alias, which have no Java counterpart.
+ */
+class SpringBoot4JacksonAnnotationUnresolvedImportTest : ExplytInspectionKotlinTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_4_0_0
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package org.springframework.boot.jackson;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+            public @interface JacksonComponent { Class<?>[] value() default {}; }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package org.springframework.boot.jackson;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+            public @interface JacksonMixin { Class<?>[] value() default {}; }
+            """.trimIndent()
+        )
+        myFixture.enableInspections(SpringBoot4JacksonAnnotationInspection::class.java)
+    }
+
+    fun testUnresolvedJsonComponentReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.JsonComponent
+            
+            @JsonComponent
+            class MyComponent
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testUnresolvedJsonMixinReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.JsonMixin
+            
+            @JsonMixin(String::class)
+            class MyComponent
+            """,
+            mixinMessage()
+        )
+    }
+
+    fun testUnresolvedStarImportReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.*
+            
+            @JsonComponent
+            class MyComponent
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testUnresolvedImportAliasReported() {
+        assertReported(
+            """
+            import org.springframework.boot.jackson.JsonComponent as JC
+            
+            @JC
+            class MyComponent
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testUnresolvedFullyQualifiedAnnotationReported() {
+        assertReported(
+            """
+            @org.springframework.boot.jackson.JsonComponent
+            class MyComponent
+            """,
+            componentMessage()
+        )
+    }
+
+    fun testMigratedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import org.springframework.boot.jackson.JacksonComponent
+            
+            @JacksonComponent
+            class MyComponent
+            """
+        )
+        assertEmpty("already migrated code must stay clean: $messages", messages)
+    }
+
+    fun testUnrelatedUnresolvedAnnotationNotReported() {
+        val messages = migrationMessages(
+            """
+            import com.example.JsonComponent
+            
+            @JsonComponent
+            class MyComponent
+            """
+        )
+        assertEmpty("an unrelated annotation must not be reported: $messages", messages)
+    }
+
+    /**
+     * `RewriteAnnotationQuickFix` rejects a `LightElement` owner, and a Kotlin class reaches it as `KtLightClass`,
+     * so the reported problem carries no applicable fix. The test pins the current behaviour: if a Kotlin-aware fix
+     * is added later this assertion fails and has to be replaced by a result assertion.
+     *
+     * The fix is identified by the "Annotate" wording of `AddAnnotationPsiFix`; matching on the annotation name
+     * instead would also catch the platform's own `Import class` / `Create annotation` intentions.
+     */
+    fun testQuickFixUnavailableOnKotlin() {
+        myFixture.configureByText(
+            "MyComponent.kt",
+            """
+            import org.springframework.boot.jackson.JsonComponent
+            
+            @Json<caret>Component
+            class MyComponent
+            """.trimIndent()
+        )
+        val migrationIntentions = myFixture.availableIntentions
+            .map { it.text }
+            .filter { it.contains("Annotate") }
+        assertEmpty(
+            "unexpected migration fix on Kotlin - the LightElement limitation may be gone: $migrationIntentions",
+            migrationIntentions
+        )
+    }
+
+    private fun assertReported(code: String, expectedMessage: String) {
+        val messages = migrationMessages(code)
+        assertTrue("expected '$expectedMessage', got: $messages", messages.contains(expectedMessage))
+    }
+
+    private fun migrationMessages(code: String): List<String> {
+        myFixture.configureByText("MyComponent.kt", code.trimIndent())
+        return myFixture.doHighlighting()
+            .mapNotNull { it.description }
+            .filter { it.contains("Spring Boot 4") }
+    }
+
+    private companion object {
+        fun componentMessage(): String =
+            SpringCoreBundle.message("explyt.spring.inspection.boot4.jackson", "JacksonComponent")
+
+        fun mixinMessage(): String =
+            SpringCoreBundle.message("explyt.spring.inspection.boot4.jackson", "JacksonMixin")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/kotlin/SpringBoot4JacksonAnnotationUnresolvedImportTest.kt
@@ -123,31 +123,48 @@ class SpringBoot4JacksonAnnotationUnresolvedImportTest : ExplytInspectionKotlinT
         assertEmpty("an unrelated annotation must not be reported: $messages", messages)
     }
 
-    /**
-     * `RewriteAnnotationQuickFix` rejects a `LightElement` owner, and a Kotlin class reaches it as `KtLightClass`,
-     * so the reported problem carries no applicable fix. The test pins the current behaviour: if a Kotlin-aware fix
-     * is added later this assertion fails and has to be replaced by a result assertion.
-     *
-     * The fix is identified by the "Annotate" wording of `AddAnnotationPsiFix`; matching on the annotation name
-     * instead would also catch the platform's own `Import class` / `Create annotation` intentions.
-     */
-    fun testQuickFixUnavailableOnKotlin() {
+    fun testQuickFixReplacesUnresolvedJsonComponent() {
         myFixture.configureByText(
             "MyComponent.kt",
             """
             import org.springframework.boot.jackson.JsonComponent
-            
-            @Json<caret>Component
+
+            @Json<caret>Component(String::class)
             class MyComponent
             """.trimIndent()
         )
-        val migrationIntentions = myFixture.availableIntentions
-            .map { it.text }
-            .filter { it.contains("Annotate") }
-        assertEmpty(
-            "unexpected migration fix on Kotlin - the LightElement limitation may be gone: $migrationIntentions",
-            migrationIntentions
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.replace.annotation.fix", "JacksonComponent")
+        val intention = myFixture.availableIntentions.firstOrNull { it.text == fixName }
+        requireNotNull(intention) {
+            "JacksonComponent migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue("new annotation should be applied:\n$result", result.contains("@JacksonComponent"))
+        assertTrue("attribute should be preserved:\n$result", result.contains("String::class"))
+        assertFalse("old annotation should be replaced:\n$result", result.contains("@JsonComponent"))
+    }
+
+    fun testQuickFixReplacesUnresolvedJsonMixin() {
+        myFixture.configureByText(
+            "MyMixin.kt",
+            """
+            import org.springframework.boot.jackson.JsonMixin
+
+            @Json<caret>Mixin(String::class)
+            class MyMixin
+            """.trimIndent()
         )
+        val fixName = SpringCoreBundle.message("explyt.spring.inspection.replace.annotation.fix", "JacksonMixin")
+        val intention = myFixture.availableIntentions.firstOrNull { it.text == fixName }
+        requireNotNull(intention) {
+            "JacksonMixin migration fix not found; available: " + myFixture.availableIntentions.map { it.text }
+        }
+        myFixture.launchAction(intention)
+        val result = myFixture.file.text
+        assertTrue("new annotation should be applied:\n$result", result.contains("@JacksonMixin"))
+        assertTrue("attribute should be preserved:\n$result", result.contains("String::class"))
+        assertFalse("old annotation should be replaced:\n$result", result.contains("@JsonMixin"))
     }
 
     private fun assertReported(code: String, expectedMessage: String) {


### PR DESCRIPTION
## Summary

Three Boot 4 migration inspections were gated on the **legacy** symbol being resolvable — the very artifact the Boot 4 upgrade removes. So each one went silent in exactly the state it exists for: a project that has just been upgraded and still contains stale source.

| inspection | gate was | gate is now |
|---|---|---|
| `SpringBoot4BootstrapPackageInspection` | `MOVED_TYPES.keys` (legacy) | `MOVED_TYPES.values` |
| `SpringBoot4JacksonAnnotationInspection` | `RENAMES.keys` (legacy) | `RENAMES.values` |
| `SpringBoot4EntityScanPackageInspection` | `OLD_ENTITY_SCAN` | `NEW_ENTITY_SCAN` |

The defect was double in each case: the gate skipped the file, and the visitor also matched on a resolved FQN (`it.qualifiedName == oldFqn`, `MOVED_TYPES[canonicalText]`), which cannot match a removed class. Both halves are fixed.

This is the same defect class as #290 (`@MockBean`), now closed across the series.

### Deliberately unchanged

`SpringBoot4Jackson2ObjectMapperInspection` still gates on the **legacy** `ObjectMapper`, and that is correct: it reports "you inject a Jackson 2 mapper in Boot 4", a problem that only exists while the legacy class is on the classpath.

## Shared helper

The "recognise a legacy symbol that no longer resolves" logic was already inlined twice (`SpringBoot4MockBeanMigrationInspection`, `SpringBoot4TestRestTemplatePackageInspection`). Three more sites would have made five copies, so it moved into `Spring4UastLocalInspectionTool`:

- `legacyAnnotationFqn(annotation, legacyFqns)`
- `legacyTypeFqn(typeSourcePsi, canonicalText, migrations)`
- `writtenAnnotationName(annotation)`

Both prior call sites now use it, which is why they show as net deletions. Covered forms: explicit import, fully qualified usage, star / on-demand import, Kotlin import alias; `KtFile` and `PsiJavaFile` both handled.

## Annotation quick fixes

`EntityScan` and Jackson now use annotation-targeted `ReplaceAnnotationQuickFix` rather than class-owner `RewriteAnnotationQuickFix`.

This fixes two defects at once:

- unresolved Java annotations are replaced in place instead of appending the replacement while leaving the stale annotation/import behind;
- Kotlin gets an applicable source-PSI quick fix (`KtAnnotationEntry`) rather than being rejected through the `KtLightClass` owner.

The shared fix preserves Java/Kotlin annotation arguments and shortens the replacement reference. For Java it also optimizes imports after replacement, removing the now-stale unresolved legacy import.

## How was this tested

Six unresolved-import test classes — Java and Kotlin twins for Bootstrap, Jackson and EntityScan — cover explicit import, fully qualified usage, star/on-demand import, Kotlin aliases, already-migrated code and unrelated same-named symbols.

Red-green was verified per inspection: restoring the legacy-class gate makes the positive unresolved-symbol cases fail while every negative control stays green.

Quick-fix result tests cover:

- unresolved Java `@JsonComponent`, `@JsonMixin`, and `@EntityScan`;
- unresolved Kotlin `@JsonComponent`, `@JsonMixin`, and `@EntityScan`;
- preserved annotation arguments;
- replacement/removal of the legacy annotation;
- removal of the stale Java import.

The refactored existing inspections remain covered by `SpringBoot4MockBeanMigrationUnresolvedImportTest`, `SpringBoot4MockBeanMigrationInspectionTest`, and `SpringBoot4TestRestTemplatePackageInspectionTest`.

Fixtures deliberately contain **no legacy stubs** — that is what makes them reproduce the bug. Highlighting is asserted by filtering `HighlightInfo` rather than by inline markup, because an unresolved symbol always emits `Cannot resolve` errors that markup comparison would otherwise force the fixture to spell out.
