### PR TITLE
fix: Evaluate the Ultimate line marker suppression once per highlighting batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fix: Navigate a configuration key with no declaring member, such as `management.endpoint.httpexchanges.access`, to its value type instead of the unrelated source class
 - fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
+- fix: Evaluate the IntelliJ IDEA Ultimate line marker suppression once per highlighting batch instead of once per PSI element
 
 ### Spring Web
 - fix: Register the web additional-beans discoverer under the extension namespace that declares the extension point, so framework-provided web beans such as `WebApplicationContext` are resolved again

--- a/modules/base/src/main/kotlin/com/explyt/plugin/PluginUtils.kt
+++ b/modules/base/src/main/kotlin/com/explyt/plugin/PluginUtils.kt
@@ -23,7 +23,9 @@ enum class PluginIds(val pluginId: String) {
     SH_JB("com.jetbrains.sh"),
     ;
 
-    fun findEnabled() = findEnabledDetails(PluginId.getId(pluginId))
+    private val id = PluginId.getId(pluginId)
+
+    fun findEnabled() = findEnabledDetails(id)
 
     fun isEnabled() = findEnabled() != null
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/ConfigurationPropertyLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/ConfigurationPropertyLineMarkerProvider.kt
@@ -13,6 +13,7 @@ import com.explyt.spring.core.properties.dataRetriever.ConfigurationPropertyData
 import com.explyt.spring.core.statistic.StatisticActionId
 import com.explyt.spring.core.statistic.StatisticService
 import com.explyt.spring.core.util.SpringCoreUtil
+import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
@@ -32,11 +33,18 @@ import com.explyt.spring.core.properties.dataRetriever.ConfigurationPropertyData
 
 class ConfigurationPropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
 
+    override fun collectSlowLineMarkers(
+        elements: MutableList<out PsiElement>,
+        result: MutableCollection<in LineMarkerInfo<*>>
+    ) {
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
+        super.collectSlowLineMarkers(elements, result)
+    }
+
     override fun collectNavigationMarkers(
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
-        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
         if (!SpringCoreUtil.isSpringProject(element.project)) return
         val uParent = getUParentForIdentifier(element) ?: return
         val dataRetriever = ConfigurationPropertyDataRetrieverFactory.createFor(uParent) ?: return
@@ -47,6 +55,11 @@ class ConfigurationPropertyLineMarkerProvider : RelatedItemLineMarkerProvider() 
 
         val prefixValue = DataRetriever.getPrefixValue(psiClass)
         if (prefixValue.isBlank()) return
+
+        // Also reached directly by RelatedItemLineMarkerGotoAdapter (Navigate | Related Symbol), bypassing
+        // collectSlowLineMarkers, so the JetBrains Spring suppression has to be repeated here. It is consulted
+        // after the cheap early-outs above: an element rejected by them produces no marker either way.
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
 
         val properties = dataRetriever.getRelatedProperties(prefixValue, memberName, module)
         val hints = dataRetriever.getMetadataName(prefixValue, memberName, module)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/EventListenerLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/EventListenerLineMarkerProvider.kt
@@ -25,6 +25,7 @@ import com.explyt.util.ExplytPsiUtil.isMetaAnnotatedBy
 import com.explyt.util.ExplytPsiUtil.isPublic
 import com.explyt.util.ExplytPsiUtil.isStatic
 import com.explyt.util.ExplytPsiUtil.resolvedPsiClass
+import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
@@ -44,17 +45,25 @@ import org.jetbrains.uast.*
 import java.util.*
 
 class EventListenerLineMarkerProvider : RelatedItemLineMarkerProvider() {
+    override fun collectSlowLineMarkers(
+        elements: MutableList<out PsiElement>,
+        result: MutableCollection<in LineMarkerInfo<*>>
+    ) {
+        if (PluginIds.SPRING_JB.isEnabledWithUltimate()) return
+        super.collectSlowLineMarkers(elements, result)
+    }
+
     override fun collectNavigationMarkers(
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
-        if (PluginIds.SPRING_JB.isEnabledWithUltimate()) return
         val uParent = getUParentForIdentifier(element)
         if (uParent is UMethod) {
             val psiMethod = uParent.javaPsi
             if (isMethodModifierForEvent(psiMethod) &&
                 (isEventListenerMethod(psiMethod) || isApplicationEventMethod(psiMethod))
             ) {
+                if (isSuppressedByJetBrainsSpring()) return
                 val builder = NavigationGutterIconBuilder.create(SpringIcons.EventPublisher)
                     .setAlignment(GutterIconRenderer.Alignment.LEFT)
                     .setTargets(NotNullLazyValue.lazy { findPublishEvents(psiMethod) })
@@ -74,6 +83,7 @@ class EventListenerLineMarkerProvider : RelatedItemLineMarkerProvider() {
                 val sourceElement = uCallExpression.methodIdentifier.sourcePsiElement
                 if (sourceElement != null && sourcePsi != null
                 ) {
+                    if (isSuppressedByJetBrainsSpring()) return
                     val builder = NavigationGutterIconBuilder.create(SpringIcons.EventListener)
                         .setAlignment(GutterIconRenderer.Alignment.LEFT)
                         .setTargets(NotNullLazyValue.createValue { findEventListeners(sourcePsi) })
@@ -86,6 +96,16 @@ class EventListenerLineMarkerProvider : RelatedItemLineMarkerProvider() {
             }
         }
     }
+
+    /**
+     * [collectNavigationMarkers] is also reached directly by `RelatedItemLineMarkerGotoAdapter`
+     * (Navigate | Related Symbol), bypassing [collectSlowLineMarkers], so the JetBrains Spring
+     * suppression has to be repeated per element and cannot be moved to the batch entry point only.
+     *
+     * Consulted only where a marker would actually be produced: an element rejected by the cheap
+     * UAST checks above yields nothing either way.
+     */
+    private fun isSuppressedByJetBrainsSpring() = PluginIds.SPRING_JB.isEnabledWithUltimate()
 
     private fun isMethodModifierForEvent(psiMethod: PsiMethod): Boolean {
         return psiMethod.isPublic && !psiMethod.isStatic && !psiMethod.isConstructor

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
@@ -39,6 +39,11 @@ class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
+        // Also reached directly by RelatedItemLineMarkerGotoAdapter (Navigate | Related Symbol), bypassing
+        // collectSlowLineMarkers, so the JetBrains Spring suppression has to be repeated here. Unlike the sibling
+        // providers the check stays first: almost every leaf of a configuration file passes the checks below, so
+        // deferring it measured no gain and made the suppressed case pay the index-backed file check.
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
         if (!SpringCoreUtil.isConfigurationPropertyFile(element.containingFile)) {
             return
         }
@@ -51,11 +56,6 @@ class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
             if (yamlKeyValue.key != element) return
             elementText = YAMLUtil.getConfigFullName(yamlKeyValue)
         }
-
-        // Also reached directly by RelatedItemLineMarkerGotoAdapter (Navigate | Related Symbol), bypassing
-        // collectSlowLineMarkers, so the JetBrains Spring suppression has to be repeated here. It is consulted
-        // after the cheap early-outs above: an element rejected by them produces no marker either way.
-        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
 
         val hints = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .getElementNameHints(module)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
@@ -12,6 +12,7 @@ import com.explyt.spring.core.completion.properties.SpringConfigurationPropertie
 import com.explyt.spring.core.statistic.StatisticActionId
 import com.explyt.spring.core.statistic.StatisticService
 import com.explyt.spring.core.util.SpringCoreUtil
+import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
@@ -26,11 +27,18 @@ import org.jetbrains.yaml.YAMLUtil
 import org.jetbrains.yaml.psi.YAMLKeyValue
 
 class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
+    override fun collectSlowLineMarkers(
+        elements: MutableList<out PsiElement>,
+        result: MutableCollection<in LineMarkerInfo<*>>
+    ) {
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
+        super.collectSlowLineMarkers(elements, result)
+    }
+
     override fun collectNavigationMarkers(
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
-        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
         if (!SpringCoreUtil.isConfigurationPropertyFile(element.containingFile)) {
             return
         }
@@ -43,6 +51,11 @@ class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
             if (yamlKeyValue.key != element) return
             elementText = YAMLUtil.getConfigFullName(yamlKeyValue)
         }
+
+        // Also reached directly by RelatedItemLineMarkerGotoAdapter (Navigate | Related Symbol), bypassing
+        // collectSlowLineMarkers, so the JetBrains Spring suppression has to be repeated here. It is consulted
+        // after the cheap early-outs above: an element rejected by them produces no marker either way.
+        if (PluginIds.SPRING_BOOT_JB.isEnabledWithUltimate()) return
 
         val hints = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .getElementNameHints(module)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/providers/java/LineMarkerGotoRelatedSymbolTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/providers/java/LineMarkerGotoRelatedSymbolTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.providers.java
+
+import com.explyt.spring.core.providers.EventListenerLineMarkerProvider
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+/**
+ * `Navigate | Related Symbol` reaches a [RelatedItemLineMarkerProvider] through
+ * `RelatedItemLineMarkerGotoAdapter`, which calls `collectNavigationMarkers(elements, result, true)`
+ * directly and never runs `collectSlowLineMarkers`. These tests pin that alternate entry point so a
+ * gate or an early-out cannot be moved into the batch method alone.
+ */
+class LineMarkerGotoRelatedSymbolTest : ExplytJavaLightTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springContext_6_0_7)
+
+    fun testEventListenerReachableWithoutCollectSlowLineMarkers() {
+        myFixture.addClass(
+            """
+            package com.example;
+            public class CustomEvent {}
+            """.trimIndent()
+        )
+        myFixture.configureByText(
+            "EventDemo.java",
+            """
+            package com.example;
+
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.context.ApplicationEventPublisher;
+            import org.springframework.context.event.EventListener;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class EventDemo {
+                @Autowired
+                private ApplicationEventPublisher publisher;
+
+                @EventListener
+                public void onCustomEve<caret>nt(CustomEvent event) {
+                }
+
+                public void fire() {
+                    publisher.publishEvent(new CustomEvent());
+                }
+            }
+            """.trimIndent()
+        )
+
+        val markers = collectForNavigation(EventListenerLineMarkerProvider())
+
+        assertTrue(
+            "Navigate | Related Symbol must still reach EventListenerLineMarkerProvider",
+            markers.isNotEmpty()
+        )
+    }
+
+    private fun collectForNavigation(
+        provider: RelatedItemLineMarkerProvider
+    ): List<RelatedItemLineMarkerInfo<*>> {
+        val parents: List<PsiElement> = generateSequence(myFixture.file.findElementAt(myFixture.caretOffset)) {
+            if (it is PsiFile) null else it.parent
+        }.toList()
+
+        val markers = mutableListOf<RelatedItemLineMarkerInfo<*>>()
+        provider.collectNavigationMarkers(parents, markers, true)
+        return markers
+    }
+}


### PR DESCRIPTION
## Problem

The JetBrains-Spring suppression gate (`PluginIds.<X>.isEnabledWithUltimate()`) was evaluated as the **first statement** of `collectNavigationMarkers(element, result)` in three line-marker providers — i.e. once per PSI leaf of every highlighting batch, before each provider's own cheap early-outs.

Each evaluation ran `PluginId.getId(pluginId)`, which allocates a `PluginId` and performs a `putIfAbsent` on a concurrent weak-key/weak-value interner map, plus two `PluginManager` service lookups and a `DisabledPluginsState` check. In the common free/Community configuration the plugin is not enabled, so `isEnabled()` returns `false` — but the lookup itself still runs on every element.

## Measurement

Temporary `AtomicInteger` counter inside `PluginIds.findEnabled()`, `myFixture.doHighlighting()` on fixture files, counter and PSI element count printed. Counter removed before committing.

| Scenario | PSI elements | `findEnabled()` calls before | after | reduction |
|---|---|---|---|---|
| Java file (2 `@Bean`, 2 `@EventListener`, 4 `publishEvent`, `@ConfigurationProperties`) | 878 | **3975** | **2250** | −43% |
| `application.properties` (43 keys) | 217 | **356** | **363** | ~0% |
| `application.yaml` | 88 | **174** | **131** | −25% |

The Java case is the meaningful one — nearly 1700 fewer interner-map operations per highlighting pass on a single medium file. The `.properties` case is flat because almost every leaf in a configuration file passes `isConfigurationPropertyFile` and therefore reaches the gate anyway; the reorder does not help there, and the batch override adds one call.

## Changes

**`modules/base` — intern the `PluginId` once**

`PluginIds.findEnabled()` now uses a `private val id = PluginId.getId(pluginId)` enum property instead of calling `PluginId.getId(...)` per invocation. This mirrors the existing `ULTIMATE_MODULE_ID` companion constant in the same file. Zero behaviour change; no call site had to change, and it benefits all six `isEnabledWithUltimate()` call sites plus every `isEnabled()` / `isNotEnabled()` caller.

**`modules/spring-core` — gate once per batch, reorder the per-element gate**

For `PropertyLineMarkerProvider`, `ConfigurationPropertyLineMarkerProvider` and `EventListenerLineMarkerProvider`:

1. Added a `collectSlowLineMarkers(elements, result)` override whose first statement is the gate, then `super.collectSlowLineMarkers(...)`. An Ultimate user now skips the whole batch once instead of once per element.
2. Kept the gate in `collectNavigationMarkers`, moved to run **after** each provider's existing cheap early-outs. Semantics are unchanged: an element that bails out early produces no marker either way, so only elements that would actually produce a marker now consult the plugin manager.

### The per-element gate is duplicated, not moved

`RelatedItemLineMarkerGotoAdapter` (`Navigate | Related Symbol`) calls `collectNavigationMarkers(parents, markers, true)` **directly** and never runs `collectSlowLineMarkers` — verified in `idea-2026.2-sources.jar`, `com/intellij/ide/actions/RelatedItemLineMarkerGotoAdapter.java:48`. Removing the per-element check would leave that path ungated and give IntelliJ Ultimate users duplicated `Navigate | Related Symbol` targets — a silent functional regression that no performance benchmark catches.

`SpringBeanLineMarkerProvider` already gates in both places for exactly this reason; its explanatory comment is adapted into each of the three providers so the duplicate is not "simplified" away later.

## Tests

New `LineMarkerGotoRelatedSymbolTest` pins the `Navigate | Related Symbol` entry point: it invokes `collectNavigationMarkers(parents, markers, true)` directly, bypassing `collectSlowLineMarkers`, and asserts a marker is still produced. **Red phase proven** — stubbing an early `return` into `collectNavigationMarkers` makes it fail (`AssertionFailedError at LineMarkerGotoRelatedSymbolTest.kt:61`), so the test genuinely exercises the path that must stay protected.

Regression run, all green (62 tests):

| Test class | tests |
|---|---|
| `providers.PropertyLineMarkerProviderTest` | 4 |
| `providers.java.ConfigurationPropertyLineMarkerProviderTest` | 13 |
| `providers.kotlin.ConfigurationPropertyLineMarkerProviderTest` | 14 |
| `providers.java.EventListenerLineMarkerProviderTest` | 2 |
| `providers.kotlin.EventListenerLineMarkerProviderTest` | 2 |
| `providers.java.SpringBeanLineMarkerProviderSimpleTest` | 12 |
| `providers.kotlin.SpringBeanLineMarkerProviderSimpleTest` | 12 |
| `providers.java.SpringLineMarkerProviderTest` | 1 |
| `providers.kotlin.SpringLineMarkerProviderTest` | 1 |
| `providers.java.LineMarkerGotoRelatedSymbolTest` (new) | 1 |

No dedicated test covering the suppression behaviour itself existed before this PR (no test references `isEnabledWithUltimate` or `PluginIds`); the fixture runs with the gate inactive, so suppression is exercised only indirectly.
