### PR TITLE
fix: Cache the @PropertySource lookup behind isConfigurationPropertyFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Spring Core
+- fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
 - fix: Report the `BootstrapRegistry`, `@JsonComponent`/`@JsonMixin` and `@EntityScan` migrations when the legacy symbol no longer resolves after a Spring Boot 4 upgrade
 - fix: Report the `@MockBean` / `@SpyBean` migration when the legacy annotation no longer resolves after a Spring Boot 4 upgrade
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/SpringCoreUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/SpringCoreUtil.kt
@@ -44,6 +44,7 @@ import com.explyt.util.ExplytPsiUtil.psiClassType
 import com.explyt.util.ExplytPsiUtil.resolvedPsiClass
 import com.explyt.util.ExplytPsiUtil.returnPsiClass
 import com.explyt.util.ExplytPsiUtil.returnPsiType
+import com.explyt.util.CacheKeyStore
 import com.explyt.util.ModuleUtil
 import com.explyt.util.SpringBaseClasses.CORE_ENVIRONMENT
 import com.explyt.util.runReadNonBlocking
@@ -65,7 +66,10 @@ import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.FileContextUtil
 import com.intellij.psi.search.PsiShortNamesCache
 import com.intellij.psi.search.searches.ClassInheritorsSearch
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.InheritanceUtil
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiUtil
 import com.intellij.xdebugger.XDebuggerManager
 import org.jetbrains.kotlin.idea.KotlinLanguage
@@ -104,6 +108,30 @@ object SpringCoreUtil {
             return true
         }
 
