### PR TITLE
fix: Navigate from a logging.level key to the group or logger name its suffix names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fix: Navigate a configuration value to its metadata hint declaration whatever its case, so `logging.level.root=INFO` navigates like `info`
 - feat: Report a configuration value that differs from its metadata hint literal only by case, with a quick-fix rewriting `INFO` to `info`
 - fix: Offer one navigation target per metadata declaration instead of repeating the same hint or key once per metadata file and once per sources jar of the same artifact
+- fix: Navigate from the key of `logging.level.<suffix>` to what the suffix names: the package or class of a logger name such as `org.springframework`, the `logging.level.keys` hint declaration of a group such as `root`, `sql` or `web`, and the `logging.group.<name>` entry of a group the project defines itself
 - fix: Navigate a configuration key with no declaring member, such as `management.endpoint.httpexchanges.access`, to its value type instead of the unrelated source class
 - fix: Do not fail the Alt+Enter preview of the deprecated configuration key replacement quick-fix
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationPropertiesKeyLoggingLevelReferenceProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationPropertiesKeyLoggingLevelReferenceProvider.kt
@@ -7,25 +7,15 @@ package com.explyt.spring.core.properties.providers
 
 import com.explyt.spring.core.SpringProperties.LOGGING_LEVEL
 import com.explyt.spring.core.SpringProperties.PLACEHOLDER_PREFIX
-import com.explyt.spring.core.SpringProperties.POSTFIX_KEYS
-import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
-import com.explyt.spring.core.completion.properties.ValueHint
-import com.explyt.spring.core.statistic.StatisticActionId
-import com.explyt.spring.core.statistic.StatisticInsertHandler
-import com.explyt.util.ExplytTextUtil.getFirstSentenceWithoutDot
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.icons.AllIcons
+import com.explyt.spring.core.properties.references.LoggingLevelKeys
 import com.intellij.openapi.module.ModuleUtilCore
-import com.intellij.openapi.util.TextRange
-import com.intellij.psi.*
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceProvider
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceSet
+import com.intellij.psi.ElementManipulators
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceProvider
 import com.intellij.util.ProcessingContext
 
 class SpringConfigurationPropertiesKeyLoggingLevelReferenceProvider : PsiReferenceProvider() {
-
-    private val referenceProvider = JavaClassReferenceProvider()
-        .apply { isSoft = true }
 
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
         val valueTextRange = ElementManipulators.getValueTextRange(element)
@@ -35,61 +25,10 @@ class SpringConfigurationPropertiesKeyLoggingLevelReferenceProvider : PsiReferen
 
         val textRange = valueTextRange.shiftRight(startInElement).grown(-startInElement)
 
-        val elementText = element.text
-        val rangeText = textRange.substring(elementText)
+        val rangeText = textRange.substring(element.text)
         if (rangeText.contains(PLACEHOLDER_PREFIX)) return PsiReference.EMPTY_ARRAY
 
-        val offset = textRange.startOffset
-        val classReferences = JavaClassReferenceSet(rangeText, element, offset, false, referenceProvider)
-            .references
-
-        val valuesReference = buildReferencesFromValueHints(element, offset)
-
-        return arrayOf(*valuesReference, *classReferences)
-    }
-
-    private fun buildReferencesFromValueHints(
-        element: PsiElement,
-        textOffset: Int
-    ): Array<PsiReference> {
-
         val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return PsiReference.EMPTY_ARRAY
-        val hint = SpringConfigurationPropertiesSearch.getInstance(element.project)
-            .findHint(module, LOGGING_LEVEL + POSTFIX_KEYS) ?: return PsiReference.EMPTY_ARRAY
-        return hint.values.mapNotNull { valueHint ->
-
-            val value = valueHint.value ?: return@mapNotNull null
-            val startOffset = textOffset
-            val endOffset = textOffset + value.length
-
-            val textRange = TextRange(startOffset, endOffset)
-
-            LoggingLevelKeysPsiReference(element, textRange, valueHint)
-        }.toTypedArray()
+        return LoggingLevelKeys.referencesForSuffix(element, module, rangeText, textRange, offerGroupVariants = true)
     }
