### PR TITLE
fix: Match a configuration hint value case-insensitively and offer one navigation target per metadata declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - fix: Complete an enum configuration value from any relaxed spelling and insert Spring's recommended one, so `r`, `request-h`, `request_h` and `REQ` all insert `request-headers`
 - feat: Report an enum configuration value that is not written in Spring's recommended spelling, with a quick-fix rewriting `REQUEST_HEADERS` to `request-headers`
 - fix: Resolve a configuration value against the enum element type of an array property such as `Include[]` and of a map property such as `java.util.Map<String, Include>`
+- fix: Navigate a configuration value to its metadata hint declaration whatever its case, so `logging.level.root=INFO` navigates like `info`
+- feat: Report a configuration value that differs from its metadata hint literal only by case, with a quick-fix rewriting `INFO` to `info`
+- fix: Offer one navigation target per metadata declaration instead of repeating the same hint or key once per metadata file and once per sources jar of the same artifact
 - fix: Navigate a configuration key with no declaring member, such as `management.endpoint.httpexchanges.access`, to its value type instead of the unrelated source class
 - fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/AbstractSpringMetadataConfigurationPropertiesLoader.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/AbstractSpringMetadataConfigurationPropertiesLoader.kt
@@ -91,10 +91,17 @@ abstract class AbstractSpringMetadataConfigurationPropertiesLoader(project: Proj
             }
             ?.findProperty(VALUES)?.value as? JsonArray ?: return null
 
-        val value = values.valueList.asSequence()
+        // A hint literal is matched the way Spring binds it: `INFO`, `Info` and `info` all name the `info` literal, so
+        // the written spelling must not decide whether navigation works. An exact match still wins over a case-only
+        // one, in case a hint ships two literals that differ by case alone.
+        val matching = values.valueList.asSequence()
             .mapNotNull { it as? JsonObject }
-            .firstOrNull { it.findProperty(VALUE)?.value?.text == "\"$valueName\"" }
-            ?.propertyList?.firstOrNull { it.name == VALUE } ?: return null
+            .mapNotNull { it.findProperty(VALUE) }
+            .filter { (it.value as? JsonStringLiteral)?.value.equals(valueName, ignoreCase = true) }
+            .toList()
+        val value = matching.firstOrNull { (it.value as JsonStringLiteral).value == valueName }
+            ?: matching.firstOrNull()
+            ?: return null
 
         return ElementHint((value.value as JsonStringLiteral).value, value)
     }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/MetadataDeclarations.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/MetadataDeclarations.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.completion.properties
