### PR TITLE
fix: Fold a property placeholder to the profile-less value instead of an arbitrary source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Spring Core
+- fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
 - fix: Report the `BootstrapRegistry`, `@JsonComponent`/`@JsonMixin` and `@EntityScan` migrations when the legacy symbol no longer resolves after a Spring Boot 4 upgrade
 - fix: Report the `@MockBean` / `@SpyBean` migration when the legacy annotation no longer resolves after a Spring Boot 4 upgrade

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/FoldedPropertyValue.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/FoldedPropertyValue.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties
+
+import com.explyt.spring.core.SpringCoreBundle
+import com.explyt.spring.core.completion.properties.DefinedConfigurationPropertiesSearch
+import com.explyt.spring.core.completion.properties.DefinedConfigurationProperty
+import com.explyt.spring.core.service.ProfilesService
+import com.intellij.openapi.module.Module
+
+/**
+ * A configuration value chosen for folding out of every source that defines the key, together with the profile the
+ * winning source belongs to.
+ */
+class FoldedPropertyValue(
+    val property: DefinedConfigurationProperty,
+    private val profile: String?
+) {
+
+    val value: String? get() = property.value
+
+    val presentation: String? get() = value?.let { decorate(it) }
+
+    /**
+     * A value taken from `application-<profile>` is not the value the application runs with unless that profile is
+     * active, so the origin is part of the folded text instead of being silently dropped.
+     */
+    fun decorate(text: String): String = profile
+        ?.let { SpringCoreBundle.message("explyt.spring.folding.property.profile", text, it) }
+        ?: text
+
+    companion object {
+
+        fun resolve(module: Module, key: String): FoldedPropertyValue? {
+            val properties = DefinedConfigurationPropertiesSearch.getInstance(module.project)
+                .findProperties(module, key)
+            if (properties.isEmpty()) return null
+
+            val profilesService = ProfilesService.getInstance(module.project)
+            return properties.asSequence()
+                .map { FoldedPropertyValue(it, profileOf(it.sourceFile)) }
+                .sortedWith(compareBy({ it.priority(profilesService) }, { it.property.sourceFile }))
+                .firstOrNull()
+        }
+
+        private fun profileOf(sourceFile: String): String? = DefinedConfigurationPropertiesSearch.fileMask
+            .matchEntire(sourceFile)
+            ?.groupValues
+            ?.get(1)
+            ?.removePrefix("-")
+            ?.ifBlank { null }
+    }
+
+    /**
+     * Spring Boot lets an active profile override the profile-less file, and never reads a file of an inactive one.
+     */
+    private fun priority(profilesService: ProfilesService): Int = when {
+        profile == null -> PROFILE_LESS
+        profilesService.compute(profile) -> ACTIVE_PROFILE
+        else -> INACTIVE_PROFILE
+    }
+
+}
+
+private const val ACTIVE_PROFILE = 0
+private const val PROFILE_LESS = 1
+private const val INACTIVE_PROFILE = 2

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/GetPropertyMethodFoldingBuilder.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/GetPropertyMethodFoldingBuilder.kt
@@ -6,8 +6,6 @@
 package com.explyt.spring.core.properties
 
 import com.explyt.spring.core.SpringCoreClasses.PROPERTY_RESOLVER
-import com.explyt.spring.core.completion.properties.DefinedConfigurationPropertiesSearch
-import com.explyt.spring.core.completion.properties.DefinedConfigurationProperty
 import com.explyt.spring.core.util.SpringCoreUtil
 import com.intellij.codeInspection.isInheritorOf
 import com.intellij.lang.ASTNode