-
-}
-
-class LoggingLevelKeysPsiReference(
-    element: PsiElement,
-    rangeInElement: TextRange,
-    private val valueHint: ValueHint
-) : PsiReferenceBase.Poly<PsiElement>(element, rangeInElement, true) {
-
-    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
-        return emptyArray()
-    }
-
-    override fun getVariants(): Array<LookupElementBuilder> {
-        val lookupString = valueHint.value ?: return emptyArray()
-        val tailText = if (valueHint.description != null)
-            " (${getFirstSentenceWithoutDot(valueHint.description)})" else ""
-        return arrayOf(
-            LookupElementBuilder.create(lookupString)
-                .appendTailText(tailText, true)
-                .withIcon(AllIcons.Nodes.Property)
-                .withInsertHandler(StatisticInsertHandler(StatisticActionId.COMPLETION_PROPERTY_KEY_CONFIGURATION))
-        )
-    }
-
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationPropertyKeyReferenceProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationPropertyKeyReferenceProvider.kt
@@ -20,6 +20,7 @@ import com.explyt.spring.core.completion.properties.SpringConfigurationPropertie
 import com.explyt.spring.core.completion.renderer.PropertyRenderer
 import com.explyt.spring.core.properties.PropertiesJavaClassReferenceSet
 import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
+import com.explyt.spring.core.properties.references.LoggingLevelKeys
 import com.explyt.spring.core.properties.references.MetaConfigurationKeyReference
 import com.explyt.spring.core.properties.references.PropertiesKeyMapValueReference
 import com.explyt.spring.core.properties.references.YamlKeyMapValueReference
