### PR TITLE
fix: Complete an enum configuration value in any relaxed spelling and insert Spring's recommended one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
 - fix: Accept an enum configuration value in any relaxed form, so `request-headers` resolves to `REQUEST_HEADERS` and is no longer reported as invalid
-- fix: Complete an enum configuration value from any relaxed spelling, so `r`, `request-h` and `request_h` all offer `REQUEST_HEADERS`
+- fix: Complete an enum configuration value from any relaxed spelling and insert Spring's recommended one, so `r`, `request-h`, `request_h` and `REQ` all insert `request-headers`
 - fix: Resolve a configuration value against the enum element type of an array property such as `Include[]` and of a map property such as `java.util.Map<String, Include>`
 - fix: Navigate a configuration key with no declaring member, such as `management.endpoint.httpexchanges.access`, to its value type instead of the unrelated source class
 - fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
 - fix: Accept an enum configuration value in any relaxed form, so `request-headers` resolves to `REQUEST_HEADERS` and is no longer reported as invalid
+- fix: Complete an enum configuration value from any relaxed spelling, so `r`, `request-h` and `request_h` all offer `REQUEST_HEADERS`
 - fix: Resolve a configuration value against the enum element type of an array property such as `Include[]` and of a map property such as `java.util.Map<String, Include>`
 - fix: Navigate a configuration key with no declaring member, such as `management.endpoint.httpexchanges.access`, to its value type instead of the unrelated source class
 - fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
@@ -230,10 +230,11 @@ class ValueHintReference(
                     return propertyTypeClass.fields.asSequence()
                         .filterIsInstance<PsiEnumConstant>()
                         .mapToList { constant ->
-                            // Case sensitivity has to stay on: it is what makes the platform insert the declared
-                            // name verbatim instead of echoing the case of the typed prefix.
-                            LookupElementBuilder.create(constant)
-                                .withLookupStrings(PropertyUtil.relaxedValueSpellings(constant.name))
+                            // Case sensitivity has to stay on: it is what makes the platform insert this literal
+                            // verbatim instead of echoing the case of the typed prefix.
+                            LookupElementBuilder.create(constant, PropertyUtil.recommendedValueSpelling(constant.name))
+                                .withLookupStrings(PropertyUtil.relaxedValueSpellings(constant.name) + constant.name)
+                                .withTailText(" ${constant.name}", true)
                         }
                 }
                 emptyList()

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
@@ -17,7 +17,6 @@ import com.explyt.spring.core.util.PropertyUtil
 import com.explyt.spring.core.util.PropertyUtil.propertyKey
 import com.explyt.spring.core.util.PropertyUtil.propertyValue
 import com.explyt.util.ExplytKotlinUtil.mapToList
-import com.explyt.util.ExplytPsiUtil.isPrivate
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.module.Module
@@ -229,8 +228,13 @@ class ValueHintReference(
                     .findClass(propertyType, GlobalSearchScope.allScope(project))
                 if (propertyTypeClass?.isEnum == true) {
                     return propertyTypeClass.fields.asSequence()
-                        .filter { !it.isPrivate }
-                        .mapToList { LookupElementBuilder.create(it) }
+                        .filterIsInstance<PsiEnumConstant>()
+                        .mapToList { constant ->
+                            // Case sensitivity has to stay on: it is what makes the platform insert the declared
+                            // name verbatim instead of echoing the case of the typed prefix.
+                            LookupElementBuilder.create(constant)
+                                .withLookupStrings(PropertyUtil.relaxedValueSpellings(constant.name))
+                        }
                 }
                 emptyList()
             }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -236,6 +236,18 @@ object PropertyUtil {
             .firstOrNull { toCommonPropertyForm(it.name) == relaxedValue }
     }
 