+        return isPropertySourceFile(psiFile)
+    }
+
+    /**
+     * Only the index-backed tail of [isConfigurationPropertyFile] is cached: it is the part that searches every
+     * `@PropertySource` in the module. Line-marker providers ask once per PSI leaf, so without the cache an ordinary
+     * `messages.properties` triggers dozens of project-wide index searches per highlighting pass.
+     *
+     * Dependencies: [PsiModificationTracker.MODIFICATION_COUNT] covers editing or adding a `@PropertySource`,
+     * [ProjectRootManager] covers source-root and dependency changes that move the resolved file or the annotation
+     * class out of scope.
+     */
+    private fun isPropertySourceFile(psiFile: PsiFile): Boolean {
+        return CachedValuesManager.getCachedValue(psiFile) {
+            CachedValueProvider.Result.create(
+                computeIsPropertySourceFile(psiFile),
+                PsiModificationTracker.MODIFICATION_COUNT,
+                ProjectRootManager.getInstance(psiFile.project),
+                CacheKeyStore.cacheReset
+            )
+        }
+    }
+
+    private fun computeIsPropertySourceFile(psiFile: PsiFile): Boolean {
         return runReadNonBlocking {
             val propertySourceFilePaths = SpringPropertySourceSearch.getInstance(psiFile.project)
                 .findPropertySourceFilePaths(psiFile)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/IsConfigurationPropertyFileTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/IsConfigurationPropertyFileTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.util
+
+import com.explyt.spring.test.ExplytBaseLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.explyt.util.runReadNonBlocking
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+
+class IsConfigurationPropertyFileTest : ExplytBaseLightTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springBootAutoConfigure_3_1_1
+    )
+
+    fun testApplicationPropertiesIsRecognized() {
+        addConfigClass(propertySourcePath = null)
+        val psiFile = myFixture.addFileToProject("application.properties", "server.port=8080")
+
+        assertTrue(isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testApplicationYamlIsRecognized() {
+        addConfigClass(propertySourcePath = null)
+        val psiFile = myFixture.addFileToProject("application.yaml", "server:\n  port: 8080")
+
+        assertTrue(isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testUnrelatedPropertiesIsNotRecognized() {
+        addConfigClass(propertySourcePath = null)
+        val psiFile = myFixture.addFileToProject("messages.properties", "greeting.hello=Hello")
+
+        assertFalse(isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testUnrelatedYamlIsNotRecognized() {
+        addConfigClass(propertySourcePath = null)
+        val psiFile = myFixture.addFileToProject("messages.yaml", "greeting:\n  hello: Hello")
+
+        assertFalse(isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testPropertySourcePropertiesIsRecognized() {
+        addConfigClass(propertySourcePath = "classpath:custom.properties")
+        val psiFile = myFixture.addFileToProject("custom.properties", "custom.key=value")
+
+        assertTrue(isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testPropertySourceYamlIsRecognized() {
+        addConfigClass(propertySourcePath = "classpath:custom.yml")
+        val psiFile = myFixture.addFileToProject("custom.yml", "custom:\n  key: value")
+
+        assertTrue(isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testBecomesPropertySourceAfterEdit() {
+        val configFile = addConfigClass(propertySourcePath = null)
+        val psiFile = myFixture.addFileToProject("custom.properties", "custom.key=value")
+
+        assertFalse("not a property source before the edit", isConfigurationPropertyFile(psiFile))
+
+        setFileText(configFile, configClassText("classpath:custom.properties"))
+
+        assertTrue("must be a property source after the edit", isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testStopsBeingPropertySourceAfterEdit() {
+        val configFile = addConfigClass(propertySourcePath = "classpath:custom.properties")
+        val psiFile = myFixture.addFileToProject("custom.properties", "custom.key=value")
+
+        assertTrue("a property source before the edit", isConfigurationPropertyFile(psiFile))
+
+        setFileText(configFile, configClassText(null))
+
+        assertFalse("must not be a property source after the edit", isConfigurationPropertyFile(psiFile))
+    }
+
+    fun testBecomesYamlPropertySourceAfterEdit() {
+        val configFile = addConfigClass(propertySourcePath = null)
+        val psiFile = myFixture.addFileToProject("custom.yml", "custom:\n  key: value")
+
+        assertFalse("not a property source before the edit", isConfigurationPropertyFile(psiFile))
+
+        setFileText(configFile, configClassText("classpath:custom.yml"))
+
+        assertTrue("must be a property source after the edit", isConfigurationPropertyFile(psiFile))
+    }
+
+    private fun addConfigClass(propertySourcePath: String?): PsiFile =
+        myFixture.addFileToProject("com/example/AppConfig.java", configClassText(propertySourcePath))
+
+    private fun configClassText(propertySourcePath: String?): String {
+        val annotation = propertySourcePath?.let { "@PropertySource(\"$it\")\n" } ?: ""
+        return """
+            package com.example;
+            
+            import org.springframework.context.annotation.Configuration;
+            import org.springframework.context.annotation.PropertySource;
+            
+            @Configuration
+            $annotation public class AppConfig {
+            }
+        """.trimIndent()
+    }
+
+    private fun setFileText(psiFile: PsiFile, text: String) {
+        val documentManager = PsiDocumentManager.getInstance(project)
+        WriteCommandAction.runWriteCommandAction(project) {
+            val document = documentManager.getDocument(psiFile) ?: error("no document for ${psiFile.name}")
+            document.replaceString(0, document.textLength, text)
+            documentManager.commitDocument(document)
+        }
+    }
+
+    private fun isConfigurationPropertyFile(psiFile: PsiFile): Boolean =
+        ApplicationManager.getApplication()
+            .executeOnPooledThread<Boolean> { runReadNonBlocking { SpringCoreUtil.isConfigurationPropertyFile(psiFile) } }
+            .get()
+}


### PR DESCRIPTION
## Problem

`RelatedItemLineMarkerProvider.collectNavigationMarkers(List, …)` dispatches to the single-element overload **once per PSI element** of the batch. `PropertyLineMarkerProvider` gates on `SpringCoreUtil.isConfigurationPropertyFile(element.containingFile)`, so that helper was asked once per PSI leaf.

For any `.properties`/`.yaml`/`.yml` file that is **not** named `application*`, **not** prefixed `application-`, and **not** inside a `config/` directory, the answer fell through to an uncached tail: `SpringPropertySourceSearch.findPropertySourceFilePaths` runs an `AnnotatedElementsSearch` over every `@PropertySource`/`@PropertySources` in the module, then `VfsUtil.findRelativeFile` per candidate.

Net effect: opening an ordinary non-Spring `.properties` file — an i18n bundle, `gradle.properties`, `logback.properties` — ran a project-wide index search per PSI leaf, always returning `false`. `isConfigurationPropertyFile` has **22 production call sites** (annotators, six completion contributors, five inspections, reference providers, documentation provider, intentions, line markers), so caching it centrally benefits all of them.

## Measurement

A temporary `AtomicInteger` around the index-backed tail, counted over one `myFixture.doHighlighting()` pass:

| fixture file | PSI leaves | before | after |
|---|---|---|---|
| `messages.properties` | 19 | **53** | **3** |
| `messages.yaml` | 29 | **120** | **2** |

The counter was removed before committing.

## The fix

The index-backed tail is extracted into `isPropertySourceFile` and cached with `CachedValuesManager.getCachedValue(psiFile)`.

**Cache dependencies**

- `PsiModificationTracker.MODIFICATION_COUNT` — invalidates when a `@PropertySource` is added, edited or removed. This is what collapses once-per-leaf into once-per-PSI-modification, which is the entire win inside a highlighting pass.
- `ProjectRootManager` — the resolved path is relative to the module source root, and the `@PropertySource` class is looked up in the libraries scope; both change with source roots and dependencies, which no PSI tracker covers. `SpringBootUtil.getSpringBootVersion` uses the same tracker for the same reason.
- `CacheKeyStore.cacheReset` — the repo-wide manual reset hook, as in `LibraryClassCache`.

**Deliberately left OUTSIDE the cache** — these are evaluated before it, and both are correctness decisions rather than performance ones:

- `SpringPropertyFolderState.isUserPropertyFolder` is a `SimplePersistentStateComponent` holding a user-managed folder list. It exposes no modification tracker and fires no event, so a cached `true` could not be invalidated when the user removes a property folder — the plugin would keep treating an unrelated file as Spring configuration until the next PSI edit. It is a plain string-prefix check over a usually-empty list, so it is cheap anyway.
- `ConfigurationPropertiesInjector.isValidPlace` applies to an **injected** properties fragment, whose context element (`FileContextUtil.getFileContext`) lives in another file. Injected `PsiFile` identity is not a stable cache key, so this branch returns before the cache is consulted.

A wrong cached `true` is worse than a slow `false`, so anything that cannot be invalidated stays outside.

## Tests

New `IsConfigurationPropertyFileTest` (9 tests). Red-green verified by removing `PsiModificationTracker.MODIFICATION_COUNT` from the dependency list:

| test | with correct deps | with `MODIFICATION_COUNT` removed |
|---|---|---|
| `testApplicationPropertiesIsRecognized` | PASS | PASS |
| `testApplicationYamlIsRecognized` | PASS | PASS |
| `testUnrelatedPropertiesIsNotRecognized` | PASS | PASS |
| `testUnrelatedYamlIsNotRecognized` | PASS | PASS |
| `testPropertySourcePropertiesIsRecognized` | PASS | PASS |
| `testPropertySourceYamlIsRecognized` | PASS | PASS |
| `testBecomesPropertySourceAfterEdit` | PASS | **FAIL** |
| `testStopsBeingPropertySourceAfterEdit` | PASS | **FAIL** |
| `testBecomesYamlPropertySourceAfterEdit` | PASS | **FAIL** |

The three after-edit tests are the invalidation tests: they add or remove a `@PropertySource("classpath:custom.properties")` on a `@Configuration` class and re-query. They are the ones that catch an over-aggressive dependency choice, and they genuinely fail without it.

## Regression runs

Three sequential `:spring-core:test --rerun` batches, **259 tests, 0 failures**:

- property/YAML completion + `PropertyLineMarkerProviderTest` — 19 classes, 122 tests
- property inspections (`SpringPropertiesInspectionTest` java+kotlin, Boot 3/4 property migration, metadata) — 6 classes, 28 tests
- property references, `FileReferenceContributorTest`, `PropertyStringUsagesSearcherTest`, enum value references — 18 classes, 109 tests

## Out of scope

The prior review's finding F4 (per-element `PluginIds.…isEnabledWithUltimate()` in `PropertyLineMarkerProvider`, `ConfigurationPropertyLineMarkerProvider` and `EventListenerLineMarkerProvider`, allocating a `PluginId` on every call, and placed *before* the cheap early-outs) still stands in current `main` and is deliberately not folded into this PR.