@@ -45,8 +46,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
 import com.intellij.psi.impl.FakePsiElement
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceProvider
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceSet
 import com.intellij.util.ProcessingContext
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtParameter
@@ -54,9 +53,6 @@ import org.jetbrains.uast.toUElement
 import org.jetbrains.yaml.YAMLLanguage
 
 class SpringConfigurationPropertyKeyReferenceProvider : PsiReferenceProvider() {
-
-    private val referenceProvider = JavaClassReferenceProvider()
-        .apply { isSoft = true }
 
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
         if (!SpringCoreUtil.isConfigurationPropertyFile(element.containingFile)) {
@@ -96,7 +92,7 @@ class SpringConfigurationPropertyKeyReferenceProvider : PsiReferenceProvider() {
         if (referencesByPrefixKey.isNotEmpty()) {
             return referencesByPrefixKey
         }
-        val referencesByLoggingLevel = getPsiReferencesByMapKeyLoggingLevel(propertyKey, element)
+        val referencesByLoggingLevel = getPsiReferencesByMapKeyLoggingLevel(propertyKey, element, module)
         if (referencesByLoggingLevel.isNotEmpty()) {
             return referencesByLoggingLevel
         }
@@ -235,15 +231,20 @@ class SpringConfigurationPropertyKeyReferenceProvider : PsiReferenceProvider() {
 
     private fun getPsiReferencesByMapKeyLoggingLevel(
         propertyKey: String,
-        element: PsiElement
+        element: PsiElement,
+        module: Module
     ): Array<PsiReference> {
         if (!propertyKey.startsWith("$LOGGING_LEVEL.")) return emptyArray()
 
+        val suffix = propertyKey.substringAfter("$LOGGING_LEVEL.")
         val valueText = ElementManipulators.getValueText(element)
-        val offset = ElementManipulators.getOffsetInElement(element)
+        // In YAML the key is split across nesting levels, so this element carries only the tail of the full key: the
+        // suffix alone under `logging.level:`, the whole key when it is written flat. Only the part of this element
+        // that belongs to the suffix may be covered.
+        if (!valueText.endsWith(suffix)) return emptyArray()
+        val offset = ElementManipulators.getOffsetInElement(element) + valueText.length - suffix.length
 
-        return JavaClassReferenceSet(valueText, element, offset, false, referenceProvider)
-            .references
+        return LoggingLevelKeys.referencesForSuffix(element, module, suffix, TextRange.from(offset, suffix.length))
     }
 }
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationYamlKeyLoggingLevelReferenceProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/SpringConfigurationYamlKeyLoggingLevelReferenceProvider.kt
@@ -6,12 +6,13 @@
 package com.explyt.spring.core.properties.providers
 
 import com.explyt.spring.core.SpringProperties.LOGGING_LEVEL
+import com.explyt.spring.core.properties.references.LoggingLevelKeys
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.ElementManipulators
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiReferenceProvider
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceProvider
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceSet
 import com.intellij.util.ProcessingContext
 import org.jetbrains.yaml.YAMLUtil
 import org.jetbrains.yaml.psi.YAMLKeyValue
@@ -19,9 +20,6 @@ import org.jetbrains.yaml.psi.YAMLMapping
 import org.jetbrains.yaml.psi.YAMLScalar
 
 class SpringConfigurationYamlKeyLoggingLevelReferenceProvider : PsiReferenceProvider() {
-
-    private val referenceProvider = JavaClassReferenceProvider()
-        .apply { isSoft = true }
 
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
         val yamlScalar = element as? YAMLScalar ?: return PsiReference.EMPTY_ARRAY
@@ -38,8 +36,10 @@ class SpringConfigurationYamlKeyLoggingLevelReferenceProvider : PsiReferenceProv
 
         val textValue = yamlScalar.textValue
         val offset = ElementManipulators.getOffsetInElement(yamlScalar)
+        val module = ModuleUtilCore.findModuleForPsiElement(yamlScalar) ?: return PsiReference.EMPTY_ARRAY
 
-        return JavaClassReferenceSet(textValue, yamlScalar, offset, false, referenceProvider)
-            .references
+        return LoggingLevelKeys.referencesForSuffix(
+            yamlScalar, module, textValue, TextRange.from(offset, textValue.length)
+        )
     }
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/LoggingLevelKeys.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/references/LoggingLevelKeys.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.references
+
+import com.explyt.spring.core.SpringProperties.LOGGING_LEVEL
+import com.explyt.spring.core.SpringProperties.POSTFIX_KEYS
+import com.explyt.spring.core.SpringProperties.VALUE
+import com.explyt.spring.core.SpringProperties.VALUES
+import com.explyt.spring.core.completion.properties.DefinedConfigurationPropertiesSearch
+import com.explyt.spring.core.completion.properties.MetadataDeclarations
+import com.explyt.spring.core.completion.properties.SpringConfigurationPropertiesSearch
+import com.explyt.spring.core.completion.properties.ValueHint
+import com.explyt.spring.core.statistic.StatisticActionId
+import com.explyt.spring.core.statistic.StatisticInsertHandler
+import com.explyt.spring.core.util.PropertyUtil
+import com.explyt.spring.core.util.PropertyUtil.DOT
+import com.explyt.util.ExplytTextUtil.getFirstSentenceWithoutDot
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.json.psi.JsonArray
+import com.intellij.json.psi.JsonObject
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceProvider
+import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceSet
+
+/**
+ * The suffix of `logging.level.<suffix>` names either a logging group or a logger name, and Spring says which:
+ * the `logging.level.keys` hint declares the groups the framework ships, `logging.group.<name>` declares the ones a
+ * project adds, and anything else is a logger name, that is a package or a class.
+ */
+object LoggingLevelKeys {
+
+    private const val LOGGING_GROUP = "logging.group"
+
+    private const val KEYS_HINT_NAME = LOGGING_LEVEL + POSTFIX_KEYS
+
+    private val loggerNameProvider = JavaClassReferenceProvider().apply {
+        // A logger name that names nothing is legal - the logger simply has no output - so an unresolved segment must
+        // not be reported as an error.
+        isSoft = true
+        // Without advanced resolve the last segment of the chain is only looked up as a class, so `springframework` of
+        // `org.springframework` resolved to nothing while the `org` before it resolved to its package.
+        setOption(JavaClassReferenceProvider.ADVANCED_RESOLVE, true)
+    }
+
+    /**
+     * The references covering [suffix], which occupies [range] of [element].
+     *
+     * [offerGroupVariants] belongs to the caller because the two configuration formats complete the suffix
+     * differently: in `.properties` the group names come from this reference, while in YAML the completion
+     * contributor already offers them, filtered by the groups the file has not used yet.
+     */
+    fun referencesForSuffix(
+        element: PsiElement,
+        module: Module,
+        suffix: String,
+        range: TextRange,
+        offerGroupVariants: Boolean = false
+    ): Array<PsiReference> {
+        // A group is a single name, so a suffix that is a chain of segments can only be a logger name. Skipping the
+        // group reference there also keeps it from covering a range it can never resolve.
+        if (suffix.contains(DOT)) return loggerNameReferences(element, suffix, range)
+
+        val groupReference = LoggingLevelGroupReference(element, module, range, suffix, offerGroupVariants)
+        // A group and a logger name are mutually exclusive, so a declared group is not offered the logger-name chain as
+        // a competing target for the same range.
+        if (isGroup(module, suffix)) return arrayOf(groupReference)
+
+        return arrayOf(groupReference, *loggerNameReferences(element, suffix, range))
+    }
+
+    private fun loggerNameReferences(element: PsiElement, suffix: String, range: TextRange): Array<PsiReference> =
+        JavaClassReferenceSet(suffix, element, range.startOffset, false, loggerNameProvider).references
+
+    /** The groups Spring itself declares, as literals of the `logging.level.keys` hint. */
+    internal fun declaredGroupHints(module: Module): List<ValueHint> {
+        return SpringConfigurationPropertiesSearch.getInstance(module.project)
+            .findHint(module, KEYS_HINT_NAME)
+            ?.values.orEmpty()
+    }
+
+    private fun isGroup(module: Module, suffix: String): Boolean {
+        if (suffix.isEmpty()) return false
+        if (declaredGroupHints(module).any { it.value.equals(suffix, ignoreCase = true) }) return true
+        return DefinedConfigurationPropertiesSearch.getInstance(module.project)
+            .getPropertiesCommonKeyMap(module)
+            .containsKey(PropertyUtil.toCommonPropertyForm("$LOGGING_GROUP.$suffix"))
+    }
+
+    /** The `"value": "<group>"` property of the `logging.level.keys` hint, or `null` when Spring declares no such group. */
+    internal fun declaredGroupDeclaration(module: Module, group: String): JsonProperty? {
+        val declarations = SpringConfigurationPropertiesSearch.getInstance(module.project)
+            .getElementNameHints(module)
+            .filter { it.name == KEYS_HINT_NAME }
+            .mapNotNull { valueDeclaration(it.jsonProperty, group) }
+        // Both metadata files of an artifact and its sources jar ship the same hint; they are one declaration.
+        return MetadataDeclarations.preferred(declarations) { it.containingFile }
+    }
+
+    /** The `logging.group.<group>` entries of the project's own configuration files. */
+    internal fun definedGroupDeclarations(module: Module, group: String): List<PsiElement> {
+        return DefinedConfigurationPropertiesSearch.getInstance(module.project)
+            .getPropertiesCommonKeyMap(module)[PropertyUtil.toCommonPropertyForm("$LOGGING_GROUP.$group")]
+            .orEmpty()
+            .mapNotNull { it.psiElement }
+    }
+
+    private fun valueDeclaration(hintName: JsonProperty, group: String): JsonProperty? {
+        val values = (hintName.parent as? JsonObject)?.findProperty(VALUES)?.value as? JsonArray ?: return null
+        val matching = values.valueList.asSequence()
+            .mapNotNull { it as? JsonObject }
+            .mapNotNull { it.findProperty(VALUE) }
+            .filter { (it.value as? JsonStringLiteral)?.value.equals(group, ignoreCase = true) }
+            .toList()
+        // An exact match wins, in case a hint ever ships two literals differing by case alone.
+        return matching.firstOrNull { (it.value as? JsonStringLiteral)?.value == group } ?: matching.firstOrNull()
+    }
+
+    internal fun groupLookupElement(valueHint: ValueHint): LookupElementBuilder? {
+        val value = valueHint.value ?: return null
+        val tailText = valueHint.description?.let { " (${getFirstSentenceWithoutDot(it)})" } ?: ""
+        return LookupElementBuilder.create(value)
+            .appendTailText(tailText, true)
+            .withIcon(AllIcons.Nodes.Property)
+            .withInsertHandler(StatisticInsertHandler(StatisticActionId.COMPLETION_PROPERTY_KEY_CONFIGURATION))
+    }
+}
+
+/**
+ * The suffix of `logging.level.<suffix>` read as a logging group: a value of the `logging.level.keys` hint, or a
+ * `logging.group.<suffix>` entry of the project's own configuration.
+ */
+class LoggingLevelGroupReference(
+    element: PsiElement,
+    private val module: Module,
+    rangeInElement: TextRange,
+    private val group: String,
+    private val offerVariants: Boolean
+) : PsiReferenceBase.Poly<PsiElement>(element, rangeInElement, true) {
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        if (group.isEmpty()) return ResolveResult.EMPTY_ARRAY
+        LoggingLevelKeys.declaredGroupDeclaration(module, group)
+            ?.let { return PsiElementResolveResult.createResults(it) }
+        return PsiElementResolveResult.createResults(LoggingLevelKeys.definedGroupDeclarations(module, group))
+    }
+
+    override fun getVariants(): Array<Any> {
+        if (!offerVariants) return emptyArray()
+        return LoggingLevelKeys.declaredGroupHints(module)
+            .mapNotNull { LoggingLevelKeys.groupLookupElement(it) }
+            .toTypedArray()
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/LoggingLevelKeyCompletionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/LoggingLevelKeyCompletionTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.explyt.spring.test.TestLibrary
+
+/**
+ * Completion of the key of `logging.level.<suffix>`.
+ *
+ * Resolution, inspection and completion of a key are three independent paths, so reworking the references that resolve
+ * the suffix has to be shown not to cost the completion served by the same references.
+ */
+class LoggingLevelKeyCompletionTest : ExplytJavaLightTestCase() {
+
+    override val libraries: Array<TestLibrary> =
+        arrayOf(TestLibrary.springBoot_3_1_1, TestLibrary.springBootAutoConfigure_3_1_1)
+
+    fun testGroupsAndPackagesAreOffered() {
+        myFixture.configureByText("application.properties", "logging.level.<caret>")
+
+        val variants = myFixture.completeBasic().map { it.lookupString }
+
+        assertContainsElements(variants, "root", "sql", "web")
+        assertContainsElements(variants, "org", "java")
+    }
+
+    fun testPackagesAreOfferedInsideAPackageChain() {
+        myFixture.configureByText("application.properties", "logging.level.org.<caret>")
+
+        val variants = myFixture.completeBasic().map { it.lookupString }
+
+        assertContainsElements(variants, "springframework")
+    }
+
+    fun testYamlGroupsAreOffered() {
+        myFixture.configureByText("application.yaml", "logging:\n  level:\n    <caret>")
+
+        val variants = myFixture.completeBasic().map { it.lookupString }
+
+        assertContainsElements(variants, "root", "sql", "web")
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/LoggingLevelKeyReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/LoggingLevelKeyReferenceTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.PsiPolyVariantReference
+
+/**
+ * Navigation on the key of `logging.level.<suffix>`.
+ *
+ * Spring describes both kinds of suffix itself: `logging.level.keys` declares the logging groups it ships, and its
+ * `logger-name` provider says anything else names a logger, that is a package or a class.
+ */
+class LoggingLevelKeyReferenceTest : ExplytJavaLightTestCase() {
+
+    override val libraries: Array<TestLibrary> =
+        arrayOf(TestLibrary.springBoot_3_1_1, TestLibrary.springBootAutoConfigure_3_1_1)
+
+    fun testPackageSuffixResolvesToPackage() {
+        myFixture.configureByText("application.properties", "logging.level.org.springframework=DEBUG")
+
+        assertResolvesToPackage("springframework", "org.springframework")
+    }
+
+    fun testNestedPackageSuffixResolvesToPackage() {
+        myFixture.configureByText("application.properties", "logging.level.org.springframework.boot=DEBUG")
+
+        assertResolvesToPackage("boot", "org.springframework.boot")
+    }
+
+    fun testFirstSegmentOfPackageSuffixStillResolves() {
+        myFixture.configureByText("application.properties", "logging.level.org.springframework=DEBUG")
+
+        assertResolvesToPackage("org", "org")
+    }
+
+    fun testRootGroupResolvesToHintValue() = assertResolvesToDeclaredGroup("root")
+
+    fun testSqlGroupResolvesToHintValue() = assertResolvesToDeclaredGroup("sql")
+
+    fun testWebGroupResolvesToHintValue() = assertResolvesToDeclaredGroup("web")
+
+    fun testUnknownSuffixResolvesToNothing() {
+        myFixture.configureByText("application.properties", "logging.level.no.such.pkg=DEBUG")
+
+        val targets = targetsAt("pkg")
+        assertEquals("a logger name naming nothing must offer no target, got: $targets", 0, targets.size)
+        assertTrue(
+            "an unknown logger name is legal and must not be reported",
+            referenceAt("pkg")?.isSoft != false
+        )
+    }
+
+    fun testYamlPackageSuffixResolvesToPackage() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                org.springframework: DEBUG
+            """.trimIndent()
+        )
+
+        assertResolvesToPackage("springframework", "org.springframework")
+    }
+
+    fun testYamlRootGroupResolvesToHintValue() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              level:
+                root: DEBUG
+            """.trimIndent()
+        )
+
+        assertDeclaredGroupResolved("root")
+    }
+
+    fun testYamlFlatKeyPackageSuffixResolvesToPackage() {
+        myFixture.configureByText("application.yaml", "logging.level.org.springframework: DEBUG")
+
+        assertResolvesToPackage("springframework", "org.springframework")
+    }
+
+    fun testYamlFlatKeyGroupResolvesToHintValue() {
+        myFixture.configureByText("application.yaml", "logging.level.root: DEBUG")
+
+        assertDeclaredGroupResolved("root")
+    }
+
+    fun testUserDefinedGroupResolvesToItsDefinition() {
+        myFixture.configureByText(
+            "application.properties",
+            """
+            logging.group.mine=com.example.a,com.example.b
+            logging.level.mine=DEBUG
+            """.trimIndent()
+        )
+
+        val targets = targetsAtLast("mine")
+
+        assertEquals(
+            "a user-defined group is one definition, got: ${targets.map { describe(it) }}",
+            1, targets.size
+        )
+        assertEquals(
+            "the group must navigate to its `logging.group` definition",
+            "logging.group.mine=com.example.a,com.example.b", targets.single().text
+        )
+    }
+
+    fun testYamlUserDefinedGroupResolvesToItsDefinition() {
+        myFixture.configureByText(
+            "application.yaml",
+            """
+            logging:
+              group:
+                mine: com.example.a,com.example.b
+              level:
+                mine: DEBUG
+            """.trimIndent()
+        )
+
+        val targets = targetsAtLast("mine")
+
+        assertEquals(
+            "a user-defined group is one definition, got: ${targets.map { describe(it) }}",
+            1, targets.size
+        )
+        assertEquals(
+            "the group must navigate to its `logging.group` definition",
+            "mine: com.example.a,com.example.b", targets.single().text
+        )
+    }
+
+    fun testUserDefinedGroupWinsOverPackageOfTheSameName() {
+        myFixture.addClass("package org.example; public class A {}")
+        myFixture.configureByText(
+            "application.properties",
+            """
+            logging.group.org=com.example.a
+            logging.level.org=DEBUG
+            """.trimIndent()
+        )
+
+        val targets = targetsAtLast("org")
+
+        assertEquals(
+            "the more specific group definition must be the only target, got: ${targets.map { describe(it) }}",
+            1, targets.size
+        )
+        assertEquals("logging.group.org=com.example.a", targets.single().text)
+    }
+
+    private fun assertResolvesToDeclaredGroup(group: String) {
+        myFixture.configureByText("application.properties", "logging.level.$group=DEBUG")
+
+        assertDeclaredGroupResolved(group)
+    }
+
+    private fun assertDeclaredGroupResolved(group: String) {
+        val targets = targetsAt(group)
+
+        assertEquals(
+            "a declared group is one declaration, got: ${targets.map { describe(it) }}",
+            1, targets.size
+        )
+        val literal = (targets.single() as? JsonProperty)?.value as? JsonStringLiteral
+        assertEquals(
+            "the group must navigate to its `logging.level.keys` hint literal, got: ${describe(targets.single())}",
+            group, literal?.value
+        )
+    }
+
+    private fun assertResolvesToPackage(segment: String, expectedPackage: String) {
+        val targets = targetsAt(segment)
+
+        assertEquals(
+            "a logger name is one package, got: ${targets.map { describe(it) }}",
+            1, targets.size
+        )
+        assertEquals(
+            "the logger name must navigate to its package",
+            expectedPackage, (targets.single() as? PsiPackage)?.qualifiedName
+        )
+    }
+
+    /** Resolution as Ctrl+Click performs it: through whatever reference the platform picks at the caret. */
+    private fun targetsAt(segment: String): List<PsiElement> {
+        val reference = referenceAt(segment) ?: return emptyList()
+        return when (reference) {
+            is PsiPolyVariantReference -> reference.multiResolve(false).mapNotNull { it.element }
+            else -> listOfNotNull(reference.resolve())
+        }
+    }
+
+    private fun targetsAtLast(segment: String): List<PsiElement> {
+        val offset = myFixture.file.text.lastIndexOf(segment) + segment.length - 1
+        val reference = myFixture.file.findReferenceAt(offset) ?: return emptyList()
+        return when (reference) {
+            is PsiPolyVariantReference -> reference.multiResolve(false).mapNotNull { it.element }
+            else -> listOfNotNull(reference.resolve())
+        }
+    }
+
+    private fun referenceAt(segment: String) =
+        myFixture.file.findReferenceAt(myFixture.file.text.indexOf(segment) + segment.length - 1)
+
+    private fun describe(element: PsiElement) =
+        "${element::class.java.simpleName}[${element.text}] in ${element.containingFile?.virtualFile?.path}"
+}


### PR DESCRIPTION
> **Stacked on #310.** `MetadataDeclarations`, which this change reuses, is not in `main` yet, so this branch is
> based on `imuromtsev/hint-value-case-insensitive`. The first commit shown here belongs to #310 and disappears
> once it merges. Please merge #310 first.

## Purpose

`Ctrl+Click` on the **key** of `logging.level.<suffix>` resolved to nothing beyond its first segment.
On `logging.level.org.springframework`, `org` navigated to its package but `springframework` did not, and
`logging.level.root`, `.sql` and `.web` navigated nowhere at all.

Spring describes both kinds of suffix itself, so neither is hardcoded here. The `logging.level.keys` hint
declares the groups the framework ships, and its `logger-name` provider says anything else names a logger —
a package or a class. The groups are read from the hint at resolve time, so a group added by a future Spring
release works without a plugin change.

## Root cause — three, one per kind of suffix

A throwaway probe dumping every reference on the key, its range and what it resolved to found each of them;
none was visible from reading the code alone.

1. **A group had no reference that resolves.** `LoggingLevelKeysPsiReference` existed and covered the right
   range, but served completion only — its `multiResolve` returned an empty array unconditionally.
2. **A logger name lost its last segment.** `JavaClassReferenceProvider` without `ADVANCED_RESOLVE` looks the
   last segment of a chain up as a *class* only, never as a package. That is why `org` resolved and
   `springframework` did not — the offset was correct all along.
3. **In YAML the key never reached the logging-level path.** The `YAMLKeyValue` carries only the *tail* of the
   key (`org.springframework` under `logging.level:`), while the range was built from the whole key, so it
   covered the wrong text and the branch bailed out.

## Change

`LoggingLevelKeys` becomes the single place that reads a suffix, and both configuration formats go through it.
A group and a logger name are mutually exclusive, so a declared group is not offered the logger-name chain as a
competing target for the same range, and a suffix containing a `.` skips the group reference entirely.

`logging.group.<name>` is covered too: a group a project defines itself is a valid `logging.level` suffix, and
`DefinedConfigurationPropertiesSearch` already indexes the project's own `.properties`/YAML, so it needed no new
machinery. A user-defined group wins over a package of the same name.

Navigation to a hint declaration goes through `MetadataDeclarations`, so an artifact shipping the hint in both
metadata files and again in its sources jar still offers **one** target rather than three.

## Targets per kind of suffix

| Suffix | Targets | What |
| --- | --- | --- |
| `org.springframework` | 1 | the `PsiPackage` |
| `root` / `sql` / `web` | 1 | the `"value"` property of the `logging.level.keys` hint |
| `mine`, with `logging.group.mine=…` | 1 | the `logging.group` entry in the project's own file |
| `no.such.pkg` | 0 | nothing, and no error — an unresolved logger name is legal |

## Verification

`LoggingLevelKeyReferenceTest` — 14 tests, `.properties`, nested YAML and flat YAML keys, asserting the **count**
of navigation targets, not just non-null.

Red phase proved by reverting the production change: 9 of them failed inside the assertion under test
(`a logger name is one package, got: [] expected:<1> but was:<0>` and the group equivalent), not in `setUp`.

Resolution, inspection and completion are three independent paths here, so completion is asserted separately.
`LoggingLevelKeyCompletionTest` covers that `logging.level.` still offers `root`/`sql`/`web` **and** packages,
and that `logging.level.org.` still offers `springframework`.

Two regressions surfaced during the run and are fixed in this commit: the group reference used to cover a
dotted suffix it could never resolve, and it duplicated the group variants YAML completion already offers.

Full run: **822 tests, 0 failures** across `properties`, `completion.properties`, `reference`, `providers`,
`PropertyUtil*` and the property inspections, sequentially with `--rerun`.

## Scope

Value handling (`ValueHintReference`) is untouched, and so is `PropertyUtil.configurationProperty`'s prefix
`find {}` — a known latent issue tracked separately.