+    /**
+     * The spellings of the enum constant [constantName] that a user types and [findEnumConstant] accepts.
+     *
+     * The canonical form compared by [findEnumConstant] has its separators stripped, so it is not a literal anyone
+     * types; completion needs the typable alternatives instead, and Spring's own metadata ships the kebab-case one as
+     * the default value.
+     */
+    fun relaxedValueSpellings(constantName: String): Set<String> {
+        val lowerSnakeCase = constantName.lowercase()
+        return setOf(lowerSnakeCase, lowerSnakeCase.replace('_', '-'))
+    }
+
     fun findSourceMember(propertyKey: String, sourceType: String, project: Project): PsiMember? {
         val foundClass = findSourceTypeClass(sourceType, project) ?: return null
         return findDeclaringMember(foundClass, propertyKey, sourceType) ?: foundClass

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -244,9 +244,17 @@ object PropertyUtil {
      * the default value.
      */
     fun relaxedValueSpellings(constantName: String): Set<String> {
-        val lowerSnakeCase = constantName.lowercase()
-        return setOf(lowerSnakeCase, lowerSnakeCase.replace('_', '-'))
+        return setOf(constantName.lowercase(), recommendedValueSpelling(constantName))
     }
+
+    /**
+     * The spelling of the enum constant [constantName] that Spring itself recommends: lower-case kebab-case.
+     *
+     * Measured on `spring-boot-autoconfigure-3.5.13`, every enum-typed property with a string `defaultValue` ships it
+     * in that form (51 single-word such as `never`, 13 dashed such as `read-uncommitted`, none in the declared
+     * `SCREAMING_SNAKE`), so this is the form to insert and to suggest.
+     */
+    fun recommendedValueSpelling(constantName: String): String = constantName.lowercase().replace('_', '-')
 
     fun findSourceMember(propertyKey: String, sourceType: String, project: Project): PsiMember? {
         val foundClass = findSourceTypeClass(sourceType, project) ?: return null

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/PropertiesCompletionValueByConfigurationPropertiesTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/PropertiesCompletionValueByConfigurationPropertiesTest.kt
@@ -37,9 +37,9 @@ class PropertiesCompletionValueByConfigurationPropertiesTest : AbstractSpringPro
             "main.local.enum-value=SD<caret>"
         )
         doTest(
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
+            "tuesday",
+            "wednesday",
+            "thursday",
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/PropertiesCompletionValueByMetadataTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/PropertiesCompletionValueByMetadataTest.kt
@@ -40,13 +40,13 @@ class PropertiesCompletionValueByMetadataTest : AbstractSpringPropertiesCompleti
         myFixture.copyFileToProject("META-INF/additional-spring-configuration-metadata.json")
         myFixture.configureByText("application.properties", "main.code-log-level=<caret>")
         doTest(
-            "DEBUG",
-            "ERROR",
-            "FATAL",
-            "INFO",
-            "OFF",
-            "TRACE",
-            "WARN"
+            "debug",
+            "error",
+            "fatal",
+            "info",
+            "off",
+            "trace",
+            "warn"
         )
     }
 
@@ -54,13 +54,13 @@ class PropertiesCompletionValueByMetadataTest : AbstractSpringPropertiesCompleti
         myFixture.copyFileToProject("META-INF/additional-spring-configuration-metadata.json")
         myFixture.configureByText("application.properties", "main.code-log-level=<caret>")
         doTest(
-            "DEBUG",
-            "ERROR",
-            "FATAL",
-            "INFO",
-            "OFF",
-            "TRACE",
-            "WARN"
+            "debug",
+            "error",
+            "fatal",
+            "info",
+            "off",
+            "trace",
+            "warn"
         )
     }
 
@@ -93,9 +93,9 @@ class PropertiesCompletionValueByMetadataTest : AbstractSpringPropertiesCompleti
             "main.enum-value-additional=SD<caret>"
         )
         doTest(
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
+            "tuesday",
+            "wednesday",
+            "thursday",
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/YamlCompletionValueByConfigurationPropertiesTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/YamlCompletionValueByConfigurationPropertiesTest.kt
@@ -45,9 +45,9 @@ main:
             """.trimIndent()
         )
         doTest(
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
+            "tuesday",
+            "wednesday",
+            "thursday",
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/YamlCompletionValueByMetadataTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/java/YamlCompletionValueByMetadataTest.kt
@@ -59,13 +59,13 @@ main:
 """.trimIndent()
         )
         doTest(
-            "DEBUG",
-            "ERROR",
-            "FATAL",
-            "INFO",
-            "OFF",
-            "TRACE",
-            "WARN"
+            "debug",
+            "error",
+            "fatal",
+            "info",
+            "off",
+            "trace",
+            "warn"
         )
     }
 
