### PR TITLE
fix: Do not request the run configuration manager on the EDT during link self-healing (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 - fix: Evaluate the IntelliJ IDEA Ultimate line marker suppression once per highlighting batch instead of once per PSI element
+- fix: Do not freeze the UI while a project opens: the linked-project self-healing pass no longer requests the run configuration manager on the event dispatch thread
 
 ### Spring Web
 - fix: Register the web additional-beans discoverer under the extension namespace that declares the extension point, so framework-provided web beans such as `WebApplicationContext` are resolved again

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairService.kt
@@ -12,7 +12,6 @@ import com.explyt.spring.core.externalsystem.utils.NativeBootUtils
 import com.intellij.execution.RunManager
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.runReadActionBlocking
@@ -21,6 +20,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.concurrency.AppExecutorUtil
+import com.intellij.util.concurrency.ThreadingAssertions
 import org.jetbrains.annotations.VisibleForTesting
 import java.util.concurrent.Callable
 import java.util.concurrent.atomic.AtomicBoolean
@@ -46,12 +46,17 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
     private val repairRequestedAgain = AtomicBoolean(false)
 
     /**
-     * Schedules a coalesced repair pass off the EDT.
+     * Schedules a coalesced repair pass on a pooled thread.
      *
      * The callers are load-path listeners that can fire while `RunManager` is still initializing — `stateLoaded` is
-     * published from inside that initialization — and touching `RunManager.getInstance` from there re-enters the
-     * service container and fails with a cycle. The whole pass, including the cheap check, is therefore deferred
-     * until the current initialization has finished; a burst of load events collapses into a single pass.
+     * published from inside that initialization — so touching `RunManager.getInstance` inline re-enters the service
+     * container and fails with a cycle. The pass is therefore deferred, and a burst of load events collapses into a
+     * single pass.
+     *
+     * It must not be deferred *to the EDT*, which is what the pass originally did: requesting a project service that
+     * has not been created yet instantiates it synchronously, and the requesting thread is parked for the whole
+     * initialization. On the EDT that is a UI freeze, reported for `RunManager` in issue #294. A pooled thread waits
+     * for exactly the same initialization without blocking the UI.
      *
      * Events arriving while a pass is in flight are not dropped: they raise [repairRequestedAgain], which triggers
      * exactly one follow-up pass, so a configuration removed or added mid-pass is still observed.
@@ -61,8 +66,7 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
             repairRequestedAgain.set(true)
             return
         }
-        ApplicationManager.getApplication()
-            .invokeLater({ startRepair() }, ModalityState.nonModal(), project.disposed)
+        AppExecutorUtil.getAppExecutorService().execute { startRepair() }
     }
 
     /** Ends a pass and runs at most one follow-up for the events that arrived while it was in flight. */
@@ -76,24 +80,34 @@ class NativeLinkRepairService(private val project: Project) : Disposable {
     /**
      * Runs the dangling-link check in memory first: nothing is submitted unless a link actually needs repairing, so
      * a healthy project pays only a walk over the linked settings and never resolves PSI.
+     *
+     * The check deliberately runs *before* — and outside of — the read action below, because it is what forces the
+     * `RunManager` service to be created: doing that while holding the read lock would park this thread inside
+     * service initialization with the lock taken, stalling every write action queued behind it.
      */
     private fun startRepair() {
-        if (findDanglingSettings().isEmpty()) {
-            finishPass()
-            return
-        }
+        ThreadingAssertions.assertBackgroundThread()
+        var passHandedOver = false
+        try {
+            if (project.isDisposed || findDanglingSettings().isEmpty()) return
 
-        ReadAction.nonBlocking(Callable { computeRepairs() })
-            .expireWith(this)
-            .coalesceBy(this)
-            // Resolving a main class goes through JavaPsiFacade and the indexes, which are unavailable in dumb mode.
-            // Project open — the case this pass exists for — is exactly when indexing runs, and a failure here would
-            // waste the only scheduled attempt, so wait for smart mode instead.
-            .inSmartMode(project)
-            .finishOnUiThread(ModalityState.nonModal()) { applyRepairs(it) }
-            .submit(AppExecutorUtil.getAppExecutorService())
-            // onProcessed also covers cancellation and expiration, so the flag never stays stuck.
-            .onProcessed { finishPass() }
+            ReadAction.nonBlocking(Callable { computeRepairs() })
+                .expireWith(this)
+                .coalesceBy(this)
+                // Resolving a main class goes through JavaPsiFacade and the indexes, which are unavailable in dumb
+                // mode. Project open — the case this pass exists for — is exactly when indexing runs, and a failure
+                // here would waste the only scheduled attempt, so wait for smart mode instead.
+                .inSmartMode(project)
+                .finishOnUiThread(ModalityState.nonModal()) { applyRepairs(it) }
+                .submit(AppExecutorUtil.getAppExecutorService())
+                // onProcessed also covers cancellation and expiration, so the flag never stays stuck.
+                .onProcessed { finishPass() }
+            passHandedOver = true
+        } finally {
+            // A pooled pass can outlive the project that scheduled it and fail on an already-disposed service; the
+            // flag must be cleared on every exit, otherwise self-healing stays off for the rest of the session.
+            if (!passHandedOver) finishPass()
+        }
     }
 
     /** Synchronous variant for tests, which must not race the background pipeline. */

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairServiceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/NativeLinkRepairServiceTest.kt
@@ -17,6 +17,7 @@ import com.intellij.execution.RunManagerListener
 import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.testFramework.PlatformTestUtil
 
 /**
  * Tests for [NativeLinkRepairService] — the self-healing path for links whose stored run configuration name no
@@ -52,6 +53,31 @@ class NativeLinkRepairServiceTest : ExplytKotlinLightTestCase() {
         NativeLinkRepairService.getInstance(project).repairNow()
 
         assertEquals("Dashboard Prod", linkedName(mainFilePath))
+    }
+
+    /**
+     * The scheduled pass must run entirely off the EDT. `RunManager` is requested by the very first step of the pass,
+     * and requesting a project service that has not been created yet blocks the calling thread for the whole service
+     * initialization — on the EDT that is the freeze reported in issue #294. `startRepair` asserts the thread, so a
+     * regression back to `invokeLater` turns this test red instead of reaching users.
+     *
+     * The link points at a plain `main()` file rather than at the `@SpringBootApplication` one used elsewhere in this
+     * class, because `SpringRunConfigurationDetectService` auto-creates a configuration for every Spring Boot entry
+     * point it finds. Waiting for an asynchronous pass gives that detection time to run, and a second configuration
+     * on the same main class would make the match ambiguous — which the repair pass deliberately leaves alone.
+     */
+    fun testScheduledRepairRunsOffEdt() {
+        val mainFilePath = configurePlainMainFile()
+        linkProject(mainFilePath, storedName = "Dashboard VPC")
+        addSpringBootConfiguration("Dashboard Prod", mainClassName = "com.demo.PlainAppKt")
+
+        NativeLinkRepairService.getInstance(project).scheduleRepair()
+
+        PlatformTestUtil.waitWithEventsDispatching(
+            "Dangling link must be repaired by the scheduled pass",
+            { linkedName(mainFilePath) == "Dashboard Prod" },
+            10
+        )
     }
 
     /** Configurations sharing a main class differ in profiles and environment, so guessing one would be wrong. */
@@ -152,6 +178,18 @@ class NativeLinkRepairServiceTest : ExplytKotlinLightTestCase() {
         return RunnerAndConfigurationSettingsImpl(runManager(), runConfiguration)
     }
 
+    /** A `main()` that `SpringRunConfigurationDetectService` does not recognize, so no configuration is added for it. */
+    private fun configurePlainMainFile(): String = myFixture.configureByText(
+        "PlainApp.kt",
+        """
+        package com.demo
+
+        fun main(args: Array<String>) {
+            println(args.size)
+        }
+        """.trimIndent()
+    ).virtualFile.canonicalPath!!
+
     private fun configureDemoApplication(): String = myFixture.configureByText(
         "DemoApplication.kt",
         """
@@ -169,11 +207,14 @@ class NativeLinkRepairServiceTest : ExplytKotlinLightTestCase() {
         """.trimIndent()
     ).virtualFile.canonicalPath!!
 
-    private fun addSpringBootConfiguration(name: String): RunnerAndConfigurationSettingsImpl {
+    private fun addSpringBootConfiguration(
+        name: String,
+        mainClassName: String = "com.demo.DemoApplicationKt"
+    ): RunnerAndConfigurationSettingsImpl {
         val runManager = runManager()
         val runConfiguration = SpringBootConfigurationFactory.createTemplateConfiguration(project)
         runConfiguration.name = name
-        runConfiguration.mainClassName = "com.demo.DemoApplicationKt"
+        runConfiguration.mainClassName = mainClassName
         val rcSettings = RunnerAndConfigurationSettingsImpl(runManager, runConfiguration)
         runManager.addConfiguration(rcSettings)
         return rcSettings


### PR DESCRIPTION
Closes #294

## Problem

`NativeLinkRepairService` deferred its repair pass with `ApplicationManager.invokeLater`, so the first step of the pass — `findDanglingSettings()` → `RunManager.getInstance(project)` — ran on the EDT.

A project service is created *synchronously by the thread that first requests it*: the call parks in `ComponentManagerImplKt.runBlockingInitialization` → `LockSupport.parkNanos` until initialization completes. On the EDT that is a UI freeze, not a lookup.

Reported stack (identical in every affected event):

```
TransactionGuardImpl.runWithWritingAllowed          <- EDT
NativeLinkRepairService.scheduleRepair$lambda$0 (65)
NativeLinkRepairService.startRepair (81)
NativeLinkRepairService.findDanglingSettings (112)
RunManager$Companion.getInstance
ComponentManagerImplKt.runBlockingInitialization
LockSupport.parkNanos                               <- EDT parked
```

This is not a one-off: four separate Sentry events reproduce it on two IDE lines and two JDKs — `262.34.101` on IU-262 / Java 25 (three events) and `253.34.104` on IU-253 / Java 21 (one event).

The deferral itself is still required — `RunManagerListener.stateLoaded` is published from inside `RunManager` initialization, and touching the service inline re-enters the container and fails with a cycle. But *any* deferral breaks that cycle; the EDT was chosen without need.

## Fix

- `scheduleRepair` now schedules the pass on `AppExecutorUtil.getAppExecutorService()` instead of `invokeLater`. The pooled thread waits for exactly the same service initialization without blocking the UI.
- `startRepair` asserts `ThreadingAssertions.assertBackgroundThread()`, so a regression fails a test instead of reaching users.
- `findDanglingSettings()` deliberately stays **outside** `ReadAction.nonBlocking`: it is what materializes `RunManager`, and doing that under the read lock would park the thread inside service initialization while holding the lock, stalling every queued write action.
- The coalescing flag is cleared in a `finally`, and `project.isDisposed` is checked: a pooled pass can outlive the project that scheduled it, and a throw would otherwise disable self-healing for the rest of the session.

## Verification

New test `NativeLinkRepairServiceTest.testScheduledRepairRunsOffEdt` was proven red/green: with `invokeLater` restored it fails, with the fix it passes.

`./gradlew :spring-core:test --tests "com.explyt.spring.core.externalsystem.NativeLinkRepairServiceTest"` — 7/7 pass.
`./gradlew :spring-core:test --tests "com.explyt.spring.core.runconfiguration.ExplytRunManagerListenerTest"` — 4/4 pass.

Note for reviewers: the new test links a plain (non-Boot) `main()` file on purpose. `SpringRunConfigurationDetectService` auto-creates a run configuration for every `@SpringBootApplication` entry point, and an asynchronous test gives that detection time to fire — a second configuration on the same main class makes the match ambiguous, which the repair pass deliberately leaves alone.