### PR TITLE
fix: Do not initialize error reporting on the EDT while recording an action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - fix: Register the web additional-beans discoverer under the extension namespace that declares the extension point, so framework-provided web beans such as `WebApplicationContext` are resolved again
 - fix: Resolve `MockMvc` and `WebTestClient` autowired in tests as beans provided by test auto-configuration
 
+### Other
+- fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded
+
 ## 262.34.101 - 2026-08-18
 
 ### Spring Core

--- a/modules/base/base.gradle.kts
+++ b/modules/base/base.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
         }
         bundledPlugins(intellijPlugins)
     }
+    testImplementation("junit:junit:4.13.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 kotlin {

--- a/modules/base/src/main/kotlin/com/explyt/base/BoundedBuffer.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/BoundedBuffer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+/**
+ * A thread-safe FIFO buffer that keeps at most [capacity] most recent items, dropping the oldest ones.
+ *
+ * It exists so that a producer can hand work over without ever blocking on the consumer's slow setup: the lock here
+ * only ever guards a list operation, never the initialization the consumer performs after draining.
+ */
+class BoundedBuffer<T>(private val capacity: Int) {
+
+    init {
+        require(capacity > 0) { "capacity must be positive but was $capacity" }
+    }
+
+    private val items = ArrayDeque<T>()
+
+    /** Appends [item], evicting the oldest one when the buffer is full. */
+    @Synchronized
+    fun offer(item: T) {
+        items.addLast(item)
+        while (items.size > capacity) {
+            items.removeFirst()
+        }
+    }
+
+    /** Removes and returns everything buffered so far, in insertion order. */
+    @Synchronized
+    fun drain(): List<T> {
+        if (items.isEmpty()) return emptyList()
+        val drained = items.toList()
+        items.clear()
+        return drained
+    }
+
+    @Synchronized
+    fun isEmpty(): Boolean = items.isEmpty()
+}

--- a/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
@@ -7,9 +7,12 @@ package com.explyt.base
 
 import com.intellij.ide.plugins.PluginDetailsService
 import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.util.concurrency.AppExecutorUtil
 import io.sentry.Breadcrumb
 import io.sentry.IScope
+import io.sentry.ScopeType
 import io.sentry.Sentry
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -17,9 +20,15 @@ object SentryReporter {
 
     private const val DSN = "https://e45ddc59e273e25c659729f194b8009f@sentry.explyt.ai/4"
 
+    /** Matches Sentry's own `maxBreadcrumbs` default, so buffering cannot retain more than Sentry would keep. */
+    private const val MAX_PENDING_BREADCRUMBS = 100
+
     @Volatile
     private var initialized = false
     private val lock = ReentrantLock()
+
+    private val pendingBreadcrumbs = BoundedBuffer<Breadcrumb>(MAX_PENDING_BREADCRUMBS)
+    private val initializationScheduled = AtomicBoolean(false)
 
     private fun ensureInitialized() {
         if (initialized) return
@@ -36,7 +45,11 @@ object SentryReporter {
                     options.isEnableUncaughtExceptionHandler = false
                 }
 
-                Sentry.configureScope { scope ->
+                // GLOBAL for the same reason as breadcrumbs: the default scope type is ISOLATION, which Sentry 8
+                // keeps in a ThreadLocal. Initialization no longer runs on the thread that submits a report, so
+                // thread-scoped tags would only reach an event by being cloned when that thread forks its scopes.
+                // The global scope is shared by reference and merged into every event regardless of the thread.
+                Sentry.configureScope(ScopeType.GLOBAL) { scope ->
                     scope.setTag("os.name", properties.getProperty("os.name", "unknown"))
                     scope.setTag("os.version", properties.getProperty("os.version", "unknown"))
 
@@ -80,16 +93,62 @@ object SentryReporter {
             .filter { !it.isBuiltIn }
             .associate { it.id.idString to (it.version ?: "unknown") }
 
+    /**
+     * Records an action breadcrumb without ever initializing Sentry on the calling thread.
+     *
+     * This is called from `AnActionListener.afterActionPerformed`, i.e. on the EDT after *every* action. Sentry's
+     * initialization is not cheap — [collectNonBundledPlugins] reads the manifest of every active plugin — so paying
+     * for it here froze the UI on the first action after IDE start. Until Sentry is up, breadcrumbs are buffered and
+     * initialization is handed to a pooled thread; a burst of actions schedules it exactly once.
+     *
+     * Telemetry is best-effort: dropping the oldest breadcrumbs is preferable to delaying an action.
+     */
     fun addBreadcrumb(breadcrumb: Breadcrumb) {
-        ensureInitialized()
-        Sentry.addBreadcrumb(breadcrumb)
+        if (initialized) {
+            flushPendingBreadcrumbs()
+            recordBreadcrumb(breadcrumb)
+            return
+        }
+
+        pendingBreadcrumbs.offer(breadcrumb)
+        if (initializationScheduled.compareAndSet(false, true)) {
+            AppExecutorUtil.getAppExecutorService().execute {
+                ensureInitialized()
+                flushPendingBreadcrumbs()
+            }
+        }
+    }
+
+    /**
+     * Also called from the fast path above, because a breadcrumb can be buffered by another thread just after the
+     * flush that follows initialization; without this it would stay in the buffer until the next report.
+     */
+    private fun flushPendingBreadcrumbs() {
+        if (pendingBreadcrumbs.isEmpty()) return
+        pendingBreadcrumbs.drain().forEach { recordBreadcrumb(it) }
+    }
+
+    /**
+     * Breadcrumbs go to the **global** scope on purpose.
+     *
+     * Sentry 8 stores current and isolation scopes in a `ThreadLocal`, and `Sentry.addBreadcrumb` writes to the
+     * isolation scope of whichever thread calls it. Initialization now happens on a pooled thread, so anything
+     * written to a thread-scoped view would be invisible to the background thread that later submits the report.
+     * `CombinedScopeView.getBreadcrumbs` merges the global scope into every event, which makes the breadcrumb trail
+     * independent of the thread that recorded it.
+     */
+    private fun recordBreadcrumb(breadcrumb: Breadcrumb) {
+        Sentry.configureScope(ScopeType.GLOBAL) { scope -> scope.addBreadcrumb(breadcrumb) }
     }
 
     /**
      * Configures the Sentry scope with an `error_report` tag and scope configuration logic.
      */
     fun withErrorReportTag(configureScope: (IScope) -> Unit) {
+        // Already invoked from a background task, so initializing here is safe; it also covers the case of a report
+        // submitted before any action had a chance to schedule initialization.
         ensureInitialized()
+        flushPendingBreadcrumbs()
         Sentry.withScope { scope ->
             scope.setTag("kind", "error_report")
             configureScope(scope)

--- a/modules/base/src/test/kotlin/com/explyt/base/BoundedBufferTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/BoundedBufferTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for [BoundedBuffer], which holds action breadcrumbs recorded before Sentry has finished initializing.
+ */
+class BoundedBufferTest {
+
+    @Test
+    fun `drain returns items in insertion order`() {
+        val buffer = BoundedBuffer<String>(10)
+
+        buffer.offer("first")
+        buffer.offer("second")
+        buffer.offer("third")
+
+        assertEquals(listOf("first", "second", "third"), buffer.drain())
+    }
+
+    /** The buffer bounds memory while the IDE keeps producing actions, so the oldest breadcrumb is the one dropped. */
+    @Test
+    fun `oldest items are evicted when capacity is exceeded`() {
+        val buffer = BoundedBuffer<Int>(3)
+
+        repeat(5) { buffer.offer(it) }
+
+        assertEquals(listOf(2, 3, 4), buffer.drain())
+    }
+
+    @Test
+    fun `drain empties the buffer`() {
+        val buffer = BoundedBuffer<String>(4)
+        buffer.offer("only")
+
+        assertEquals(listOf("only"), buffer.drain())
+
+        assertTrue(buffer.isEmpty())
+        assertEquals(emptyList<String>(), buffer.drain())
+    }
+
+    @Test
+    fun `isEmpty reflects buffered content`() {
+        val buffer = BoundedBuffer<String>(2)
+        assertTrue(buffer.isEmpty())
+
+        buffer.offer("value")
+
+        assertFalse(buffer.isEmpty())
+    }
+
+    /**
+     * Breadcrumbs are produced on the EDT while the pooled initialization thread drains them, so concurrent
+     * `offer`/`drain` must neither lose an item nor deliver one twice.
+     */
+    @Test
+    fun `concurrent offers and drains lose no items`() {
+        val producerCount = 4
+        val perProducer = 500
+        val buffer = BoundedBuffer<Int>(producerCount * perProducer)
+        val drained = mutableListOf<Int>()
+
+        val executor = Executors.newFixedThreadPool(producerCount + 1)
+        val startLine = CountDownLatch(1)
+        val producersDone = CountDownLatch(producerCount)
+        try {
+            repeat(producerCount) { producer ->
+                executor.execute {
+                    startLine.await()
+                    repeat(perProducer) { buffer.offer(producer * perProducer + it) }
+                    producersDone.countDown()
+                }
+            }
+            executor.execute {
+                startLine.await()
+                while (producersDone.count > 0L) {
+                    synchronized(drained) { drained += buffer.drain() }
+                }
+            }
+
+            startLine.countDown()
+            assertTrue("producers must finish", producersDone.await(30, TimeUnit.SECONDS))
+        } finally {
+            executor.shutdown()
+            assertTrue("executor must terminate", executor.awaitTermination(30, TimeUnit.SECONDS))
+        }
+
+        val observed = synchronized(drained) { drained.toList() } + buffer.drain()
+        assertEquals("every item must be delivered exactly once", producerCount * perProducer, observed.size)
+        assertEquals((0 until producerCount * perProducer).toSet(), observed.toSet())
+    }
+}


### PR DESCRIPTION
Closes #307

## Problem

`ActionBreadcrumbListener.afterActionPerformed` runs on the EDT after every action and calls `SentryReporter.addBreadcrumb`, which lazily ran the whole `Sentry.init`. Initialization reads the jar manifest of every active plugin via `collectNonBundledPlugins()`, so the first action after IDE start paid an unbounded cost on the EDT and was reported as a freeze (Sentry `SPRING-PLUGIN-86`).

This is a separate root cause from #294, which parked the EDT in project-service initialization.

## Fix

- Breadcrumbs recorded before Sentry is up go into a bounded FIFO (`BoundedBuffer`, capacity 100 — Sentry's own `maxBreadcrumbs` default), and initialization is handed to `AppExecutorUtil.getAppExecutorService()`. A burst of actions schedules it exactly once. Dropping the oldest breadcrumb is preferable to delaying an action.
- Buffered breadcrumbs are flushed after initialization, and also on the fast path, so a breadcrumb buffered by another thread just after the post-init flush cannot be stranded.
- `withErrorReportTag` still initializes synchronously: it already runs inside a background task, and it covers a report submitted before any action scheduled initialization.

## Scope subtlety worth reviewing

Sentry 8 keeps the *current* and *isolation* scopes in a `ThreadLocal`, and the default scope type is `ISOLATION`. Moving initialization off the EDT therefore silently changes which scope tags and breadcrumbs land in — the pooled thread's isolation scope is not the one the background reporting thread later reads, so telemetry would have degraded without any compile error.

Both `configureScope` (tags) and breadcrumb recording are now pinned to `ScopeType.GLOBAL`. `CombinedScopeView.getBreadcrumbs` merges global + isolation + current into every event, and `Scopes.captureEvent` builds its local scope from that combined view, so the trail is now independent of the recording thread.

## Verification

`BoundedBufferTest` covers FIFO order, eviction at capacity, drain semantics, and a concurrent producer/drainer case. The concurrency test was proven red/green: removing `@Synchronized` from `offer` makes it fail, restoring it makes it pass.

`./gradlew :base:test --tests "com.explyt.base.BoundedBufferTest"` — 5/5 pass.
`./gradlew :spring-core:compileKotlin :base:compileKotlin` — clean; IDE inspections report nothing on the changed files.

Note: `modules/base` had no test source set before this change; the PR adds the JUnit 4 test dependencies to `base.gradle.kts` to host the new test.