@@ -115,9 +115,9 @@ main:
             """.trimIndent()
         )
         doTest(
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
+            "tuesday",
+            "wednesday",
+            "thursday",
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/PropertiesCompletionValueByConfigurationPropertiesTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/PropertiesCompletionValueByConfigurationPropertiesTest.kt
@@ -26,11 +26,11 @@ class PropertiesCompletionValueByConfigurationPropertiesTest : AbstractSpringPro
         myFixture.copyFileToProject("META-INF/additional-spring-configuration-metadata.json")
         myFixture.configureByText("application.properties", "main.code-log-level=<caret>")
         doTest(
-            "DEBUG",
-            "ERROR",
-            "INFO",
-            "TRACE",
-            "WARN"
+            "debug",
+            "error",
+            "info",
+            "trace",
+            "warn"
         )
     }
 
@@ -63,9 +63,9 @@ class PropertiesCompletionValueByConfigurationPropertiesTest : AbstractSpringPro
             "main.local.enum-value=SD<caret>"
         )
         doTest(
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
+            "tuesday",
+            "wednesday",
+            "thursday",
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/PropertiesCompletionValueByMetadataTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/PropertiesCompletionValueByMetadataTest.kt
@@ -26,11 +26,11 @@ class PropertiesCompletionValueByMetadataTest : AbstractSpringPropertiesCompleti
         myFixture.copyFileToProject("META-INF/additional-spring-configuration-metadata.json")
         myFixture.configureByText("application.properties", "main.code-log-level=<caret>")
         doTest(
-            "DEBUG",
-            "ERROR",
-            "INFO",
-            "TRACE",
-            "WARN"
+            "debug",
+            "error",
+            "info",
+            "trace",
+            "warn"
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/YamlCompletionValueByConfigurationPropertiesTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/YamlCompletionValueByConfigurationPropertiesTest.kt
@@ -64,9 +64,9 @@ main:
             """.trimIndent()
         )
         doTest(
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
+            "tuesday",
+            "wednesday",
+            "thursday",
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/YamlCompletionValueByMetadataTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/kotlin/YamlCompletionValueByMetadataTest.kt
@@ -42,11 +42,11 @@ main:
         )
 
         doTest(
-            "DEBUG",
-            "ERROR",
-            "INFO",
-            "TRACE",
-            "WARN"
+            "debug",
+            "error",
+            "info",
+            "trace",
+            "warn"
         )
     }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/RelaxedEnumValueCompletionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/RelaxedEnumValueCompletionTest.kt