+
+import com.explyt.spring.core.SpringProperties.ADDITIONAL_CONFIGURATION_METADATA_FILE_NAME
+import com.intellij.psi.PsiFile
+import com.intellij.util.io.URLUtil.JAR_SEPARATOR
+
+/**
+ * One navigation target per metadata declaration.
+ *
+ * A library ships the same declaration up to three times: the hand-written `additional-spring-configuration-metadata.json`
+ * and the generated `spring-configuration-metadata.json` of the binary jar, plus the `additional-…` copy inside the
+ * `-sources` jar. They are one declaration, so offering three targets for one key only asks the user to pick at random.
+ */
+object MetadataDeclarations {
+
+    /** One target per declaration name and artifact, keeping the preferred copy of each. */
+    fun <T> distinct(targets: Iterable<T>, name: (T) -> String, file: (T) -> PsiFile): List<T> {
+        return targets
+            .groupBy { name(it) to artifactOf(file(it)) }
+            .values
+            .mapNotNull { group -> group.minByOrNull { rank(pathOf(file(it))) } }
+    }
+
+    /** The single preferred target among [targets], which are assumed to be the same declaration. */
+    fun <T> preferred(targets: Iterable<T>, file: (T) -> PsiFile): T? {
+        return targets.minByOrNull { rank(pathOf(file(it))) }
+    }
+
+    /**
+     * The lower the better: the sources jar first, matching what navigation offers everywhere else in the IDE, and the
+     * hand-written metadata file before the generated one, because it is what the library actually maintains.
+     */
+    private fun rank(path: String): Int {
+        val sourcesRank = if (jarOf(path).endsWith(SOURCES_JAR_SUFFIX)) 0 else 2
+        val fileRank = if (path.endsWith(ADDITIONAL_CONFIGURATION_METADATA_FILE_NAME)) 0 else 1
+        return sourcesRank + fileRank
+    }
+
+    /**
+     * The artifact [file] belongs to: the jar, with its `-sources` twin folded into it, or the containing directory
+     * for a file that is not in a jar.
+     */
+    private fun artifactOf(file: PsiFile): String {
+        val path = pathOf(file)
+        if (!path.contains(JAR_SEPARATOR)) return path.substringBeforeLast('/')
+        val jar = jarOf(path)
+        return if (jar.endsWith(SOURCES_JAR_SUFFIX)) jar.removeSuffix(SOURCES_JAR_SUFFIX) + JAR_SUFFIX else jar
+    }
+
+    private fun jarOf(path: String): String = path.substringBefore(JAR_SEPARATOR)
+
+    private fun pathOf(file: PsiFile): String = file.viewProvider.virtualFile.path
+
+    private const val JAR_SUFFIX = ".jar"
+    private const val SOURCES_JAR_SUFFIX = "-sources$JAR_SUFFIX"
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/ProjectConfigurationPropertiesLoader.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/ProjectConfigurationPropertiesLoader.kt
@@ -59,10 +59,11 @@ class ProjectConfigurationPropertiesLoader(project: Project) :
     }
 
     override fun findMetadataValueElement(module: Module, propertyName: String, propertyValue: String): ElementHint? {
-        return findMetadataFiles(module)
+        // mapNotNull, not map: the first metadata file that declares nothing must not hide the one that does.
+        val declarations = findMetadataFiles(module)
             .filterIsInstance<JsonFile>()
-            .map { collectElementMetadataHintsValue(it, propertyName, propertyValue) }
-            .firstOrNull()
+            .mapNotNull { collectElementMetadataHintsValue(it, propertyName, propertyValue) }
+        return MetadataDeclarations.preferred(declarations) { it.jsonProperty.containingFile }
     }
 
     private fun loadPropertiesFromConfiguration(module: Module): HashMap<String, ConfigurationProperty> =

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/SpringMetadataLibraryConfigurationPropertiesLoader.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/SpringMetadataLibraryConfigurationPropertiesLoader.kt
@@ -83,10 +83,11 @@ class SpringMetadataLibraryConfigurationPropertiesLoader(project: Project) :
     }
 
     override fun findMetadataValueElement(module: Module, propertyName: String, propertyValue: String): ElementHint? {
-        return findMetadataFiles(module).asSequence()
+        val declarations = findMetadataFiles(module).asSequence()
             .filterIsInstance<JsonFile>()
             .mapNotNull { collectElementMetadataHintsValue(it, propertyName, propertyValue) }
-            .firstOrNull()
+            .toList()
+        return MetadataDeclarations.preferred(declarations) { it.jsonProperty.containingFile }
     }
 
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringRecommendedEnumValueInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringRecommendedEnumValueInspection.kt
@@ -12,6 +12,7 @@ import com.explyt.spring.core.SpringProperties.PLACEHOLDER_SUFFIX
 import com.explyt.spring.core.completion.properties.ConfigurationProperty
 import com.explyt.spring.core.completion.properties.DefinedConfigurationProperty
 import com.explyt.spring.core.completion.properties.PropertiesPropertySource
+import com.explyt.spring.core.completion.properties.PropertyHint
 import com.explyt.spring.core.completion.properties.YamlPropertySource
 import com.explyt.spring.core.util.PropertyUtil
 import com.explyt.spring.core.util.PropertyUtil.propertyValuePsiElement
