### PR TITLE
fix: Complete a metadata hint value from a prefix written in any case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
 - fix: Accept an enum configuration value in any relaxed form, so `request-headers` resolves to `REQUEST_HEADERS` and is no longer reported as invalid
 - fix: Complete an enum configuration value from any relaxed spelling and insert Spring's recommended one, so `r`, `request-h`, `request_h` and `REQ` all insert `request-headers`
+- fix: Complete a metadata hint value from a prefix written in any case and insert the declared literal, so `logging.level.org.springframework=IN` offers and inserts `info`
 - feat: Report an enum configuration value that is not written in Spring's recommended spelling, with a quick-fix rewriting `REQUEST_HEADERS` to `request-headers`
 - fix: Resolve a configuration value against the enum element type of an array property such as `Include[]` and of a map property such as `java.util.Map<String, Include>`
 - fix: Navigate a configuration value to its metadata hint declaration whatever its case, so `logging.level.root=INFO` navigates like `info`

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/ValueHintReference.kt
@@ -162,8 +162,16 @@ class ValueHintReference(
         val result = mutableListOf<Any>()
         result.addAll(
             propertyHint.values
-            .filter { it.value != null }
-            .map { LookupElementBuilder.create(it, it.value!!).withRenderer(PropertyValueRenderer()) })
+                .filter { it.value != null }
+                .map {
+                    val literal = it.value!!
+                    // Hint resolution matches a literal ignoring case, so completion has to offer it for a prefix in
+                    // any case too. Case sensitivity has to stay on: it is what makes the platform insert the declared
+                    // literal verbatim instead of echoing the case of the typed prefix.
+                    LookupElementBuilder.create(it, literal)
+                        .withLookupStrings(PropertyUtil.hintValueSpellings(literal))
+                        .withRenderer(PropertyValueRenderer())
+                })
 
         propertyHint.providers.flatMapTo(result) { providerHint ->
             processProviderHints(providerHint)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -267,6 +267,15 @@ object PropertyUtil {
     }
 
     /**
+     * The spellings of the metadata hint literal [literal] that a user types and hint resolution accepts.
+     *
+     * A hint literal is an arbitrary string, not an enum constant name, so [relaxedValueSpellings] does not apply: it
+     * maps `_` to `-`, a rewrite hint matching does not perform. Only the case is free, which is why the alternatives
+     * are the case variants of the literal itself.
+     */
+    fun hintValueSpellings(literal: String): Set<String> = setOf(literal.lowercase(), literal.uppercase())
+
+    /**
      * The spelling of the enum constant [constantName] that Spring itself recommends: lower-case kebab-case.
      *
      * Measured on `spring-boot-autoconfigure-3.5.13`, every enum-typed property with a string `defaultValue` ships it

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/HintValueCaseInsensitiveCompletionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/HintValueCaseInsensitiveCompletionTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.test.ExplytInspectionJavaTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.codeInsight.CodeInsightSettings
+
+/**
+ * Value completion has to offer a metadata hint literal for every case relaxed binding accepts, and still insert the
+ * literal Spring ships. `logging.level.values` declares `trace`/`debug`/`info`/..., all lower case, while the level a
+ * user types is habitually upper case.
+ */
+class HintValueCaseInsensitiveCompletionTest : ExplytInspectionJavaTestCase() {
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springBoot_3_1_1)
+
+    private var savedCompletionCaseSensitive = CodeInsightSettings.FIRST_LETTER
+
+    override fun setUp() {
+        super.setUp()
+        // An upper-case prefix would match regardless of the fix under CodeInsightSettings.NONE, so pin the
+        // production default instead of trusting the test environment.
+        val settings = CodeInsightSettings.getInstance()
+        savedCompletionCaseSensitive = settings.completionCaseSensitive
+        settings.completionCaseSensitive = CodeInsightSettings.FIRST_LETTER
+    }
+
+    override fun tearDown() {
+        try {
+            CodeInsightSettings.getInstance().completionCaseSensitive = savedCompletionCaseSensitive
+        } catch (e: Throwable) {
+            addSuppressedException(e)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testUpperCasePrefixInsertsDeclaredLiteral() =
+        assertCompletesTo("logging.level.org.springframework=IN", "logging.level.org.springframework=info")
+
+    fun testMixedCasePrefixInsertsDeclaredLiteral() =
+        assertCompletesTo("logging.level.org.springframework=In", "logging.level.org.springframework=info")
+
+    fun testFullUpperCaseValueInsertsDeclaredLiteral() =
+        assertCompletesTo("logging.level.org.springframework=INFO", "logging.level.org.springframework=info")
+
+    fun testLowerCasePrefixStillInsertsDeclaredLiteral() =
+        assertCompletesTo("logging.level.org.springframework=in", "logging.level.org.springframework=info")
+
+    fun testUpperCasePrefixInsertsTheLiteralItMatches() =
+        assertCompletesTo("logging.level.root=WA", "logging.level.root=warn")
+
+    fun testEmptyPrefixOffersEveryDeclaredLiteral() {
+        myFixture.configureByText("application.properties", "logging.level.root=<caret>")
+        myFixture.completeBasic()
+
+        val lookupElementStrings = myFixture.lookupElementStrings
+        assertNotNull("expected a completion popup, but got a single auto-inserted item", lookupElementStrings)
+        assertEquals(
+            setOf("trace", "debug", "info", "warn", "error", "fatal", "off"),
+            lookupElementStrings!!.toSet()
+        )
+    }
+
+    fun testPrefixMatchingNoLiteralOffersNothing() {
+        myFixture.configureByText("application.properties", "logging.level.root=ZZ<caret>")
+        myFixture.completeBasic()
+
+        assertTrue(
+            "no hint literal starts with the typed prefix, got: ${myFixture.lookupElementStrings}",
+            myFixture.lookupElementStrings.isNullOrEmpty()
+        )
+        myFixture.checkResult("logging.level.root=ZZ")
+    }
+
+    fun testYamlUpperCasePrefixInsertsDeclaredLiteral() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                root: IN<caret>
+            """.trimIndent()
+        )
+        myFixture.completeBasic()
+
+        myFixture.checkResult(
+            """
+            logging:
+              level:
+                root: info
+            """.trimIndent()
+        )
+    }
+
+    fun testYamlLowerCasePrefixStillInsertsDeclaredLiteral() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                root: in<caret>
+            """.trimIndent()
+        )
+        myFixture.completeBasic()
+
+        myFixture.checkResult(
+            """
+            logging:
+              level:
+                root: info
+            """.trimIndent()
+        )
+    }
+
+    private fun assertCompletesTo(text: String, expected: String) {
+        myFixture.configureByText("application.properties", "$text<caret>")
+        myFixture.completeBasic()
+
+        myFixture.checkResult(expected)
+    }
+}


