### PR TITLE
fix: Resolve collection element enum values in configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`
 - fix: Navigate from an indexed collection key such as `ingest.s3-logs.sources[0].enabled` to the member of the collection's element class
 
+- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
+- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<Include>`
+- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 
 ### Spring Web

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
@@ -455,7 +455,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
             val elementFileProperty = property.psiElement ?: continue
             val psiValue = elementFileProperty.propertyValuePsiElement() ?: continue
             val configurationProperty = getConfigurationProperty(module, property) ?: continue
-            val propertyType = getPropertyType(configurationProperty) ?: continue
+            val propertyType = PropertyUtil.valueTypeOf(configurationProperty) ?: continue
             val values = getPropertyValue(property, configurationProperty)
             for (value in values) {
                 val resultConvert = tryConvert(propertyType, value)
@@ -541,21 +541,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         return resultEncoding
     }
 
-    private fun getPropertyType(configurationProperty: ConfigurationProperty): String? {
-        val propertyType = configurationProperty.type ?: return null
-        return when {
-            configurationProperty.isList() ->
-                propertyType.substringAfter("<").substringBefore(">")
 
-            configurationProperty.isMap() ->
-                propertyType.substringAfter(",").substringBefore(">")
-
-            configurationProperty.isArray() ->
-                propertyType.substringBefore("[]")
-
-            else -> propertyType.replace('$', '.')
-        }
-    }
 
     private fun isProblemPropertyType(propertyType: String, value: String): Boolean {
         return when (propertyType) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
@@ -74,7 +74,7 @@ class ValueHintReference(
         val javaPsiFacade = JavaPsiFacade.getInstance(module.project)
         val configurationProperty = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .findProperty(module, propertyKey) ?: return emptyResolveResult()
-        val propertyType = configurationProperty.type?.replace('$', '.') ?: return emptyResolveResult()
+        val propertyType = PropertyUtil.valueTypeOf(configurationProperty) ?: return emptyResolveResult()
         val propertyTypeClass = javaPsiFacade.findClass(propertyType, GlobalSearchScope.allScope(module.project))
         if (propertyTypeClass?.isEnum == true) {
             val field = propertyTypeClass.findFieldByName(propertyValue, true) ?: return emptyResolveResult()
@@ -149,7 +149,7 @@ class ValueHintReference(
             ?: SpringPropertiesCompletionContributor.getDynamicMapProperties(module, propertyKey)
                 .firstOrNull { it.name == propertyKey }
 
-        configurationProperty?.type?.replace('$', '.')?.let {
+        configurationProperty?.let { PropertyUtil.valueTypeOf(it) }?.let {
             result.addAll(getVariantsByPropertyType(it))
         }
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -202,6 +202,24 @@ object PropertyUtil {
     }
 
 
+    /**
+     * The type of a single value of [configurationProperty]: the element type for a collection or array, the value
+     * type for a map, and the declared type otherwise.
+     *
+     * A metadata `type` such as `java.util.Set<...Include>` names the container, so resolving it verbatim finds no
+     * class. Every consumer that inspects or resolves an individual value has to unwrap it the same way, otherwise
+     * the inspection and the reference disagree about the same property.
+     */
+    fun valueTypeOf(configurationProperty: ConfigurationProperty): String? {
+        val propertyType = configurationProperty.type ?: return null
+        return when {
+            configurationProperty.isList() -> propertyType.substringAfter("<").substringBefore(">")
+            configurationProperty.isMap() -> propertyType.substringAfter(",").substringBefore(">")
+            configurationProperty.isArray() -> propertyType.substringBefore("[]")
+            else -> propertyType
+        }.replace('$', '.').trim()
+    }
+
     fun findSourceMember(propertyKey: String, sourceType: String, project: Project): PsiMember? {
         val javaPsiFacade = JavaPsiFacade.getInstance(project)
         var memberName = sourceType.substringAfterLast('#', "")

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/CollectionEnumValueReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/CollectionEnumValueReferenceTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.core.properties.references.ValueHintReference
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.psi.PsiEnumConstant
+
+/**
+ * A metadata `type` such as `java.util.Set<...Include>` names the container, so the element type has to be unwrapped
+ * before the value can be resolved against the enum. The inspection already did that, the reference did not, which is
+ * why a valid constant was never highlighted as an enum value.
+ */
+class CollectionEnumValueReferenceTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_3_1_1
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package com.explyt;
+
+            public enum RecordingInclude {
+                TIME_TAKEN, REQUEST_HEADERS, RESPONSE_HEADERS
+            }
+            """.trimIndent()
+        )
+        myFixture.copyFileToProject(
+            "collectionEnumValue/META-INF/additional-spring-configuration-metadata.json",
+            "META-INF/additional-spring-configuration-metadata.json"
+        )
+    }
+
+    fun testSetElementResolvesToEnumConstant() = assertResolvesToConstant("explyt.recording.include")
+
+    fun testListElementResolvesToEnumConstant() = assertResolvesToConstant("explyt.recording.list")
+
+    fun testCollectionElementResolvesToEnumConstant() = assertResolvesToConstant("explyt.recording.collection")
+
+
+    fun testScalarEnumStillResolves() = assertResolvesToConstant("explyt.recording.single")
+
+    fun testYamlSetElementResolvesToEnumConstant() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            explyt:
+              recording:
+                include: REQUEST_HEADERS
+            """.trimIndent()
+        )
+
+        assertEnumConstantResolved()
+    }
+
+    private fun assertResolvesToConstant(key: String) {
+        myFixture.configureByText("application.properties", "$key=REQUEST_HEADERS")
+
+        assertEnumConstantResolved()
+    }
+
+    private fun assertEnumConstantResolved() {
+        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf("REQUEST_HEADERS"))
+        val valueReference = requireNotNull(reference as? ValueHintReference) {
+            "expected a ValueHintReference on the value, got: $reference"
+        }
+
+        val resolved = valueReference.multiResolve(false).map { it.element }
+        assertEquals(ValueHintReference.ResultType.ENUM, valueReference.getResultType())
+        assertTrue(
+            "the value should resolve to the enum constant, got: $resolved",
+            resolved.any { it is PsiEnumConstant && it.name == "REQUEST_HEADERS" }
+        )
+    }
+}

--- a/modules/spring-core/testdata/java/inspection/collectionEnumValue/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/spring-core/testdata/java/inspection/collectionEnumValue/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,36 @@
+{
+  "groups": [],
+  "properties": [
+    {
+      "name": "explyt.recording.include",
+      "type": "java.util.Set<com.explyt.RecordingInclude>",
+      "description": "Items to include in the recording."
+    },
+    {
+      "name": "explyt.recording.list",
+      "type": "java.util.List<com.explyt.RecordingInclude>",
+      "description": "Items to include, as a list."
+    },
+    {
+      "name": "explyt.recording.collection",
+      "type": "java.util.Collection<com.explyt.RecordingInclude>",
+      "description": "Items to include, as a collection."
+    },
+    {
+      "name": "explyt.recording.array",
+      "type": "com.explyt.RecordingInclude[]",
+      "description": "Items to include, as an array."
+    },
+    {
+      "name": "explyt.recording.by-name",
+      "type": "java.util.Map<java.lang.String,com.explyt.RecordingInclude>",
+      "description": "Items to include, keyed by name."
+    },
+    {
+      "name": "explyt.recording.single",
+      "type": "com.explyt.RecordingInclude",
+      "description": "A single item to include."
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
## Summary

A configuration value was never resolved or highlighted as an enum constant when the property type was a collection, e.g. `management.httpexchanges.recording.include=REQUEST_HEADERS`.

The metadata `type` names the container (`java.util.Set<org.springframework.boot.actuate.web.exchanges.Include>`), so resolving it verbatim finds no class, `isEnum` is false, and the value falls through.

The inspection already unwrapped the element type via `isList()` / `isMap()` / `isArray()`; `ValueHintReference` did not. The two paths disagreed about the same property, which is the actual defect. Value completion used the raw type as well.

## Fix

The unwrapping moves into `PropertyUtil.valueTypeOf(ConfigurationProperty)` and all three call sites use it, so they cannot drift apart again.

## Earlier diagnosis was wrong

This was first attributed to metadata merge order in `AbstractSpringMetadataConfigurationPropertiesLoader`. That is not the cause: `SpringMetadataLibraryConfigurationPropertiesLoader.findMetadataFiles` ends with `.sortedBy { it.name }`, so `additional-spring-configuration-metadata.json` is always processed **before** `spring-configuration-metadata.json`. The untyped entry comes first and the typed entry then fills `type` and recomputes `propertyType` correctly. No loader change is included here.

## Tests

`CollectionEnumValueReferenceTest`, 5 tests, all passing: `Set`, `List`, `Collection` elements, a scalar enum (regression guard) and YAML. Red-green verified - before the fix the collection cases fail with `expected:<ENUM> but was:<NONE>` while the scalar case passes, so the failure is specific to the missing unwrap. `SpringPropertiesInspectionTest` stays green (6 tests).

The fixture declares the collection property in `additional-spring-configuration-metadata.json`, which is what `ProjectConfigurationPropertiesLoader` reads; reproducing a two-file merge is unnecessary.

## Out of scope

Array (`Include[]`) and map-value keys still resolve to `NONE` even with the unwrap, so they fail for an additional reason and are left out rather than shipped half-fixed.