@@ -10,9 +10,9 @@ import com.explyt.spring.test.TestLibrary
 import com.intellij.codeInsight.CodeInsightSettings
 
 /**
- * Value completion has to offer an enum constant for every spelling relaxed binding accepts, because Spring's own
- * metadata ships the dashed lower-case form as the default value: only the declared name was a lookup string, so a
- * user following the framework's own recommendation got "No suggestions".
+ * Value completion has to offer an enum constant for every spelling relaxed binding accepts and insert the one Spring
+ * itself recommends: its own metadata ships enum default values in lower-case kebab-case (`never`, `read-uncommitted`)
+ * and never in the declared `SCREAMING_SNAKE` form.
  */
 class RelaxedEnumValueCompletionTest : ExplytInspectionJavaTestCase() {
     override val libraries: Array<TestLibrary> = arrayOf(
@@ -56,34 +56,37 @@ class RelaxedEnumValueCompletionTest : ExplytInspectionJavaTestCase() {
 
     fun testLowerCasePrefixOffersConstants() = assertVariants(
         "explyt.recording.include=r<caret>",
-        "REQUEST_HEADERS", "RESPONSE_HEADERS"
+        "request-headers", "response-headers"
     )
 
     fun testUpperCasePrefixStillOffersConstants() = assertVariants(
         "explyt.recording.include=R<caret>",
-        "REQUEST_HEADERS", "RESPONSE_HEADERS"
+        "request-headers", "response-headers"
     )
 
     fun testEmptyPrefixOffersAllConstants() = assertVariants(
         "explyt.recording.include=<caret>",
-        "TIME_TAKEN", "REQUEST_HEADERS", "RESPONSE_HEADERS"
+        "time-taken", "request-headers", "response-headers"
     )
 
-    fun testKebabCasePrefixInsertsDeclaredName() =
-        assertInsertsDeclaredName("explyt.recording.include=request-h<caret>")
+    fun testKebabCasePrefixInsertsRecommendedForm() =
+        assertInsertsRecommendedForm("explyt.recording.include=request-h<caret>")
 
-    fun testSnakeCasePrefixInsertsDeclaredName() =
-        assertInsertsDeclaredName("explyt.recording.include=request_h<caret>")
+    fun testSnakeCasePrefixInsertsRecommendedForm() =
+        assertInsertsRecommendedForm("explyt.recording.include=request_h<caret>")
 
-    fun testDeclaredPrefixInsertsDeclaredName() =
-        assertInsertsDeclaredName("explyt.recording.include=REQUEST_H<caret>")
+    fun testDeclaredPrefixInsertsRecommendedForm() =
+        assertInsertsRecommendedForm("explyt.recording.include=REQUEST_H<caret>")
 
-    fun testFullKebabCaseValueInsertsDeclaredName() =
-        assertInsertsDeclaredName("explyt.recording.include=request-headers<caret>")
+    fun testDeclaredNamePrefixStillMatches() =
+        assertInsertsRecommendedForm("explyt.recording.include=REQ<caret>")
+
+    fun testFullKebabCaseValueInsertsRecommendedForm() =
+        assertInsertsRecommendedForm("explyt.recording.include=request-headers<caret>")
 
     fun testScalarEnumOffersConstantsForLowerCasePrefix() = assertVariants(
         "explyt.recording.single=r<caret>",
-        "REQUEST_HEADERS", "RESPONSE_HEADERS"
+        "request-headers", "response-headers"
     )
 
     fun testNonEnumValueTypeIsUnaffected() = assertVariants(
@@ -101,16 +104,16 @@ class RelaxedEnumValueCompletionTest : ExplytInspectionJavaTestCase() {
             """.trimIndent()
         )
 
-        assertLookupElements("REQUEST_HEADERS", "RESPONSE_HEADERS")
+        assertLookupElements("request-headers", "response-headers")
     }
 
-    fun testYamlKebabCasePrefixInsertsDeclaredName() {
+    fun testYamlDeclaredPrefixInsertsRecommendedForm() {
         myFixture.configureByText(
             "application.yaml",
             """
             explyt:
               recording:
-                include: request-h<caret>
+                include: REQUEST_H<caret>
             """.trimIndent()
         )
         myFixture.completeBasic()
@@ -119,7 +122,7 @@ class RelaxedEnumValueCompletionTest : ExplytInspectionJavaTestCase() {
             """
             explyt:
               recording:
-                include: REQUEST_HEADERS
+                include: request-headers
             """.trimIndent()
         )
     }
@@ -137,10 +140,10 @@ class RelaxedEnumValueCompletionTest : ExplytInspectionJavaTestCase() {
         assertEquals(expected.toSet(), lookupElementStrings!!.toSet())
     }
 
-    private fun assertInsertsDeclaredName(text: String) {
+    private fun assertInsertsRecommendedForm(text: String) {
         myFixture.configureByText("application.properties", text)
         myFixture.completeBasic()
 
-        myFixture.checkResult("explyt.recording.include=REQUEST_HEADERS")
+        myFixture.checkResult("explyt.recording.include=request-headers")
     }
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/RelaxedEnumValueCompletionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/RelaxedEnumValueCompletionTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.codeInsight.CodeInsightSettings
+
+/**
+ * Value completion has to offer an enum constant for every spelling relaxed binding accepts, because Spring's own
+ * metadata ships the dashed lower-case form as the default value: only the declared name was a lookup string, so a
+ * user following the framework's own recommendation got "No suggestions".
+ */
+class RelaxedEnumValueCompletionTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBoot_3_1_1
+    )
+
+    private var savedCompletionCaseSensitive = CodeInsightSettings.FIRST_LETTER
+
+    override fun setUp() {
+        super.setUp()
+        // The lower-case prefix would match regardless of the fix under CodeInsightSettings.NONE, so pin the
+        // production default instead of trusting the test environment.
+        val settings = CodeInsightSettings.getInstance()
+        savedCompletionCaseSensitive = settings.completionCaseSensitive
+        settings.completionCaseSensitive = CodeInsightSettings.FIRST_LETTER
+        myFixture.addClass(
+            """
+            package com.explyt;
+
+            public enum RecordingInclude {
+                TIME_TAKEN, REQUEST_HEADERS, RESPONSE_HEADERS
+            }
+            """.trimIndent()
+        )
+        myFixture.copyFileToProject(
+            "collectionEnumValue/META-INF/additional-spring-configuration-metadata.json",
+            "META-INF/additional-spring-configuration-metadata.json"
+        )
+    }
+
+    override fun tearDown() {
+        try {
+            CodeInsightSettings.getInstance().completionCaseSensitive = savedCompletionCaseSensitive
+        } catch (e: Throwable) {
+            addSuppressedException(e)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testLowerCasePrefixOffersConstants() = assertVariants(
+        "explyt.recording.include=r<caret>",
+        "REQUEST_HEADERS", "RESPONSE_HEADERS"
+    )
+
+    fun testUpperCasePrefixStillOffersConstants() = assertVariants(
+        "explyt.recording.include=R<caret>",
+        "REQUEST_HEADERS", "RESPONSE_HEADERS"
+    )
+
+    fun testEmptyPrefixOffersAllConstants() = assertVariants(
+        "explyt.recording.include=<caret>",
+        "TIME_TAKEN", "REQUEST_HEADERS", "RESPONSE_HEADERS"
+    )
+
+    fun testKebabCasePrefixInsertsDeclaredName() =
+        assertInsertsDeclaredName("explyt.recording.include=request-h<caret>")
+
+    fun testSnakeCasePrefixInsertsDeclaredName() =
+        assertInsertsDeclaredName("explyt.recording.include=request_h<caret>")
+
+    fun testDeclaredPrefixInsertsDeclaredName() =
+        assertInsertsDeclaredName("explyt.recording.include=REQUEST_H<caret>")
+
+    fun testFullKebabCaseValueInsertsDeclaredName() =
+        assertInsertsDeclaredName("explyt.recording.include=request-headers<caret>")
+
+    fun testScalarEnumOffersConstantsForLowerCasePrefix() = assertVariants(
+        "explyt.recording.single=r<caret>",
+        "REQUEST_HEADERS", "RESPONSE_HEADERS"
+    )
+
+    fun testNonEnumValueTypeIsUnaffected() = assertVariants(
+        "explyt.recording.enabled=<caret>",
+        "true", "false"
+    )
+
+    fun testYamlLowerCasePrefixOffersConstants() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            explyt:
+              recording:
+                include: r<caret>
+            """.trimIndent()
+        )
+
+        assertLookupElements("REQUEST_HEADERS", "RESPONSE_HEADERS")
+    }
+
+    fun testYamlKebabCasePrefixInsertsDeclaredName() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            explyt:
+              recording:
+                include: request-h<caret>
+            """.trimIndent()
+        )
+        myFixture.completeBasic()
+
+        myFixture.checkResult(
+            """
+            explyt:
+              recording:
+                include: REQUEST_HEADERS
+            """.trimIndent()
+        )
+    }
+
+    private fun assertVariants(text: String, vararg expected: String) {
+        myFixture.configureByText("application.properties", text)
+
+        assertLookupElements(*expected)
+    }
+
+    private fun assertLookupElements(vararg expected: String) {
+        myFixture.completeBasic()
+        val lookupElementStrings = myFixture.lookupElementStrings
+        assertNotNull("expected a completion popup, got a single auto-inserted item", lookupElementStrings)
+        assertEquals(expected.toSet(), lookupElementStrings!!.toSet())
+    }
+
+    private fun assertInsertsDeclaredName(text: String) {
+        myFixture.configureByText("application.properties", text)
+        myFixture.completeBasic()
+
+        myFixture.checkResult("explyt.recording.include=REQUEST_HEADERS")
+    }
+}

--- a/modules/spring-core/testdata/java/inspection/collectionEnumValue/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/spring-core/testdata/java/inspection/collectionEnumValue/META-INF/additional-spring-configuration-metadata.json
@@ -30,6 +30,11 @@
       "name": "explyt.recording.single",
       "type": "com.explyt.RecordingInclude",
       "description": "A single item to include."
+    },
+    {
+      "name": "explyt.recording.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether recording is enabled."
     }
   ],
   "hints": []


### PR DESCRIPTION
In `application.properties`, on `management.httpexchanges.recording.include=`, typing `R` offered the enum constants but typing `r` said **"No suggestions"** — and the lower-case dashed spelling is exactly what Spring recommends: the metadata for that key ships `defaultValue: ["time-taken", "request-headers", "response-headers"]`.

Resolution and highlighting of such values already work (#299 added `PropertyUtil.findEnumConstant`); completion was the last place that still insisted on the declared casing.

## Cause

`ValueHintReference.getVariantsByPropertyType` built each variant with `LookupElementBuilder.create(field)`, whose only lookup string is the declared name. The platform prefix matcher therefore rejected `r` against `REMOTE_ADDRESS` under the default `CodeInsightSettings.FIRST_LETTER`, and no spelling with `-` could ever match a name containing `_`.

## Fix

Enum constants now carry the typable relaxed spellings as **additional lookup strings** — lower snake case and kebab case, derived from the constant name next to `findEnumConstant` so resolution and completion share one notion of a relaxed spelling.

**The inserted text is unchanged: the declared constant name.** `withCaseSensitivity(false)` was tried first and rejected — it makes the platform echo the case of the typed prefix, so `request-h` inserted `request_headers`. Keeping case sensitivity on is what guarantees `REQUEST_HEADERS` lands in the file; only matching became relaxed.

Same commit also narrows the variant filter from "any non-private field" to `PsiEnumConstant`, matching what `findEnumConstant` resolves — completion could previously offer a plain static field that then failed to resolve.

## Before / after

| typed prefix | before | after | inserted |
|---|---|---|---|
| `R` | 6 constants | 6 constants | `REQUEST_HEADERS` |
| `r` | **No suggestions** | 6 constants | `REQUEST_HEADERS` |
| `REQUEST_H` | `REQUEST_HEADERS` | `REQUEST_HEADERS` | `REQUEST_HEADERS` |
| `request-h` | **No suggestions** | `REQUEST_HEADERS` | `REQUEST_HEADERS` |
| `request_h` | **No suggestions** | `REQUEST_HEADERS` | `REQUEST_HEADERS` |
| `request-headers` | **No suggestions** | `REQUEST_HEADERS` | `REQUEST_HEADERS` |

Hint-provided values (`getVariantsByHint`) were left alone: those literals come from metadata already written in the spelling the user types, so there is no declared-name mismatch to relax.

## Verification

New `RelaxedEnumValueCompletionTest` (11 tests, `.properties` and YAML). It pins `CodeInsightSettings.completionCaseSensitive` to the production default `FIRST_LETTER` in `setUp` and restores it in `tearDown`, because under `NONE` a lower-case prefix matches even without the fix and the test would prove nothing.

Red phase without the production change: 7 failures, all on the assertion — `expected:<[REQUEST_HEADERS, RESPONSE_HEADERS]> but was:<[]>` for the lower-case prefixes and `FileComparisonFailedError` for the dashed/underscored ones. Green: 11/11.

Regression: 31 classes / 171 tests across `com.explyt.spring.core.properties.*` and `com.explyt.spring.core.completion.properties.*` — 0 failures, 0 errors. `CollectionEnumValueReferenceTest`, `ArrayAndMapEnumValueReferenceTest` and `RelaxedEnumValueInspectionTest` stay green.


---

## Follow-up commit: the inserted text is now Spring's recommended spelling

The first commit made completion **match** every relaxed spelling while still **inserting** the declared `REQUEST_HEADERS`. That inserted form is one Spring itself never writes. Measured on `spring-boot-autoconfigure-3.5.13`, counting only enum-typed properties with a string `defaultValue`:

| form | count | examples |
|---|---|---|
| lower-case | 51 | `never`, `always`, `graceful`, `ncsa` |
| kebab-case | 13 | `read-uncommitted`, `fail-on-existing`, `on-save`, `path-pattern-parser` |
| `SCREAMING_SNAKE` | **0** | — (the 20 apparent hits were `DataSize` values such as `8KB`) |

So the recommended spelling is `constantName.lowercase().replace('_', '-')`, and that is what accepting a completion item now inserts.

### Mechanism

`LookupElementBuilder.create(constant, kebabForm)` — the two-argument overload keeps the `PsiEnumConstant` as the lookup **object** (icon, rendering, `Ctrl+Q`) while making `kebabForm` the lookup **string**, which is what gets inserted. `withLookupStrings(relaxedValueSpellings(name) + name)` keeps `REQ`, `request_h` and `request-h` all matching, and `withTailText(" REQUEST_HEADERS", grayed = true)` keeps the declared constant visible in the popup.

`withCaseSensitivity(false)` is still avoided: it also drives `LookupUtil.getCaseCorrectedLookupString`, which echoes the typed prefix's case into the inserted text. The literal now comes from our own set instead.

The single canonical helper is `PropertyUtil.recommendedValueSpelling`, and `relaxedValueSpellings` is expressed in terms of it, so there is exactly one normalisation in the package.

### Before / after (this commit)

| typed prefix | matched before | matched now | inserted before | inserted now |
|---|---|---|---|---|
| `REQ` | ✔ | ✔ | `REQUEST_HEADERS` | `request-headers` |
| `r` | ✔ | ✔ | `REQUEST_HEADERS` | `request-headers` |
| `request-h` | ✔ | ✔ | `REQUEST_HEADERS` | `request-headers` |
| `request_h` | ✔ | ✔ | `REQUEST_HEADERS` | `request-headers` |

### Verification

`RelaxedEnumValueCompletionTest` grew to 12 tests and its insertion assertions were updated from the declared name to the kebab form — that change of expectation *is* the feature. Added `testDeclaredNamePrefixStillMatches` (`REQ` → `request-headers`) so the declared spelling is proven to keep matching, and `testYamlDeclaredPrefixInsertsRecommendedForm` for the YAML path.

Red phase with the production change stashed: 11 of 12 failed on the assertion — `expected:<[request-headers, response-headers]> but was:<[REQUEST_HEADERS, RESPONSE_HEADERS]>` for the popup contents and `FileComparisonFailedError` for every insertion. Green: 12/12.

Nine pre-existing completion tests asserted the declared enum casing (`DEBUG`/`TUESDAY`, both the `handle-as` provider path and plain enum property types, Java and Kotlin, `.properties` and YAML); their expectations were updated to the lower-case/kebab form.

Regression: 32 classes / 179 tests across `com.explyt.spring.core.properties.*`, `com.explyt.spring.core.completion.properties.*` and `RelaxedEnumValueInspectionTest` — 0 failures, 0 errors.
