### PR TITLE
fix: Do not start a write action in the replacement key quick-fix preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`
 - fix: Navigate from an indexed collection key such as `ingest.s3-logs.sources[0].enabled` to the member of the collection's element class
 
+- fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 
 ### Spring Web

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/ReplacementKeyQuickFix.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/quickfix/ReplacementKeyQuickFix.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.inspections.quickfix
 
 import com.explyt.spring.core.SpringCoreBundle
 import com.explyt.spring.core.util.RenameUtil
+import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.lang.properties.psi.impl.PropertyImpl
 import com.intellij.openapi.command.WriteCommandAction
@@ -37,6 +38,16 @@ class ReplacementKeyQuickFix(val key: String, element: PsiElement) :
         if (startElement !is PropertyImpl) return
         val oldKey = startElement.key ?: return
         if (oldKey == key) return
+
+        // The platform renders the Alt+Enter preview by invoking the fix on a file copy inside a read action, where
+        // starting a write action deadlocks. In that mode the copy is already modifiable, so only the key of the
+        // shown file is renamed: `${...}` usages and same-key properties live in other real files, which a preview
+        // must never touch.
+        if (IntentionPreviewUtils.isIntentionPreviewActive()) {
+            startElement.setName(key)
+            return
+        }
+
         val containingFile = startElement.context?.containingFile
 
         // Collect the usages before the key is renamed: afterwards `${oldKey}` references no longer resolve to it.

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/ReplacementKeyQuickFixPreviewTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/ReplacementKeyQuickFixPreviewTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.inspections.SpringPropertiesInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * The Alt+Enter preview invokes the fix on a file copy inside a read action, where starting a write action is
+ * forbidden. These tests drive the real preview pipeline, which a highlighting or `launchAction` test never reaches.
+ */
+class ReplacementKeyQuickFixPreviewTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_3_1_1,
+        TestLibrary.springBootAutoConfigure_3_1_1
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.copyFileToProject(
+            "properties/src/resources/META-INF/additional-spring-configuration-metadata.json",
+            "META-INF/additional-spring-configuration-metadata.json"
+        )
+        myFixture.enableInspections(SpringPropertiesInspection::class.java)
+    }
+
+    fun testPreviewRenamesDeprecatedKey() {
+        myFixture.configureByText("application.properties", "$DEPRECATED_KEY=1")
+
+        val previewText = myFixture.getIntentionPreviewText(myFixture.findSingleIntention(fixName()))
+
+        assertEquals("$REPLACEMENT_KEY=1", previewText)
+    }
+
+    fun testPreviewLeavesTheRealFileUntouched() {
+        myFixture.configureByText("application.properties", "$DEPRECATED_KEY=1")
+
+        myFixture.getIntentionPreviewText(myFixture.findSingleIntention(fixName()))
+
+        myFixture.checkResult("$DEPRECATED_KEY=1")
+    }
+
+    fun testPreviewMatchesRealInvocation() {
+        myFixture.configureByText("application.properties", "$DEPRECATED_KEY=1")
+
+        myFixture.checkPreviewAndLaunchAction(myFixture.findSingleIntention(fixName()))
+
+        myFixture.checkResult("$REPLACEMENT_KEY=1")
+    }
+
+    private fun fixName(): String =
+        SpringCoreBundle.message("explyt.spring.inspection.properties.quick.fix.replacement", REPLACEMENT_KEY)
+
+    private companion object {
+        const val DEPRECATED_KEY = "main.foo2.notexist"
+        const val REPLACEMENT_KEY = "my.try-integer"
+    }
+}


### PR DESCRIPTION
## Summary

Pressing Alt+Enter on a deprecated configuration key crashed while rendering the intention preview:

```
Exceptions occurred on invoking the intention 'Use replacement key
'management.httpexchanges.recording.include'' on a copy of the file.

java.lang.IllegalStateException: Must not start write action from within read action - deadlock is coming
	at com.explyt.spring.core.inspections.quickfix.ReplacementKeyQuickFix.invoke(ReplacementKeyQuickFix.kt:45)
	at com.intellij.codeInsight.intention.IntentionAction.generatePreview(IntentionAction.java:116)
```

The platform renders the preview by invoking the fix **on a copy of the file inside a read action**, so the `WriteCommandAction` the fix starts there is illegal. Reported from a local snapshot build; the defect is pre-existing, not a regression from the recent migration-inspection work.

## Fix

In preview mode the file copy is already modifiable, so no write action is needed:

```kotlin
if (IntentionPreviewUtils.isIntentionPreviewActive()) {
    startElement.setName(key)
    return
}
```

The early return is deliberate rather than wrapping the whole body. The remaining work — `renameUsages` and `RenameUtil.renameSameProperty` — starts its own nested write actions *and* walks into other real files (`renameSameProperty` explicitly filters `containingFile != baseElement.containingFile`). A preview must never modify files outside the copy it was given, so wrapping the outer call would have been wrong even if it silenced the exception.

Real invocation is untouched: key, `${...}` usages and the same key in other property files are still renamed inside one write command.

## How was this tested

New `ReplacementKeyQuickFixPreviewTest`, 3 tests, all passing:

| test | what it pins |
|---|---|
| `testPreviewRenamesDeprecatedKey` | the preview produces the renamed key, not an empty diff |
| `testPreviewLeavesTheRealFileUntouched` | generating a preview does not modify the real file |
| `testPreviewMatchesRealInvocation` | `checkPreviewAndLaunchAction` — the shown diff equals the actual result |

Red-green verified: with the fix stashed, the two preview tests fail inside the defect itself —

```
TestLoggerFactory$TestLoggerAssertionError: Side effect not allowed: INVOKE_LATER
	at RenameUtil.renameIProperty(RenameUtil.kt:101)
	at WriteCommandAction.runWriteCommandAction(WriteCommandAction.java:214)
	at ReplacementKeyQuickFix.invoke(...)
```

while `testPreviewMatchesRealInvocation`'s non-preview part keeps passing, so the failure is preview-specific. (In the test environment `SideEffectGuard` trips before the write-action check that fires in production; same root cause.)

A highlighting or plain `launchAction` test cannot catch this — neither reaches the preview pipeline. The tests use the public fixture API (`getIntentionPreviewText`, `checkPreviewAndLaunchAction`) rather than the `@ApiStatus.Internal` preview processor.

## Scope note

`ReplacementKeyQuickFix` handles `.properties` only — `invoke` starts with `if (startElement !is PropertyImpl) return`, so YAML never reaches it and no YAML preview test is possible for this class.

The same `WriteCommandAction`-inside-`invoke` pattern exists in several sibling fixes, which are likely to crash in preview the same way. They are **out of scope here** and left for a follow-up: `YamlKeyToKebabQuickFix` (two nested write actions, and multi-file through `RenameUtil` — the highest-value next candidate), `ReplacementStringQuickFix`, `AddQualifierQuickFix`, `AddJsonElementQuickFix`, `KotlinObjectToClassQuickFix`, `RewriteAnnotationQuickFix`.