### PR DESCRIPTION
Stacked on #310 — base is `imuromtsev/hint-value-case-insensitive`, so the diff here is one commit. GitHub retargets it to `main` once #310 merges. The tests need #310's hint fixtures, which is why it is not branched off `main`.

## Problem

`logging.level.org.springframework=IN<caret>` offered nothing. `logging.level.values` declares the lowercase literals `trace`/`debug`/`info`/`warn`/`error`/`fatal`/`off`, and a hint lookup element carried the declared literal as its **only** lookup string. Under the production completion case sensitivity (`FIRST_LETTER`) the prefix `IN` matched none of them, so the popup said "No suggestions" — while the same value resolves and is inspected case-insensitively after #310.

This is the third independent path for one value. #299 fixed enum resolution and the inspection, and completion still needed #302 afterwards; #310 fixed hint resolution and the inspection, and this is its completion half.

## Fix

`ValueHintReference.getVariantsByHint` now gives each hint lookup element the case variants of the literal via `withLookupStrings`.

`PropertyUtil.relaxedValueSpellings` is **not** reusable here: it maps `_` to `-`, a rewrite hint matching never performs, and a hint literal is an arbitrary string rather than an enum constant name (`create-drop`, `text/html`, `ru_RU`). The new `PropertyUtil.hintValueSpellings` keeps to the lower- and upper-case spellings of the literal, which is exactly what `collectElementMetadataHintsValue`'s `ignoreCase = true` accepts.

Case sensitivity stays **on**. `withCaseSensitivity(false)` also drives `LookupUtil.getCaseCorrectedLookupString`, which echoes the typed prefix's case into the inserted text — the trap that cost a build-and-revert cycle in #302. The extra lookup strings alone give case-insensitive matching while the inserted text stays the declared literal.

The enum branch, `processProviderHints` and `PropertyValueRenderer` are untouched.

## Verification

New `HintValueCaseInsensitiveCompletionTest` (9 tests, `.properties` and YAML). It pins `CodeInsightSettings.completionCaseSensitive` to the production `FIRST_LETTER` in `setUp` and restores it in `tearDown`: under the `NONE` default an uppercase-prefix test would pass without the fix and prove nothing.

Red phase without the fix — 6 of 9 failed, each inside its assertion, none in setup:

| test | failure |
| --- | --- |
| `testUpperCasePrefixInsertsDeclaredLiteral` | `FileComparisonFailedError` — `IN` stayed unchanged |
| `testMixedCasePrefixInsertsDeclaredLiteral` | `FileComparisonFailedError` |
| `testFullUpperCaseValueInsertsDeclaredLiteral` | `FileComparisonFailedError` |
| `testUpperCasePrefixInsertsTheLiteralItMatches` | `FileComparisonFailedError` |
| `testYamlUpperCasePrefixInsertsDeclaredLiteral` | `FileComparisonFailedError` |
| `testPrefixMatchingNoLiteralOffersNothing` | `AssertionFailedError: no hint literal starts with the typed prefix, got: []` — the popup was empty for every prefix, including the ones that should match |

With the fix: 9/9 green. The lowercase-prefix and no-match cases are the regression guards.

Inserted text is asserted with `checkResult`, not with the lookup strings: `IN`, `In` and `INFO` all end as `info`, never `INFO` or `In`.

Regression, run sequentially: `PropertiesCompletionValueByMetadataTest` (java 14, kotlin 3), `YamlCompletionValueByMetadataTest` (java 16, kotlin 3), `RelaxedEnumValueCompletionTest` (12) — all green, 57 tests total with the new class.
