### PR TITLE
fix: Match enum configuration values by relaxed binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`
 - fix: Navigate from an indexed collection key such as `ingest.s3-logs.sources[0].enabled` to the member of the collection's element class
 
+- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
+- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<Include>`
+- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 
 ### Spring Web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 - fix: Navigate from an indexed collection key such as `ingest.s3-logs.sources[0].enabled` to the member of the collection's element class
 
 - fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
-- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<Include>`
-- fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
+- fix: Accept an enum configuration value in any relaxed form, so `request-headers` resolves to `REQUEST_HEADERS` and is no longer reported as invalid
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 
 ### Spring Web

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
@@ -610,9 +610,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         value: String
     ): List<ProblemDescriptor> {
         val propertyTypeClass = getCachedPropertyTypeClass(module, propertyType) ?: return emptyList()
-        if (propertyTypeClass.isEnum
-            && !propertyTypeClass.fields.map { it.name.lowercase() }.any { it == value.lowercase() }
-        ) {
+        if (propertyTypeClass.isEnum && PropertyUtil.findEnumConstant(propertyTypeClass, value) == null) {
             return listOf(
                 manager.createProblemDescriptor(
                     psiElement,

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
@@ -455,7 +455,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
             val elementFileProperty = property.psiElement ?: continue
             val psiValue = elementFileProperty.propertyValuePsiElement() ?: continue
             val configurationProperty = getConfigurationProperty(module, property) ?: continue
-            val propertyType = getPropertyType(configurationProperty) ?: continue
+            val propertyType = PropertyUtil.valueTypeOf(configurationProperty) ?: continue
             val values = getPropertyValue(property, configurationProperty)
             for (value in values) {
                 val resultConvert = tryConvert(propertyType, value)
@@ -541,21 +541,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         return resultEncoding
     }
 
-    private fun getPropertyType(configurationProperty: ConfigurationProperty): String? {
-        val propertyType = configurationProperty.type ?: return null
-        return when {
-            configurationProperty.isList() ->
-                propertyType.substringAfter("<").substringBefore(">")
 
-            configurationProperty.isMap() ->
-                propertyType.substringAfter(",").substringBefore(">")
-
-            configurationProperty.isArray() ->
-                propertyType.substringBefore("[]")
-
-            else -> propertyType.replace('$', '.')
-        }
-    }
 
     private fun isProblemPropertyType(propertyType: String, value: String): Boolean {
         return when (propertyType) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
@@ -77,8 +77,9 @@ class ValueHintReference(
         val propertyType = PropertyUtil.valueTypeOf(configurationProperty) ?: return emptyResolveResult()
         val propertyTypeClass = javaPsiFacade.findClass(propertyType, GlobalSearchScope.allScope(module.project))
         if (propertyTypeClass?.isEnum == true) {
-            val field = propertyTypeClass.findFieldByName(propertyValue, true) ?: return emptyResolveResult()
-            return ResolveResultContainer(arrayOf(PsiElementResolveResult(field)), ResultType.ENUM)
+            val constant = PropertyUtil.findEnumConstant(propertyTypeClass, propertyValue)
+                ?: return emptyResolveResult()
+            return ResolveResultContainer(arrayOf(PsiElementResolveResult(constant)), ResultType.ENUM)
         }
         return emptyResolveResult()
     }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
@@ -74,7 +74,7 @@ class ValueHintReference(
         val javaPsiFacade = JavaPsiFacade.getInstance(module.project)
         val configurationProperty = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .findProperty(module, propertyKey) ?: return emptyResolveResult()
-        val propertyType = configurationProperty.type?.replace('$', '.') ?: return emptyResolveResult()
+        val propertyType = PropertyUtil.valueTypeOf(configurationProperty) ?: return emptyResolveResult()
         val propertyTypeClass = javaPsiFacade.findClass(propertyType, GlobalSearchScope.allScope(module.project))
         if (propertyTypeClass?.isEnum == true) {
             val field = propertyTypeClass.findFieldByName(propertyValue, true) ?: return emptyResolveResult()
@@ -149,7 +149,7 @@ class ValueHintReference(
             ?: SpringPropertiesCompletionContributor.getDynamicMapProperties(module, propertyKey)
                 .firstOrNull { it.name == propertyKey }
 
-        configurationProperty?.type?.replace('$', '.')?.let {
+        configurationProperty?.let { PropertyUtil.valueTypeOf(it) }?.let {
             result.addAll(getVariantsByPropertyType(it))
         }
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -220,6 +220,22 @@ object PropertyUtil {
         }.replace('$', '.').trim()
     }
 
+    /**
+     * The constant of the enum [enumClass] that [value] denotes under Spring's relaxed binding, or `null` when the
+     * enum declares none.
+     *
+     * Relaxed binding accepts a constant in any case with `-` and `_` interchangeable, and Spring's own metadata
+     * ships the dashed form as the default value (`management.httpexchanges.recording.include` defaults to
+     * `request-headers`), so comparing names verbatim rejects the spelling the framework itself recommends.
+     */
+    fun findEnumConstant(enumClass: PsiClass, value: String): PsiEnumConstant? {
+        if (!enumClass.isEnum) return null
+        val relaxedValue = toCommonPropertyForm(value)
+        return enumClass.fields.asSequence()
+            .filterIsInstance<PsiEnumConstant>()
+            .firstOrNull { toCommonPropertyForm(it.name) == relaxedValue }
+    }
+
     fun findSourceMember(propertyKey: String, sourceType: String, project: Project): PsiMember? {
         val javaPsiFacade = JavaPsiFacade.getInstance(project)
         var memberName = sourceType.substringAfterLast('#', "")

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -202,6 +202,24 @@ object PropertyUtil {
     }
 
 
+    /**
+     * The type of a single value of [configurationProperty]: the element type for a collection or array, the value
+     * type for a map, and the declared type otherwise.
+     *
+     * A metadata `type` such as `java.util.Set<...Include>` names the container, so resolving it verbatim finds no
+     * class. Every consumer that inspects or resolves an individual value has to unwrap it the same way, otherwise
+     * the inspection and the reference disagree about the same property.
+     */
+    fun valueTypeOf(configurationProperty: ConfigurationProperty): String? {
+        val propertyType = configurationProperty.type ?: return null
+        return when {
+            configurationProperty.isList() -> propertyType.substringAfter("<").substringBefore(">")
+            configurationProperty.isMap() -> propertyType.substringAfter(",").substringBefore(">")
+            configurationProperty.isArray() -> propertyType.substringBefore("[]")
+            else -> propertyType
+        }.replace('$', '.').trim()
+    }
+
     fun findSourceMember(propertyKey: String, sourceType: String, project: Project): PsiMember? {
         val javaPsiFacade = JavaPsiFacade.getInstance(project)
         var memberName = sourceType.substringAfterLast('#', "")

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/RelaxedEnumValueInspectionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/RelaxedEnumValueInspectionTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.inspections.SpringPropertiesInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * Spring's relaxed binding accepts an enum constant in any case with `-` and `_` interchangeable, and Spring's own
+ * metadata ships the dashed form as a default value, so reporting it as unresolved flags the spelling the framework
+ * recommends. The inspection and [com.explyt.spring.core.properties.references.ValueHintReference] share the same
+ * matcher, so they cannot disagree about whether a value is valid.
+ */
+class RelaxedEnumValueInspectionTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_3_1_1
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package com.explyt;
+
+            public enum RecordingInclude {
+                TIME_TAKEN, REQUEST_HEADERS, RESPONSE_HEADERS
+            }
+            """.trimIndent()
+        )
+        myFixture.copyFileToProject(
+            "collectionEnumValue/META-INF/additional-spring-configuration-metadata.json",
+            "META-INF/additional-spring-configuration-metadata.json"
+        )
+        myFixture.enableInspections(SpringPropertiesInspection::class.java)
+    }
+
+    fun testDashedFormNotReported() = assertNotReported("explyt.recording.include=request-headers")
+
+    fun testLowerCaseUnderscoreFormNotReported() = assertNotReported("explyt.recording.include=request_headers")
+
+    fun testMixedCaseDashedFormNotReported() = assertNotReported("explyt.recording.include=Request-Headers")
+
+    fun testCanonicalFormNotReported() = assertNotReported("explyt.recording.include=REQUEST_HEADERS")
+
+    fun testScalarEnumDashedFormNotReported() = assertNotReported("explyt.recording.single=time-taken")
+
+    fun testInvalidValueStillReported() {
+        myFixture.configureByText("application.properties", "explyt.recording.include=NOT_A_VALUE")
+
+        val problems = enumProblems()
+
+        assertTrue("an invalid constant must still be reported, got: $problems", problems.isNotEmpty())
+    }
+
+    fun testYamlDashedFormNotReported() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            explyt:
+              recording:
+                include: request-headers
+            """.trimIndent()
+        )
+
+        val problems = enumProblems()
+
+        assertEmpty("the dashed form must not be reported: $problems", problems)
+    }
+
+    private fun assertNotReported(propertyLine: String) {
+        myFixture.configureByText("application.properties", propertyLine)
+
+        val problems = enumProblems()
+
+        assertEmpty("a relaxed enum form must not be reported: $problems", problems)
+    }
+
+    private fun enumProblems(): List<String> = myFixture.doHighlighting()
+        .mapNotNull { it.description }
+        .filter { it.contains("RecordingInclude") }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/CollectionEnumValueReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/CollectionEnumValueReferenceTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.core.properties.references.ValueHintReference
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.psi.PsiEnumConstant
+
+/**
+ * A metadata `type` such as `java.util.Set<...Include>` names the container, so the element type has to be unwrapped
+ * before the value can be resolved against the enum. The inspection already did that, the reference did not, which is
+ * why a valid constant was never highlighted as an enum value.
+ */
+class CollectionEnumValueReferenceTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_3_1_1
+    )
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.addClass(
+            """
+            package com.explyt;
+
+            public enum RecordingInclude {
+                TIME_TAKEN, REQUEST_HEADERS, RESPONSE_HEADERS
+            }
+            """.trimIndent()
+        )
+        myFixture.copyFileToProject(
+            "collectionEnumValue/META-INF/additional-spring-configuration-metadata.json",
+            "META-INF/additional-spring-configuration-metadata.json"
+        )
+    }
+
+    fun testSetElementResolvesToEnumConstant() = assertResolvesToConstant("explyt.recording.include")
+
+    fun testListElementResolvesToEnumConstant() = assertResolvesToConstant("explyt.recording.list")
+
+    fun testCollectionElementResolvesToEnumConstant() = assertResolvesToConstant("explyt.recording.collection")
+
+
+    fun testScalarEnumStillResolves() = assertResolvesToConstant("explyt.recording.single")
+
+    fun testYamlSetElementResolvesToEnumConstant() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            explyt:
+              recording:
+                include: REQUEST_HEADERS
+            """.trimIndent()
+        )
+
+        assertEnumConstantResolved()
+    }
+
+    private fun assertResolvesToConstant(key: String) {
+        myFixture.configureByText("application.properties", "$key=REQUEST_HEADERS")
+
+        assertEnumConstantResolved()
+    }
+
+    private fun assertEnumConstantResolved() {
+        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf("REQUEST_HEADERS"))
+        val valueReference = requireNotNull(reference as? ValueHintReference) {
+            "expected a ValueHintReference on the value, got: $reference"
+        }
+
+        val resolved = valueReference.multiResolve(false).map { it.element }
+        assertEquals(ValueHintReference.ResultType.ENUM, valueReference.getResultType())
+        assertTrue(
+            "the value should resolve to the enum constant, got: $resolved",
+            resolved.any { it is PsiEnumConstant && it.name == "REQUEST_HEADERS" }
+        )
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/CollectionEnumValueReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/CollectionEnumValueReferenceTest.kt
@@ -47,6 +47,29 @@ class CollectionEnumValueReferenceTest : ExplytInspectionJavaTestCase() {
 
     fun testScalarEnumStillResolves() = assertResolvesToConstant("explyt.recording.single")
 
+    fun testLowerCaseUnderscoreFormResolves() =
+        assertResolvesToConstant("explyt.recording.include", "request_headers")
+
+    fun testDashedFormResolves() =
+        assertResolvesToConstant("explyt.recording.include", "request-headers")
+
+    fun testMixedCaseDashedFormResolves() =
+        assertResolvesToConstant("explyt.recording.include", "Request-Headers")
+
+    fun testScalarEnumResolvesDashedForm() =
+        assertResolvesToConstant("explyt.recording.single", "request-headers")
+
+    fun testUnknownValueDoesNotResolve() {
+        myFixture.configureByText("application.properties", "explyt.recording.include=NOT_A_VALUE")
+
+        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf("NOT_A_VALUE"))
+        val valueReference = reference as? ValueHintReference
+        assertTrue(
+            "an unknown value must not resolve to a constant",
+            valueReference == null || valueReference.multiResolve(false).isEmpty()
+        )
+    }
+
     fun testYamlSetElementResolvesToEnumConstant() {
         myFixture.configureByText(
             "application.yaml",
@@ -60,14 +83,27 @@ class CollectionEnumValueReferenceTest : ExplytInspectionJavaTestCase() {
         assertEnumConstantResolved()
     }
 
-    private fun assertResolvesToConstant(key: String) {
-        myFixture.configureByText("application.properties", "$key=REQUEST_HEADERS")
+    fun testYamlDashedFormResolves() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            explyt:
+              recording:
+                include: request-headers
+            """.trimIndent()
+        )
 
-        assertEnumConstantResolved()
+        assertEnumConstantResolved("request-headers")
     }
 
-    private fun assertEnumConstantResolved() {
-        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf("REQUEST_HEADERS"))
+    private fun assertResolvesToConstant(key: String, value: String = "REQUEST_HEADERS") {
+        myFixture.configureByText("application.properties", "$key=$value")
+
+        assertEnumConstantResolved(value)
+    }
+
+    private fun assertEnumConstantResolved(value: String = "REQUEST_HEADERS") {
+        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf(value))
         val valueReference = requireNotNull(reference as? ValueHintReference) {
             "expected a ValueHintReference on the value, got: $reference"
         }

--- a/modules/spring-core/testdata/java/inspection/collectionEnumValue/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/spring-core/testdata/java/inspection/collectionEnumValue/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,36 @@
+{
+  "groups": [],
+  "properties": [
+    {
+      "name": "explyt.recording.include",
+      "type": "java.util.Set<com.explyt.RecordingInclude>",
+      "description": "Items to include in the recording."
+    },
+    {
+      "name": "explyt.recording.list",
+      "type": "java.util.List<com.explyt.RecordingInclude>",
+      "description": "Items to include, as a list."
+    },
+    {
+      "name": "explyt.recording.collection",
+      "type": "java.util.Collection<com.explyt.RecordingInclude>",
+      "description": "Items to include, as a collection."
+    },
+    {
+      "name": "explyt.recording.array",
+      "type": "com.explyt.RecordingInclude[]",
+      "description": "Items to include, as an array."
+    },
+    {
+      "name": "explyt.recording.by-name",
+      "type": "java.util.Map<java.lang.String,com.explyt.RecordingInclude>",
+      "description": "Items to include, keyed by name."
+    },
+    {
+      "name": "explyt.recording.single",
+      "type": "com.explyt.RecordingInclude",
+      "description": "A single item to include."
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
## Summary

An enum configuration value only resolved when spelled exactly like the constant. Spring's relaxed binding is case-insensitive and treats `-` and `_` as interchangeable, so the plugin disagreed with the framework:

| spelling | reference (highlight/resolve) | inspection |
|---|---|---|
| `REQUEST_HEADERS` | resolved | ok |
| `request_headers` | **not resolved** | ok |
| `request-headers` | **not resolved** | **reported as invalid** |
| `Request-Headers` | **not resolved** | **reported as invalid** |

After this change every form above resolves and none is reported.

The dashed form matters most: Spring ships it as the **default value** in its own metadata — `management.httpexchanges.recording.include` defaults to `["time-taken", "request-headers", "response-headers"]`. The plugin was flagging the spelling the framework recommends.

## Implementation

`PropertyUtil.findEnumConstant(enumClass, value)` owns the comparison and reuses `toCommonPropertyForm`, the canonicalisation already applied to property *keys* — it lowercases and strips `-`/`_`, which is exactly relaxed binding for a constant name.

Both call sites now use it:

- `ValueHintReference.resolveResultContainer` — replaced `findFieldByName(propertyValue, true)` (exact match);
- `SpringBasePropertyInspection.getProblemEnum` — replaced a `lowercase()` comparison that handled case but not dashes.

One shared matcher is the design point rather than a convenience. The previous bug in this area (#298) existed precisely because the resolve path and the inspection path each unwrapped the property type on their own and drifted apart; a single function makes "is this value valid" answerable in exactly one way.

Completion needs no change: `getVariants` enumerates all constants instead of matching a typed value.

## How was this tested

Red-green verified per suite, `--rerun` on each, run sequentially.

`CollectionEnumValueReferenceTest` — 11 tests, extended with the relaxed forms:

| phase | result |
|---|---|
| without the fix | 5 fail with `AssertionFailedError: expected:<ENUM> but was:<NONE>` (`request_headers`, `request-headers`, `Request-Headers`, scalar dashed, YAML dashed) |
| with the fix | 11/11 pass |

New `RelaxedEnumValueInspectionTest` — 7 tests, pinning that valid forms are not reported:

| phase | result |
|---|---|
| without the fix | 3 fail with `Cannot resolve field 'request-headers' in enum 'com.explyt.RecordingInclude'` (and the mixed-case and scalar variants) |
| with the fix | 7/7 pass |

In both suites the canonical form and `testInvalidValueStillReported` passed in **both** phases, so the failures are specific to relaxed matching and the fix does not silence the check — `NOT_A_VALUE` is still reported, and `testUnknownValueDoesNotResolve` still resolves to nothing.

Regression: `SpringPropertiesInspectionTest` 6/6.

Covered forms: `SCREAMING_SNAKE`, `lower_snake`, `kebab-case`, `Mixed-Kebab`; collection element types (`Set`, `List`, `Collection`) and scalar enums; `.properties` and YAML.

## Out of scope

Arrays (`Include[]`) and map values (`Map<String,Include>`) still do not resolve — a different cause upstream of the matcher, tracked separately.