@@ -15,7 +13,6 @@ import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.FoldingGroup
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.psi.ElementManipulators
@@ -47,14 +44,14 @@ class GetPropertyMethodFoldingBuilder : FoldingBuilderEx() {
                 val key = ElementManipulators.getValueText(psiElement)
                 if (key.isBlank()) return false
 
-                val propertyInfo = getPropertyInfo(module, key)
+                val propertyValue = FoldedPropertyValue.resolve(module, key)
 
-                if (propertyInfo != null) {
+                if (propertyValue != null) {
                     descriptors.add(
                         FoldingDescriptor(
                             psiElement.node,
                             psiElement.textRange,
-                            group, setOfNotNull(propertyInfo.psiElement)
+                            group, setOfNotNull(propertyValue.property.psiElement)
                         )
                     )
                 }
@@ -82,16 +79,7 @@ class GetPropertyMethodFoldingBuilder : FoldingBuilderEx() {
         val key = ElementManipulators.getValueText(node.psi)
         if (key.isBlank()) return null
         val module = ModuleUtilCore.findModuleForPsiElement(node.psi) ?: return null
-        return getPropertyInfo(module, key)?.value
-    }
-
-    private fun getPropertyInfo(
-        module: Module,
-        key: String
-    ): DefinedConfigurationProperty? {
-        return DefinedConfigurationPropertiesSearch.getInstance(module.project)
-            .findProperties(module, key)
-            .firstOrNull()
+        return FoldedPropertyValue.resolve(module, key)?.presentation
     }
 
     override fun isCollapsedByDefault(node: ASTNode): Boolean = true

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/ValueAnnotationFoldingBuilder.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/ValueAnnotationFoldingBuilder.kt
@@ -6,8 +6,6 @@
 package com.explyt.spring.core.properties
 
 import com.cronutils.descriptor.CronDescriptor
-import com.explyt.spring.core.completion.properties.DefinedConfigurationPropertiesSearch
-import com.explyt.spring.core.completion.properties.DefinedConfigurationProperty
 import com.explyt.spring.core.inspections.CRON_PARSER
 import com.explyt.spring.core.inspections.SpringScheduledInspection
 import com.explyt.spring.core.util.PropertyUtil
@@ -70,10 +68,10 @@ class ValueAnnotationFoldingBuilder : FoldingBuilderEx() {
             }
 
             val (key, defaultValue) = matchResult.destructured
-            val propertyInfo = getPropertyInfo(module, key)
+            val propertyValue = FoldedPropertyValue.resolve(module, key)
 
-            if (propertyInfo != null || defaultValue.isNotEmpty()) {
-                val placeholder = getPlaceholder(uElement, propertyInfo, defaultValue) ?: return
+            if (propertyValue != null || defaultValue.isNotEmpty()) {
+                val placeholder = getPlaceholder(uElement, propertyValue, defaultValue) ?: return
                 descriptors.add(
                     FoldingDescriptor(element.node, element.textRange, group, placeholder)
                 )
@@ -82,14 +80,17 @@ class ValueAnnotationFoldingBuilder : FoldingBuilderEx() {
     }
 
     private fun getPlaceholder(
-        uElement: UExpression, propertyInfo: DefinedConfigurationProperty?, defaultValue: String
+        uElement: UExpression, propertyValue: FoldedPropertyValue?, defaultValue: String
     ): String? {
-        val placeholder = propertyInfo?.value ?: defaultValue
+        val resolvedValue = propertyValue?.value
+        val placeholder = resolvedValue ?: defaultValue
         val uastParent = uElement.uastParent
-        if (uastParent is UNamedExpression && uastParent.name == SpringScheduledInspection.CRON_PARAM) {
-            return parseCron(placeholder)
+        val text = if (uastParent is UNamedExpression && uastParent.name == SpringScheduledInspection.CRON_PARAM) {
+            parseCron(placeholder) ?: return null
+        } else {
+            placeholder
         }
-        return placeholder
+        return if (resolvedValue != null) propertyValue.decorate(text) else text
     }
 
     private fun parseCron(placeholder: String, returnNullOnError: Boolean = false): String? {
@@ -109,19 +110,10 @@ class ValueAnnotationFoldingBuilder : FoldingBuilderEx() {
 
         val (key, defaultValue) = matchResult.destructured
 
-        val propertyValue = getPropertyInfo(module, key)
+        val propertyValue = FoldedPropertyValue.resolve(module, key)
             ?: return defaultValue.ifBlank { StringUtil.THREE_DOTS }
 
-        return propertyValue.value
-    }
-
-    private fun getPropertyInfo(
-        module: Module,
-        key: String
-    ): DefinedConfigurationProperty? {
-        return DefinedConfigurationPropertiesSearch.getInstance(module.project)
-            .findProperties(module, key)
-            .firstOrNull()
+        return propertyValue.presentation
     }
 
     override fun isCollapsedByDefault(node: ASTNode): Boolean = true

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -240,6 +240,7 @@ explyt.toolwindow.endpoints.title=Explyt Endpoints
 explyt.toolwindow.endpoints.notification.message=Open the Explyt Endpoints panel in the Tool Window
 explyt.spring.gutter.spi.tooltip.title.usage=Navigate to SPI
 explyt.spring.gutter.spi.popup.title.usage=Choose SPI implementation
+explyt.spring.folding.property.profile={0} (profile: {1})
 explyt.spring.folder.mark.property=Spring Application Property Folder
 explyt.spring.folder.unmark.property=Unmark as Spring Application Property Folder
 explyt.spring.debugger.show.dialog=\u2026Evaluate

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/GetPropertyMethodFoldingBuilderTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/GetPropertyMethodFoldingBuilderTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.explyt.spring.test.TestLibrary
+import junit.framework.TestCase
+
+class GetPropertyMethodFoldingBuilderTest : ExplytJavaLightTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springContext_6_0_7)
+
+    fun testProfileLessPropertiesWinsOverInactiveProfile() {
+        myFixture.addFileToProject("application.properties", "database=h2")
+        myFixture.addFileToProject("application-mysql.properties", "database=mysql")
+
+        configureBean()
+
+        TestCase.assertEquals("h2", foldedPlaceholderText())
+    }
+
+    fun testValueOnlyDefinedInProfileShowsProfileOrigin() {
+        myFixture.addFileToProject("application-mysql.properties", "database=mysql")
+
+        configureBean()
+
+        TestCase.assertEquals("mysql (profile: mysql)", foldedPlaceholderText())
+    }
+
+    private fun configureBean() {
+        myFixture.configureByText(
+            "TestBean.java", """
+            import org.springframework.core.env.Environment;
+
+            public class TestBean {
+              private Environment environment;
+
+              String database() { return environment.getProperty("database"); }
+            }
+            """.trimIndent()
+        )
+        myFixture.doHighlighting()
+    }
+
+    private fun foldedPlaceholderText(): String {
+        val document = myFixture.editor.document
+        val regions = myFixture.editor.foldingModel.allFoldRegions
+        return regions.firstOrNull { document.getText(it.textRange) == "\"database\"" }
+            ?.placeholderText
+            ?: throw AssertionError(
+                "no folded key literal among " + regions.joinToString {
+                    "[" + it.placeholderText + "] <- [" + document.getText(it.textRange) + "]"
+                }
+            )
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/kotlin/ValueAnnotationFoldingBuilderTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/kotlin/ValueAnnotationFoldingBuilderTest.kt
@@ -8,7 +8,10 @@ package com.explyt.spring.core.properties.kotlin
 import com.explyt.spring.core.SpringCoreClasses
 import com.explyt.spring.test.ExplytKotlinLightTestCase
 import com.explyt.spring.test.TestLibrary
+import com.intellij.openapi.util.TextRange
 import junit.framework.TestCase
+
+private const val PLACEHOLDER_START = "\${"
 
 class ValueAnnotationFoldingBuilderTest : ExplytKotlinLightTestCase() {
 
@@ -17,7 +20,7 @@ class ValueAnnotationFoldingBuilderTest : ExplytKotlinLightTestCase() {
     fun testCronPlaceholderIsFolded() {
         myFixture.addFileToProject("application.properties", "test.property=valueTestFolding")
 
-        val propertyString = "\\\${test.property}"
+        val propertyString = "\\" + PLACEHOLDER_START + "test.property}"
         myFixture.configureByText(
             "TestBean.kt", """            
             
@@ -32,5 +35,84 @@ class ValueAnnotationFoldingBuilderTest : ExplytKotlinLightTestCase() {
         val foldRegion = myFixture.editor.foldingModel.allFoldRegions
             .find { it.placeholderText == "valueTestFolding" }
         TestCase.assertNotNull(foldRegion)
+    }
+
+    fun testValueFromProfileLessPropertiesIsFolded() {
+        myFixture.addFileToProject("application.properties", "database=h2")
+
+        configureBean("database")
+
+        TestCase.assertEquals("h2", foldedPlaceholderText())
+    }
+
+    fun testProfileLessPropertiesWinsOverInactiveProfile() {
+        myFixture.addFileToProject("application.properties", "database=h2")
+        myFixture.addFileToProject("application-mysql.properties", "database=mysql")
+
+        configureBean("database")
+
+        TestCase.assertEquals("h2", foldedPlaceholderText())
+    }
+
+    fun testProfileLessYamlWinsOverInactiveProfile() {
+        myFixture.addFileToProject("application.yaml", "database: h2")
+        myFixture.addFileToProject("application-mysql.yaml", "database: mysql")
+
+        configureBean("database")
+
+        TestCase.assertEquals("h2", foldedPlaceholderText())
+    }
+
+    fun testValueOnlyDefinedInProfileShowsProfileOrigin() {
+        myFixture.addFileToProject("application-mysql.properties", "database=mysql")
+
+        configureBean("database")
+
+        TestCase.assertEquals("mysql (profile: mysql)", foldedPlaceholderText())
+    }
+
+    fun testActiveProfileWinsOverProfileLessProperties() {
+        myFixture.addFileToProject("application.properties", "spring.profiles.active=mysql\ndatabase=h2")
+        myFixture.addFileToProject("application-mysql.properties", "database=mysql")
+
+        configureBean("database")
+
+        TestCase.assertEquals("mysql (profile: mysql)", foldedPlaceholderText())
+    }
+
+    fun testDefaultValueIsFoldedWhenPropertyIsMissing() {
+        myFixture.addFileToProject("application.properties", "database=h2")
+
+        configureBean("missing:fallback")
+
+        TestCase.assertEquals("fallback", foldedPlaceholderText())
+    }
+
+    private fun configureBean(placeholder: String) {
+        myFixture.configureByText(
+            "TestBean.kt", """
+            @${SpringCoreClasses.COMPONENT}
+            class TestBean {
+              @${SpringCoreClasses.VALUE}("\$PLACEHOLDER_START$placeholder}") lateinit var s: String
+            }
+            """.trimIndent()
+        )
+        myFixture.doHighlighting()
+    }
+
+    private fun foldedPlaceholderText(): String {
+        val document = myFixture.editor.document
+        val regions = myFixture.editor.foldingModel.allFoldRegions
+        val placeholders = regions
+            .filter {
+                val text = document.getText(TextRange(it.startOffset, it.endOffset))
+                text.startsWith("\"") && text.contains(PLACEHOLDER_START)
+            }
+            .map { it.placeholderText }
+        return placeholders.singleOrNull() ?: throw AssertionError(
+            "expected a single folded @Value literal, got " + regions.joinToString {
+                "[" + it.placeholderText + "] <- [" + document.getText(TextRange(it.startOffset, it.endOffset)) + "]"
+            }
+        )
     }
 }


### PR DESCRIPTION
## Purpose

`@Value("${database}")` folded in the editor to the value of an **inactive** Spring profile. On `spring-petclinic-kotlin`, with `application.properties` defining `database=h2` and `application-mysql.properties` defining `database=mysql`, the editor showed `mysql` while the application with no active profile runs with `h2`.

`DefinedConfigurationPropertiesSearch.findProperties` returns a match from every `application*` file that defines the key, and both folding builders took `firstOrNull()` — an arbitrary winner with no profile awareness.

## Change

New `FoldedPropertyValue` selects the source deliberately instead of taking the first one:

1. a file of a currently active profile (`ProfilesService.compute`, which already models `spring.profiles.active`, `@Profile`, `setAdditionalProfiles` and Maven profiles);
2. the profile-less `application.properties` / `.yaml` / `.yml`;
3. a file of an inactive profile, only when nothing else defines the key.

Ties inside a group are broken by the source file name so folding is stable between highlighting passes.

When the winning value comes from a profile-specific file, the profile name is part of the folded text — `mysql (profile: mysql)` — instead of the value being silently presented as *the* value.

`GetPropertyMethodFoldingBuilder` (folding of `Environment.getProperty("key")`) had the identical `firstOrNull()` defect and is fixed the same way.

## Verification

`:spring-core:test --tests "com.explyt.spring.core.properties.*"` — 10 folding tests, all green.

Red phase proven by stubbing the selection back to `properties.first()`: 6 of the new assertions fail with `expected:<h2> but was:<mysql>` and `expected:<mysql (profile: mysql)> but was:<mysql>`.

New tests cover: key only in `application.properties`; key in both `application.properties` and `application-mysql.properties`; the same for YAML; key only in `application-mysql.properties`; `spring.profiles.active=mysql` making the profile win; and `${missing:fallback}` default handling.