@@ -35,18 +36,20 @@ import org.jetbrains.yaml.psi.YAMLFile
 import org.jetbrains.yaml.psi.YAMLScalar
 
 /**
- * Reports an enum configuration value that is not written in the spelling Spring itself recommends, and offers a
- * quick-fix that rewrites it.
+ * Reports a configuration value that is not written in the spelling Spring itself recommends, and offers a quick-fix
+ * that rewrites it. Relaxed binding accepts every spelling, so this is a style report, not an error.
  *
- * Spring's own metadata never ships the declared `SCREAMING_SNAKE` name as a default value: measured on
- * `spring-boot-autoconfigure-3.5.13`, all 64 enum-typed properties with a string `defaultValue` use lower case
- * (`never`, `graceful`) or kebab-case (`read-uncommitted`, `path-pattern-parser`). Relaxed binding accepts the other
- * spellings, so this is a style report, not an error.
+ * Two sources say what the recommended spelling is:
  *
- * Only values that resolve to an enum constant are considered. A value that resolves to nothing is a different
- * diagnostic ([SpringBasePropertyInspection] reports it), and a value backed by metadata hints is left alone: those
- * literals come from metadata already written in the spelling users type. `logging.level.root=INFO` is such a case —
- * it is a `Map<String, String>` value with a `logging.level.values` hint, not an enum constant.
+ * - **Metadata hints.** A hint states the accepted literals verbatim, and every literal Spring ships is lower case
+ *   (`trace`, `info`, `read-only`), so a value that differs from a literal only by case is written against the
+ *   metadata that declares it. `logging.level.*=INFO` is the everyday case.
+ * - **Enum constants.** Spring's own metadata never ships the declared `SCREAMING_SNAKE` name as a default value:
+ *   measured on `spring-boot-autoconfigure-3.5.13`, all 64 enum-typed properties with a string `defaultValue` use
+ *   lower case (`never`, `graceful`) or kebab-case (`read-uncommitted`, `path-pattern-parser`).
+ *
+ * A value that matches nothing is never reported here: it is either free-form (a hint whose provider is `any`) or a
+ * genuine error, which [SpringBasePropertyInspection] owns.
  */
 class SpringRecommendedEnumValueInspection : SpringBaseLocalInspectionTool() {
 
@@ -81,37 +84,64 @@ class SpringRecommendedEnumValueInspection : SpringBaseLocalInspectionTool() {
         val psiElement = property.psiElement ?: return emptyList()
         val value = property.value?.trimEnd()
         if (value.isNullOrBlank()) return emptyList()
-        // Metadata hints spell out the accepted literals themselves, so an enum-typed property that ships hints has
-        // already declared the spelling to use and this inspection must not second-guess it.
-        if (PropertyUtil.getPropertyHint(module, property.key) != null) return emptyList()
-
-        val configurationProperty = PropertyUtil.findValueOwner(module, property.key) ?: return emptyList()
-        val enumClass = enumValueTypeOf(module, configurationProperty) ?: return emptyList()
         val psiValue = psiElement.propertyValuePsiElement() ?: return emptyList()
+
+        val configurationProperty = PropertyUtil.findValueOwner(module, property.key)
+        // A hint states the literals of this very property, so it outranks the value type: an enum-typed property that
+        // also ships hints has already declared which spelling to write.
+        val hint = PropertyUtil.getPropertyHint(module, property.key)
+        val recommend = hintRecommendation(hint)
+            ?: enumRecommendation(module, configurationProperty)
+            ?: return emptyList()
 
         val problems = mutableListOf<ProblemDescriptor>()
         for (element in valueElements(value, configurationProperty, property.key)) {
             if (element.text.contains(PLACEHOLDER_PREFIX) && element.text.contains(PLACEHOLDER_SUFFIX)) continue
-            val constant = PropertyUtil.findEnumConstant(enumClass, element.text) ?: continue
-            val recommended = PropertyUtil.recommendedValueSpelling(constant.name)
-            if (element.text == recommended) continue
+            val recommended = recommend(element.text) ?: continue
+            if (element.text == recommended.spelling) continue
 
             problems += manager.createProblemDescriptor(
                 psiValue,
                 element.rangeIn(psiValue.text, value),
-                message("explyt.spring.inspection.properties.value.enum.not.recommended", recommended),
+                message(recommended.messageKey, recommended.spelling),
                 ProblemHighlightType.WEAK_WARNING,
                 isOnTheFly,
-                RewriteEnumValueQuickFix(element.text, recommended)
+                RewriteValueQuickFix(element.text, recommended.spelling)
             )
         }
         return problems
     }
 
-    private fun enumValueTypeOf(module: Module, configurationProperty: ConfigurationProperty) =
-        PropertyUtil.valueTypeOf(configurationProperty)
+    /**
+     * The literal of [hint] that a written value denotes, matched the way Spring binds it — case-insensitively, so
+     * `INFO` and `Info` both name the `info` literal that the metadata declares.
+     */
+    private fun hintRecommendation(hint: PropertyHint?): ((String) -> Recommendation?)? {
+        val literals = hint?.values?.mapNotNull { it.value }?.takeIf { it.isNotEmpty() } ?: return null
+        return { written ->
+            literals.firstOrNull { it.equals(written, ignoreCase = true) }
+                ?.let { Recommendation(it, "explyt.spring.inspection.properties.value.not.recommended") }
+        }
+    }
+
+    private fun enumRecommendation(
+        module: Module,
+        configurationProperty: ConfigurationProperty?
+    ): ((String) -> Recommendation?)? {
+        val enumClass = configurationProperty
+            ?.let { PropertyUtil.valueTypeOf(it) }
             ?.let { JavaPsiFacade.getInstance(module.project).findClass(it, GlobalSearchScope.allScope(module.project)) }
             ?.takeIf { it.isEnum }
+            ?: return null
+        return { written ->
+            PropertyUtil.findEnumConstant(enumClass, written)?.let {
+                Recommendation(
+                    PropertyUtil.recommendedValueSpelling(it.name),
+                    "explyt.spring.inspection.properties.value.enum.not.recommended"
+                )
+            }
+        }
+    }
 
     /**
      * The individual values written in [value]: the elements of a comma-separated list for a collection property, and
@@ -119,10 +149,12 @@ class SpringRecommendedEnumValueInspection : SpringBaseLocalInspectionTool() {
      */
     private fun valueElements(
         value: String,
-        configurationProperty: ConfigurationProperty,
+        configurationProperty: ConfigurationProperty?,
         key: String
     ): List<ValueElement> {
-        val isCollection = (configurationProperty.isArray() || configurationProperty.isList()) && !key.endsWith("]")
+        val isCollection = configurationProperty != null
+                && (configurationProperty.isArray() || configurationProperty.isList())
+                && !key.endsWith("]")
         if (!isCollection) return listOf(ValueElement(value.trim(), value.indexOf(value.trim())))
 
         val elements = mutableListOf<ValueElement>()
@@ -135,6 +167,9 @@ class SpringRecommendedEnumValueInspection : SpringBaseLocalInspectionTool() {
         return elements
     }
 }
+
+/** The spelling to write instead of what the user wrote, and the message explaining where it comes from. */
+private data class Recommendation(val spelling: String, val messageKey: String)
 
 /** One value written in a property, with its offset inside the raw value text. */
 private data class ValueElement(val text: String, val offsetInValue: Int) {
@@ -150,7 +185,7 @@ private data class ValueElement(val text: String, val offsetInValue: Int) {
     }
 }
 
-private class RewriteEnumValueQuickFix(
+private class RewriteValueQuickFix(
     private val oldValue: String,
     private val newValue: String
 ) : LocalQuickFix {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/ConfigurationPropertyDataRetriever.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/ConfigurationPropertyDataRetriever.kt
@@ -7,6 +7,7 @@ package com.explyt.spring.core.properties.dataRetriever
 
 import com.explyt.spring.core.SpringCoreClasses
 import com.explyt.spring.core.completion.properties.DefinedConfigurationPropertiesSearch
+import com.explyt.spring.core.completion.properties.MetadataDeclarations
 import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
 import com.explyt.spring.core.service.ConfigurationPropertiesService
 import com.explyt.spring.core.tracker.ModificationTrackerManager
@@ -53,12 +54,11 @@ abstract class ConfigurationPropertyDataRetriever {
         val propertyFqn = prefix + name
         val hints = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .getElementNameHints(module)
-
-        return hints
-            .asSequence()
             .filter { PropertyUtil.isSameProperty(it.name, propertyFqn) }
+
+        return MetadataDeclarations
+            .distinct(hints, { it.name }, { it.jsonProperty.containingFile })
             .mapNotNull { it.jsonProperty.value }
-            .toList()
     }
 
     companion object {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/MetaConfigurationKeyReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/MetaConfigurationKeyReference.kt
@@ -5,8 +5,8 @@
 
 package com.explyt.spring.core.properties.references
 
+import com.explyt.spring.core.completion.properties.MetadataDeclarations
 import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
-import com.intellij.json.psi.JsonProperty
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -21,33 +21,14 @@ open class MetaConfigurationKeyReference(
     textRange: TextRange? = null
 ) : PsiReferenceBase.Poly<PsiElement>(element, textRange, false) {
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
-        val metadataProperties = SpringConfigurationPropertiesSearch.getInstance(module.project)
+        val declarations = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .getElementNameProperties(module)
-        var result: List<JsonProperty> = metadataProperties.asSequence()
             .filter { it.name == propertyKey }
-            .mapTo(mutableListOf()) { it.jsonProperty }
-
-        result = getOnlySourceIfExist(result)
+        // The same key is declared by both metadata files of an artifact and again in its sources jar; they are one
+        // declaration, so only the preferred copy of each artifact is offered.
+        val result = MetadataDeclarations
+            .distinct(declarations, { it.name }, { it.jsonProperty.containingFile })
+            .map { it.jsonProperty }
         return PsiElementResolveResult.createResults(result)
     }
-
-    private fun getOnlySourceIfExist(result: List<JsonProperty>): List<JsonProperty> {
-        if (result.size <= 1) {
-            return result
-        }
-
-        val resultWithSources = mutableListOf<JsonProperty>()
-        for (it in result) {
-            val path = it.containingFile.containingDirectory.virtualFile.canonicalPath
-            if (path != null && path.contains("sources")) {
-                resultWithSources.add(it)
-            }
-        }
-        if (resultWithSources.isNotEmpty()) {
-            return resultWithSources
-        }
-
-        return result
-    }
-
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProvider.kt
@@ -8,6 +8,7 @@ package com.explyt.spring.core.providers
 import com.explyt.plugin.PluginIds
 import com.explyt.spring.core.SpringCoreBundle
 import com.explyt.spring.core.SpringIcons
+import com.explyt.spring.core.completion.properties.MetadataDeclarations
 import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
 import com.explyt.spring.core.statistic.StatisticActionId
 import com.explyt.spring.core.statistic.StatisticService
@@ -16,7 +17,6 @@ import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
-import com.intellij.json.psi.JsonProperty
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.util.NotNullLazyValue
@@ -60,18 +60,12 @@ class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
         val hints = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .getElementNameHints(module)
 
-        val targets = hints.asSequence()
-            .filter { it.name == elementText || isMapKey(elementText, it.name, isYaml) }
+        val matching = hints.filter { it.name == elementText || isMapKey(elementText, it.name, isYaml) }
+        // One artifact ships the same hint in both its generated and its hand-written metadata file, and again in its
+        // sources jar; they are one declaration, so only the preferred copy of each becomes a target.
+        val targets = MetadataDeclarations
+            .distinct(matching, { it.name }, { it.jsonProperty.containingFile })
             .map { it.jsonProperty }
-            .groupingBy { it.containingFile.virtualFile.path.replace(SOURCES_SUFFIX, "") }
-            .aggregate { _, acc: JsonProperty?, elem: JsonProperty, _ ->
-                when {
-                    acc == null -> elem
-                    acc.containingFile.virtualFile.path.contains(SOURCES_SUFFIX) -> acc
-                    else -> elem
-                }
-            }
-            .values
 
         if (targets.isEmpty()) return
 
@@ -95,8 +89,4 @@ class PropertyLineMarkerProvider : RelatedItemLineMarkerProvider() {
         val name = propertyName.substringBefore(".keys")
         return elementText.startsWith(name) && if (isYaml) name == elementText else !elementText.contains("=")
     }
-    companion object {
-        const val SOURCES_SUFFIX = "-sources"
-    }
-
 }

--- a/modules/spring-core/src/main/resources/inspectionDescriptions/SpringRecommendedEnumValueInspection.html
+++ b/modules/spring-core/src/main/resources/inspectionDescriptions/SpringRecommendedEnumValueInspection.html
@@ -5,25 +5,32 @@
 
 <html lang="en">
 <head>
-    <title>Enum configuration value not in Spring's recommended spelling</title>
+    <title>Configuration value not in Spring's recommended spelling</title>
 </head>
 <body>
 
 <p>
-    Reports a configuration value that resolves to an enum constant but is not written in the spelling Spring itself
-    recommends &mdash; lower case with <code>-</code> between words &mdash; and offers a quick-fix that rewrites it.
+    Reports a configuration value that is not written in the spelling Spring itself recommends, and offers a quick-fix
+    that rewrites it.
 </p>
 
 <p>
-    Spring's relaxed binding accepts the declared <code>SCREAMING_SNAKE</code> name too, so this is a style report.
-    Spring's own configuration metadata, however, never uses that form for a default value: on
-    <code>spring-boot-autoconfigure-3.5.13</code> all enum-typed properties with a string <code>defaultValue</code>
-    spell it in lower case (<code>never</code>, <code>graceful</code>) or kebab-case (<code>read-uncommitted</code>,
-    <code>path-pattern-parser</code>).
+    Two sources say what that spelling is. A <b>metadata hint</b> states the accepted literals verbatim, and every
+    literal Spring ships is lower case, so <code>logging.level.root=INFO</code> is written against the metadata that
+    declares <code>info</code>. For an <b>enum-typed</b> value the recommended form is lower case with <code>-</code>
+    between words: Spring's own metadata never uses the declared <code>SCREAMING_SNAKE</code> name as a default value
+    &mdash; on <code>spring-boot-autoconfigure-3.5.13</code> all enum-typed properties with a string
+    <code>defaultValue</code> spell it in lower case (<code>never</code>, <code>graceful</code>) or kebab-case
+    (<code>read-uncommitted</code>, <code>path-pattern-parser</code>).
+</p>
+
+<p>
+    Spring's relaxed binding accepts every spelling, so this is a style report rather than an error.
 </p>
 
 <p><b>Examples:</b></p>
 <pre><code>
+logging.level.root=INFO                           # -> info
 management.endpoint.conditions.access=READ_ONLY   # -> read-only
 management.httpexchanges.recording.include=REQUEST_HEADERS,response_headers
                                                   # -> request-headers,response-headers
@@ -31,9 +38,8 @@ management.httpexchanges.recording.include=REQUEST_HEADERS,response_headers
 
 <p>The inspection does not report:</p>
 <ul>
-    <li>a value that does not resolve to an enum constant &mdash; that is a separate diagnostic;</li>
-    <li>a value backed by metadata hints, such as <code>logging.level.root=INFO</code>, because those literals come
-        from metadata already written in the spelling users type;
+    <li>a value matching neither a hint literal nor an enum constant &mdash; it is either free-form, such as a hint
+        whose provider is <code>any</code>, or a genuine error reported by a separate diagnostic;
     </li>
     <li>a value containing a <code>${...}</code> placeholder, which is resolved at runtime.</li>
 </ul>

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -137,7 +137,8 @@ explyt.spring.inspection.properties.value.unresolved.static=Invalid value ''{0}'
 explyt.spring.inspection.properties.value.unknown.encoding=Unknown encoding: ''{0}''
 explyt.spring.inspection.properties.value.should.be.kebab=Should be kebab-case
 explyt.spring.inspection.properties.value.enum.not.recommended=Spring writes this enum value as ''{0}''
-explyt.spring.inspection.properties.value.enum.recommended.name=Enum configuration value not in Spring''s recommended spelling
+explyt.spring.inspection.properties.value.not.recommended=Spring writes this value as ''{0}''
+explyt.spring.inspection.properties.value.enum.recommended.name=Configuration value not in Spring''s recommended spelling
 explyt.spring.inspection.properties.quick.fix.replacement=Use replacement key ''{0}''
 explyt.spring.inspection.properties.auto.configuration.problem=Property org.springframework.boot.autoconfigure.EnableAutoConfiguration is deprecated since spring-boot 2.7. \
   The setting must be moved to the file: META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports.

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/RecommendedHintValueInspectionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/inspections/java/RecommendedHintValueInspectionTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.inspections.java
+
+import com.explyt.spring.core.inspections.SpringRecommendedEnumValueInspection
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * Every hint literal Spring ships is written in lower case, so a value that only differs from one by case is a
+ * spelling problem with a rewrite, not an error: relaxed binding accepts it and `getProblemValues` deliberately says
+ * nothing about a hint whose provider is `any`.
+ *
+ * A value matching no literal at all stays unreported here — it is either free-form or already owned by
+ * [com.explyt.spring.core.inspections.SpringBasePropertyInspection].
+ */
+class RecommendedHintValueInspectionTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springBoot_3_1_1)
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.enableInspections(SpringRecommendedEnumValueInspection::class.java)
+    }
+
+    fun testUpperCaseLogLevelReported() = assertReported("logging.level.root=INFO", "info")
+
+    fun testMixedCaseLogLevelReported() = assertReported("logging.level.org.springframework=Debug", "debug")
+
+    fun testExactLogLevelNotReported() = assertNotReported("logging.level.root=info")
+
+    fun testUnknownValueNotReported() = assertNotReported("logging.level.root=NOT_A_LEVEL")
+
+    fun testQuickFixRewritesValue() {
+        myFixture.configureByText("application.properties", "logging.level.root=IN<caret>FO")
+
+        applySingleFix()
+
+        myFixture.checkResult("logging.level.root=info")
+    }
+
+    fun testYamlUpperCaseLogLevelReported() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                root: INFO
+            """.trimIndent()
+        )
+
+        val problems = recommendationProblems()
+
+        assertEquals("expected exactly one report, got: $problems", 1, problems.size)
+        assertTrue("expected info to be suggested, got: $problems", problems.single().contains("info"))
+    }
+
+    fun testYamlQuickFixRewritesValue() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                root: IN<caret>FO
+            """.trimIndent()
+        )
+
+        applySingleFix()
+
+        myFixture.checkResult(
+            """
+            logging:
+              level:
+                root: info
+            """.trimIndent()
+        )
+    }
+
+    private fun assertReported(propertyLine: String, expectedSuggestion: String) {
+        myFixture.configureByText("application.properties", propertyLine)
+
+        val problems = recommendationProblems()
+
+        assertEquals("expected exactly one report, got: $problems", 1, problems.size)
+        assertTrue(
+            "expected '$expectedSuggestion' to be suggested, got: $problems",
+            problems.single().contains(expectedSuggestion)
+        )
+    }
+
+    private fun assertNotReported(propertyLine: String) {
+        myFixture.configureByText("application.properties", propertyLine)
+
+        val problems = recommendationProblems()
+
+        assertEmpty("nothing must be reported here: $problems", problems)
+    }
+
+    private fun applySingleFix() {
+        val intentions = myFixture.availableIntentions.filter { it.text.startsWith("Replacement") }
+        assertEquals("expected exactly one rewrite fix, got: ${intentions.map { it.text }}", 1, intentions.size)
+        myFixture.checkPreviewAndLaunchAction(intentions.single())
+    }
+
+    private fun recommendationProblems(): List<String> = myFixture.doHighlighting()
+        .mapNotNull { it.description }
+        .filter { it.contains("Spring writes this value as") }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/HintValueCaseInsensitiveReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/HintValueCaseInsensitiveReferenceTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.core.properties.references.ValueHintReference
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonStringLiteral
+
+/**
+ * A metadata hint literal is matched under Spring's relaxed binding, not verbatim.
+ *
+ * `logging.level.*` is bound as `Map<String, LogLevel>`, so `INFO`, `Info` and `info` are the same value at runtime,
+ * yet only the exactly written literal used to navigate to the hint declaration.
+ */
+class HintValueCaseInsensitiveReferenceTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springBoot_3_1_1)
+
+    fun testUpperCaseValueResolvesToHintLiteral() = assertResolvesToHintLiteral("INFO")
+
+    fun testMixedCaseValueResolvesToHintLiteral() = assertResolvesToHintLiteral("Info")
+
+    fun testExactValueStillResolvesToHintLiteral() = assertResolvesToHintLiteral("info")
+
+    fun testUnknownValueDoesNotResolve() {
+        myFixture.configureByText("application.properties", "logging.level.root=NOT_A_LEVEL")
+
+        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf("NOT_A_LEVEL"))
+        val valueReference = reference as? ValueHintReference
+
+        assertTrue(
+            "a value matching no hint literal must not resolve",
+            valueReference == null || valueReference.multiResolve(false).isEmpty()
+        )
+    }
+
+    fun testYamlUpperCaseValueResolvesToHintLiteral() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                root: INFO
+            """.trimIndent()
+        )
+
+        assertHintLiteralResolved("INFO", "info")
+    }
+
+    private fun assertResolvesToHintLiteral(written: String) {
+        myFixture.configureByText("application.properties", "logging.level.root=$written")
+
+        assertHintLiteralResolved(written, written.lowercase())
+    }
+
+    private fun assertHintLiteralResolved(written: String, expectedLiteral: String) {
+        val reference = myFixture.file.findReferenceAt(myFixture.file.text.indexOf(written))
+        val valueReference = requireNotNull(reference as? ValueHintReference) {
+            "expected a ValueHintReference on the value, got: $reference"
+        }
+
+        val resolved = valueReference.multiResolve(false).mapNotNull { it.element }
+        val literals = resolved.filterIsInstance<JsonProperty>()
+            .mapNotNull { (it.value as? JsonStringLiteral)?.value }
+
+        assertEquals(
+            "one hint declaration is the useful target, got: ${resolved.map { it.containingFile.virtualFile.path }}",
+            1, resolved.size
+        )
+        assertEquals(
+            "the written value must navigate to the hint literal, got: $literals",
+            listOf(expectedLiteral), literals
+        )
+        assertEquals(ValueHintReference.ResultType.METADATA, valueReference.getResultType())
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProviderTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/providers/PropertyLineMarkerProviderTest.kt
@@ -59,6 +59,11 @@ main:
         }.size, 1)
     }
 
+    /**
+     * `logging.level.keys` is declared by both `additional-spring-configuration-metadata.json` and
+     * `spring-configuration-metadata.json` of the same `spring-boot` artifact, which are the same declaration; the
+     * gutter must offer it once.
+     */
     fun testPropertiesToMetadataHintsMapKeysName() {
         myFixture.copyFileToProject("META-INF/additional-spring-configuration-metadata.json")
         myFixture.configureByText(
@@ -71,9 +76,8 @@ main:
         val allBeanGutters = getAllBeanGuttersByIcon(myFixture, icons)
         val gutterTargetString = getGutterTargetString(allBeanGutters)
 
-        assertEquals(gutterTargetString.flatMap { gutter ->
-            gutter.filter { it == "name" }
-        }.size, 2)
+        val targets = gutterTargetString.flatMap { gutter -> gutter.filter { it == "name" } }
+        assertEquals("the same hint declared twice in one artifact must be offered once: $targets", 1, targets.size)
     }
 
     fun testYamlToMetadataHintsMapKeysName() {
@@ -92,8 +96,7 @@ logging:
         val allBeanGutters = getAllBeanGuttersByIcon(myFixture, icons)
         val gutterTargetString = getGutterTargetString(allBeanGutters)
 
-        assertEquals(gutterTargetString.flatMap { gutter ->
-            gutter.filter { it == "name" }
-        }.size, 2)
+        val targets = gutterTargetString.flatMap { gutter -> gutter.filter { it == "name" } }
+        assertEquals("the same hint declared twice in one artifact must be offered once: $targets", 1, targets.size)
     }
 }


### PR DESCRIPTION
## Purpose

Three defects around Spring configuration metadata **hints**, all visible on `logging.level.org.springframework=INFO` (Spring Boot 4.1.0).

`LoggingApplicationListener` binds `logging.level.*` as `Bindable.mapOf(String.class, LogLevel.class)`, so the value goes through relaxed binding: `INFO`, `Info` and `info` all work at runtime. The metadata hint `logging.level.values`, however, lists only lower-case literals.

### 1. Navigation ignored relaxed binding

`collectElementMetadataHintsValue` compared the written value to the hint literal verbatim (`it.findProperty(VALUE)?.value?.text == "\"$valueName\""`), so `info` navigated to its declaration and `INFO` navigated nowhere. Matching is now case-insensitive, with an exact match still preferred in case a hint ever ships two literals differing only by case.

### 2. Nothing told the user which spelling to write

No error is reported for `INFO` and that is correct — `getProblemValues` deliberately says nothing about a hint whose provider is `any`. But every hint literal Spring ships is lower case, so `SpringRecommendedEnumValueInspection` now also covers hint-provided values: a value matching a literal case-insensitively but not written as the literal is a `WEAK WARNING` with a rewrite quick-fix (`INFO` → `info`). A value matching no literal at all is **not** reported — it is either free-form or a genuine error owned by `SpringBasePropertyInspection`.

The inspection was extended rather than duplicated; the fix reuses the existing preview-safe PSI-editing machinery.

### 3. One declaration was offered as three navigation targets

`findMetadataFiles` collects from `librariesOnlyScope` with no de-duplication, so one key produced three identical targets: `spring-boot-4.1.0.jar!/…/additional-…json`, `spring-boot-4.1.0-sources.jar!/…/additional-…json` and `spring-boot-4.1.0.jar!/…/spring-configuration-metadata.json`.

New `MetadataDeclarations` collapses them per declaration name and artifact, preferring the sources jar and the hand-written `additional-…` file. It replaces two ad-hoc implementations: the `SOURCES_SUFFIX` grouping in `PropertyLineMarkerProvider` and `getOnlySourceIfExist` in `MetaConfigurationKeyReference` — neither of which de-duplicated the two metadata files inside one artifact. `ConfigurationPropertyDataRetriever.getMetadataName` had no de-duplication at all and now uses the same helper.

## How this was verified

Red-green, both `.properties` and YAML:

| Test | Red | Green |
|---|---|---|
| `HintValueCaseInsensitiveReferenceTest` (5) | `one hint declaration is the useful target, got: [] expected:<1> but was:<0>` ×3 | 5/5 |
| `RecommendedHintValueInspectionTest` (7) | `expected exactly one report, got: [] expected:<1> but was:<0>` ×3, `expected exactly one rewrite fix, got: [] expected:<1> but was:<0>` ×2 | 7/7 |
| `PropertyLineMarkerProviderTest` (4) | `the same hint declared twice in one artifact must be offered once: [name, name] expected:<1> but was:<2>` ×2 | 4/4 |

Every red failure lands on the assertion under test, not in `setUp`.

Quick-fix tests use `checkPreviewAndLaunchAction`, which asserts the Alt+Enter preview diff equals the real result — the trap that a plain `launchAction` misses.

Regression: `:spring-core:test` over `reference.*`, `completion.properties.*`, `providers.*`, `inspections.java.*Propert*`, `inspections.yaml.*` — **740 tests, 0 failures**, run with `--rerun` to bypass the build cache.

`RecommendedEnumValueLoggingLevelTest.testLoggingLevelRootNotReported` was the previous acceptance test asserting `logging.level.root=INFO` is silent; it was rewritten in this PR because that is exactly the case now being reported. The blocker it protected — never reporting a value that resolves to nothing — is still covered by `testUnknownValueNotReported`.

## Known gap, deliberately not fixed here

Navigation on the **key** `logging.level.org.springframework` still goes nowhere: `logging.level` is a `Map<String, String>`, so the suffix is arbitrary and no exact metadata entry exists. `PropertyUtil.findValueOwner` already implements the longest-map-prefix fallback needed to resolve it; wiring the key reference to it is a separate change.