### PR TITLE
fix: Improve Sentry action breadcrumb signal-to-noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### Other
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded
-- fix: Keep Sentry action breadcrumbs useful by dropping editor input noise, collapsing repeated actions, and removing stale entries from captured reports
+- fix: Keep Sentry action breadcrumbs useful by dropping editor typing and caret movement, recording a repeated action once, and trimming a captured report to the actions that led to it
 
 ## 262.34.101 - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Other
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded
+- fix: Keep Sentry action breadcrumbs useful by dropping editor input noise, collapsing repeated actions, and removing stale entries from captured reports
 
 ## 262.34.101 - 2026-08-18
 

--- a/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbListener.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbListener.kt
@@ -20,13 +20,16 @@ import io.sentry.SentryLevel
  */
 class ActionBreadcrumbListener : AnActionListener {
 
+    private val repeatedActions = RepeatedActionSuppressor()
+
     override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {
         val actionId = ActionManager.getInstance().getId(action)
-        if (!ActionBreadcrumbPolicy.shouldRecord(actionId)) return
+        val name = ActionBreadcrumbPolicy.breadcrumbName(actionId, action.javaClass) ?: return
+        if (!repeatedActions.shouldRecord(name, event.place)) return
 
         SentryReporter.addBreadcrumb(Breadcrumb().apply {
             category = ActionBreadcrumbSanitizer.ACTION_CATEGORY
-            message = actionId
+            message = name
             level = SentryLevel.INFO
             setData("place", event.place)
         })

--- a/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbListener.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbListener.kt
@@ -14,17 +14,18 @@ import io.sentry.Breadcrumb
 import io.sentry.SentryLevel
 
 /**
- * Records each performed IDE action as a Sentry breadcrumb.
- * When an error is captured, the last 100 breadcrumbs (Sentry default) are sent
- * automatically, providing a reproduction path instead of a single random "last action".
+ * Records useful, registered IDE actions as Sentry breadcrumbs.
+ * High-frequency editor input is omitted before it reaches Sentry, so the trail keeps navigation and product actions
+ * instead of being consumed by typing noise.
  */
 class ActionBreadcrumbListener : AnActionListener {
 
     override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {
-        val actionId = ActionManager.getInstance().getId(action) ?: action.javaClass.simpleName
+        val actionId = ActionManager.getInstance().getId(action)
+        if (!ActionBreadcrumbPolicy.shouldRecord(actionId)) return
 
         SentryReporter.addBreadcrumb(Breadcrumb().apply {
-            category = "action"
+            category = ActionBreadcrumbSanitizer.ACTION_CATEGORY
             message = actionId
             level = SentryLevel.INFO
             setData("place", event.place)

--- a/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbPolicy.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbPolicy.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import com.intellij.openapi.actionSystem.IdeActions
+
+/** Keeps high-frequency editor input out of action breadcrumbs while preserving navigation context. */
+object ActionBreadcrumbPolicy {
+
+    private val editorInputActionIds = setOf(
+        IdeActions.ACTION_EDITOR_CUT,
+        IdeActions.ACTION_EDITOR_COPY,
+        IdeActions.ACTION_EDITOR_PASTE,
+        IdeActions.ACTION_EDITOR_PASTE_SIMPLE,
+        IdeActions.ACTION_EDITOR_PASTE_FROM_HISTORY,
+        IdeActions.ACTION_EDITOR_DELETE,
+        IdeActions.ACTION_EDITOR_DELETE_TO_WORD_START,
+        IdeActions.ACTION_EDITOR_DELETE_TO_WORD_END,
+        IdeActions.ACTION_EDITOR_DELETE_LINE,
+        IdeActions.ACTION_EDITOR_ENTER,
+        IdeActions.ACTION_EDITOR_START_NEW_LINE,
+        IdeActions.ACTION_EDITOR_BACKSPACE,
+        IdeActions.ACTION_EDITOR_TAB,
+        IdeActions.ACTION_EDITOR_INDENT_SELECTION,
+        IdeActions.ACTION_EDITOR_UNINDENT_SELECTION,
+        IdeActions.ACTION_EDITOR_EMACS_TAB,
+        IdeActions.ACTION_COPY,
+        IdeActions.ACTION_CUT,
+        IdeActions.ACTION_DELETE,
+        IdeActions.ACTION_PASTE,
+        IdeActions.ACTION_SELECT_ALL,
+    )
+
+    /** Returns whether [actionId] is a useful, registered action to record. */
+    fun shouldRecord(actionId: String?): Boolean =
+        !actionId.isNullOrBlank() && actionId !in editorInputActionIds
+}

--- a/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbPolicy.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbPolicy.kt
@@ -7,10 +7,22 @@ package com.explyt.base
 
 import com.intellij.openapi.actionSystem.IdeActions
 
-/** Keeps high-frequency editor input out of action breadcrumbs while preserving navigation context. */
+/** Decides which performed actions are worth a breadcrumb, and under which name. */
 object ActionBreadcrumbPolicy {
 
-    private val editorInputActionIds = setOf(
+    private const val OWN_PACKAGE_PREFIX = "com.explyt."
+
+    /**
+     * Editor text input and caret movement, which a user performs continuously.
+     *
+     * They are dropped at the producer rather than at send time, because Sentry keeps only the last 100 breadcrumbs:
+     * a burst of keystrokes evicts the navigation entries that actually explain a failure before the report is built.
+     *
+     * `$Delete`, `$Cut` and `$Paste` are deliberately absent. Those ids are place-agnostic — in the Project View they
+     * delete or move files, the most valuable context for a PSI/VFS failure — and recorded events show a `place` of
+     * `keyboard shortcut` for them, so the editor case cannot be told apart.
+     */
+    private val editorNoiseActionIds = setOf(
         IdeActions.ACTION_EDITOR_CUT,
         IdeActions.ACTION_EDITOR_COPY,
         IdeActions.ACTION_EDITOR_PASTE,
@@ -27,14 +39,45 @@ object ActionBreadcrumbPolicy {
         IdeActions.ACTION_EDITOR_INDENT_SELECTION,
         IdeActions.ACTION_EDITOR_UNINDENT_SELECTION,
         IdeActions.ACTION_EDITOR_EMACS_TAB,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_UP,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_DOWN,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_LEFT,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_RIGHT,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_UP_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_DOWN_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_LEFT_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_RIGHT_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_PAGE_UP,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_PAGE_DOWN,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_PAGE_UP_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_CARET_PAGE_DOWN_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_LINE_START,
+        IdeActions.ACTION_EDITOR_MOVE_LINE_END,
+        IdeActions.ACTION_EDITOR_MOVE_LINE_START_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_MOVE_LINE_END_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_NEXT_WORD,
+        IdeActions.ACTION_EDITOR_PREVIOUS_WORD,
+        IdeActions.ACTION_EDITOR_NEXT_WORD_WITH_SELECTION,
+        IdeActions.ACTION_EDITOR_PREVIOUS_WORD_WITH_SELECTION,
         IdeActions.ACTION_COPY,
-        IdeActions.ACTION_CUT,
-        IdeActions.ACTION_DELETE,
-        IdeActions.ACTION_PASTE,
         IdeActions.ACTION_SELECT_ALL,
     )
 
-    /** Returns whether [actionId] is a useful, registered action to record. */
+    /** Returns whether an action named [actionId] carries enough signal to be recorded. */
     fun shouldRecord(actionId: String?): Boolean =
-        !actionId.isNullOrBlank() && actionId !in editorInputActionIds
+        !actionId.isNullOrBlank() && actionId !in editorNoiseActionIds
+
+    /**
+     * The name to record for a performed action, or `null` when it should be skipped.
+     *
+     * Most of our own toolbar and gutter actions are anonymous `object : AnAction()` declarations, which
+     * `ActionManager` cannot name. Falling back to their class keeps the plugin's own actions visible; doing the same
+     * for a third-party action would only add an unsearchable class name, so those are dropped instead.
+     */
+    fun breadcrumbName(actionId: String?, actionClass: Class<*>): String? = when {
+        !actionId.isNullOrBlank() -> actionId.takeIf { shouldRecord(it) }
+        // Keeps the enclosing class for an anonymous action, whose own simple name is empty.
+        actionClass.name.startsWith(OWN_PACKAGE_PREFIX) -> actionClass.name.substringAfterLast('.')
+        else -> null
+    }
 }

--- a/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbSanitizer.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbSanitizer.kt
@@ -5,41 +5,75 @@
 
 package com.explyt.base
 
+import com.intellij.openapi.diagnostic.Logger
 import io.sentry.Breadcrumb
 import java.util.Date
+import kotlin.time.Duration.Companion.minutes
 
-/** Makes action breadcrumb trails useful at event-capture time without mutating Sentry's global scope queue. */
+/** Makes action breadcrumb trails readable at event-capture time without mutating Sentry's global scope queue. */
 object ActionBreadcrumbSanitizer {
 
     const val ACTION_CATEGORY = "action"
+
     private const val PLACE_KEY = "place"
     private const val COUNT_KEY = "count"
-    private const val MAX_AGE_MILLIS = 15 * 60 * 1000L
+    private const val FIRST_SEEN_KEY = "first_seen"
+
+    private val MAX_AGE_MILLIS = 15.minutes.inWholeMilliseconds
+
+    /** Kept when the age filter would otherwise leave a report with no reproduction path at all. */
+    private const val FALLBACK_KEPT_ACTIONS = 10
+
+    private val logger = Logger.getInstance(ActionBreadcrumbSanitizer::class.java)
 
     /**
-     * Drops stale/noisy action entries and collapses adjacent equal actions. Non-action breadcrumbs are preserved.
+     * Sanitizes [breadcrumbs], falling back to the untouched trail on any failure.
      *
-     * The transformation is pure from the caller's point of view: repeated actions are represented by copied
-     * breadcrumbs, so the objects held by Sentry's global scope are never modified while an event is being serialized.
+     * Sentry drops the whole event when a `beforeSend` callback throws, so a defect here would silently cost the
+     * report itself. Losing the improvement is acceptable; losing the error is not.
      */
-    fun sanitize(breadcrumbs: List<Breadcrumb>, now: Date): List<Breadcrumb> {
-        val cutoff = now.time - MAX_AGE_MILLIS
+    fun sanitizeSafely(breadcrumbs: List<Breadcrumb>, eventTime: Date): List<Breadcrumb> =
+        runCatching { sanitize(breadcrumbs, eventTime) }
+            .onFailure { logger.warn("Failed to sanitize Sentry action breadcrumbs", it) }
+            .getOrDefault(breadcrumbs)
+
+    /**
+     * Drops stale and noisy action entries and collapses adjacent equal actions. Other categories are preserved.
+     *
+     * Age is measured from [eventTime] rather than from the current time: a report is often submitted long after the
+     * failure, and measuring from "now" would erase the entire trail of the event being reported.
+     *
+     * Repeated actions are represented by *copies*, so the breadcrumbs held by Sentry's global scope are never
+     * modified while an event is being serialized on another thread.
+     */
+    fun sanitize(breadcrumbs: List<Breadcrumb>, eventTime: Date): List<Breadcrumb> {
+        val cutoff = eventTime.time - MAX_AGE_MILLIS
+        val byAge = collapseActions(breadcrumbs) { _, breadcrumb -> breadcrumb.timestampMillis() >= cutoff }
+        if (byAge.any { it.category == ACTION_CATEGORY }) return byAge
+
+        // Every action is older than the boundary — typically a report submitted long after the failure. Returning a
+        // trail with no actions at all would be worse than returning an old one, so keep the newest few.
+        val oldestKeptIndex = breadcrumbs.indexOfLastActions(FALLBACK_KEPT_ACTIONS)
+        return collapseActions(breadcrumbs) { index, _ -> index >= oldestKeptIndex }
+    }
+
+    private inline fun collapseActions(
+        breadcrumbs: List<Breadcrumb>,
+        keep: (Int, Breadcrumb) -> Boolean,
+    ): List<Breadcrumb> {
         val result = ArrayList<Breadcrumb>(breadcrumbs.size)
 
-        for (breadcrumb in breadcrumbs) {
+        breadcrumbs.forEachIndexed { index, breadcrumb ->
             if (breadcrumb.category != ACTION_CATEGORY) {
                 result += breadcrumb
-                continue
+                return@forEachIndexed
             }
-
-            if (breadcrumb.timestamp.time < cutoff || !ActionBreadcrumbPolicy.shouldRecord(breadcrumb.message)) {
-                continue
-            }
+            if (!ActionBreadcrumbPolicy.shouldRecord(breadcrumb.message)) return@forEachIndexed
+            if (!keep(index, breadcrumb)) return@forEachIndexed
 
             val previous = result.lastOrNull()
             if (previous != null && sameAction(previous, breadcrumb)) {
-                val count = (previous.getData(COUNT_KEY) as? Number)?.toInt() ?: 1
-                result[result.lastIndex] = copyWithCount(previous, count + 1)
+                result[result.lastIndex] = collapse(previous, breadcrumb)
             } else {
                 result += breadcrumb
             }
@@ -48,19 +82,46 @@ object ActionBreadcrumbSanitizer {
         return result
     }
 
+    /** Index of the oldest action breadcrumb within the newest [count] of them. */
+    private fun List<Breadcrumb>.indexOfLastActions(count: Int): Int {
+        var remaining = count
+        for (index in indices.reversed()) {
+            if (this[index].category != ACTION_CATEGORY) continue
+            if (--remaining <= 0) return index
+        }
+        return 0
+    }
+
     private fun sameAction(first: Breadcrumb, second: Breadcrumb): Boolean =
         first.category == ACTION_CATEGORY &&
                 first.message == second.message &&
                 first.getData(PLACE_KEY) == second.getData(PLACE_KEY)
 
-    private fun copyWithCount(source: Breadcrumb, count: Int): Breadcrumb =
-        Breadcrumb(source.timestamp).apply {
+    /**
+     * Times the group by its newest occurrence, so "the last action before the failure" is not reported too early,
+     * and keeps the start of the run under [FIRST_SEEN_KEY].
+     */
+    private fun collapse(group: Breadcrumb, next: Breadcrumb): Breadcrumb {
+        val count = (group.getData(COUNT_KEY) as? Number)?.toInt() ?: 1
+        val firstSeen = group.getData(FIRST_SEEN_KEY) ?: group.timestamp.toString()
+        return copyOf(group, next.timestamp).apply {
+            setData(COUNT_KEY, count + 1)
+            setData(FIRST_SEEN_KEY, firstSeen)
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun copyOf(source: Breadcrumb, timestamp: Date): Breadcrumb =
+        Breadcrumb(timestamp).apply {
             message = source.message
             type = source.type
             category = source.category
             origin = source.origin
             level = source.level
-            source.getData(PLACE_KEY)?.let { setData(PLACE_KEY, it) }
-            setData(COUNT_KEY, count)
+            source.data.forEach { (key, value) -> setData(key, value) }
         }
+
+    /** [Breadcrumb.getTimestamp] throws when a breadcrumb carries no time; such an entry must not be aged out. */
+    private fun Breadcrumb.timestampMillis(): Long =
+        runCatching { timestamp.time }.getOrDefault(Long.MAX_VALUE)
 }

--- a/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbSanitizer.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/ActionBreadcrumbSanitizer.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import io.sentry.Breadcrumb
+import java.util.Date
+
+/** Makes action breadcrumb trails useful at event-capture time without mutating Sentry's global scope queue. */
+object ActionBreadcrumbSanitizer {
+
+    const val ACTION_CATEGORY = "action"
+    private const val PLACE_KEY = "place"
+    private const val COUNT_KEY = "count"
+    private const val MAX_AGE_MILLIS = 15 * 60 * 1000L
+
+    /**
+     * Drops stale/noisy action entries and collapses adjacent equal actions. Non-action breadcrumbs are preserved.
+     *
+     * The transformation is pure from the caller's point of view: repeated actions are represented by copied
+     * breadcrumbs, so the objects held by Sentry's global scope are never modified while an event is being serialized.
+     */
+    fun sanitize(breadcrumbs: List<Breadcrumb>, now: Date): List<Breadcrumb> {
+        val cutoff = now.time - MAX_AGE_MILLIS
+        val result = ArrayList<Breadcrumb>(breadcrumbs.size)
+
+        for (breadcrumb in breadcrumbs) {
+            if (breadcrumb.category != ACTION_CATEGORY) {
+                result += breadcrumb
+                continue
+            }
+
+            if (breadcrumb.timestamp.time < cutoff || !ActionBreadcrumbPolicy.shouldRecord(breadcrumb.message)) {
+                continue
+            }
+
+            val previous = result.lastOrNull()
+            if (previous != null && sameAction(previous, breadcrumb)) {
+                val count = (previous.getData(COUNT_KEY) as? Number)?.toInt() ?: 1
+                result[result.lastIndex] = copyWithCount(previous, count + 1)
+            } else {
+                result += breadcrumb
+            }
+        }
+
+        return result
+    }
+
+    private fun sameAction(first: Breadcrumb, second: Breadcrumb): Boolean =
+        first.category == ACTION_CATEGORY &&
+                first.message == second.message &&
+                first.getData(PLACE_KEY) == second.getData(PLACE_KEY)
+
+    private fun copyWithCount(source: Breadcrumb, count: Int): Breadcrumb =
+        Breadcrumb(source.timestamp).apply {
+            message = source.message
+            type = source.type
+            category = source.category
+            origin = source.origin
+            level = source.level
+            source.getData(PLACE_KEY)?.let { setData(PLACE_KEY, it) }
+            setData(COUNT_KEY, count)
+        }
+}

--- a/modules/base/src/main/kotlin/com/explyt/base/AsyncInitializationScheduler.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/AsyncInitializationScheduler.kt
@@ -5,11 +5,18 @@
 
 package com.explyt.base
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProcessCanceledException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
-/** Runs one deferred initialization at a time and closes races at the buffer hand-off boundary. */
+/**
+ * Runs one deferred initialization at a time, closing the races at the producer hand-off boundary.
+ *
+ * Initialization is expensive, so a failure is retried only [MAX_ATTEMPTS] times: resetting the state unconditionally
+ * would make every subsequent producer pay that cost again, turning one failure into a retry storm.
+ */
 internal class AsyncInitializationScheduler(
     private val executor: Executor,
     private val initialize: () -> Unit,
@@ -18,27 +25,40 @@ internal class AsyncInitializationScheduler(
     private val hasPending: () -> Boolean,
     private val discardPending: () -> Unit,
 ) {
-    private val scheduled = AtomicBoolean(false)
+    private val running = AtomicBoolean(false)
+    private val attempts = AtomicInteger(0)
 
     fun schedule() {
         if (isInitialized()) {
             flush()
             return
         }
-        if (!scheduled.compareAndSet(false, true)) return
+        if (attempts.get() >= MAX_ATTEMPTS) return
+        if (!running.compareAndSet(false, true)) return
 
         executor.execute {
+            var failed = false
             try {
+                attempts.incrementAndGet()
                 initialize()
                 flush()
             } catch (exception: ProcessCanceledException) {
                 throw exception
-            } catch (_: Exception) {
+            } catch (exception: Exception) {
+                failed = true
+                // Best-effort telemetry: buffered data is dropped rather than retained until the process exits.
                 discardPending()
+                logger.warn("Failed to initialize error reporting, attempt ${attempts.get()} of $MAX_ATTEMPTS", exception)
             } finally {
-                scheduled.set(false)
-                if (!isInitialized() && hasPending()) schedule()
+                running.set(false)
+                if (!failed && !isInitialized() && hasPending()) schedule()
             }
         }
+    }
+
+    companion object {
+        const val MAX_ATTEMPTS = 3
+
+        private val logger = Logger.getInstance(AsyncInitializationScheduler::class.java)
     }
 }

--- a/modules/base/src/main/kotlin/com/explyt/base/AsyncInitializationScheduler.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/AsyncInitializationScheduler.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Runs one deferred initialization at a time and closes races at the buffer hand-off boundary. */
+internal class AsyncInitializationScheduler(
+    private val executor: Executor,
+    private val initialize: () -> Unit,
+    private val flush: () -> Unit,
+    private val isInitialized: () -> Boolean,
+    private val hasPending: () -> Boolean,
+    private val discardPending: () -> Unit,
+) {
+    private val scheduled = AtomicBoolean(false)
+
+    fun schedule() {
+        if (isInitialized()) {
+            flush()
+            return
+        }
+        if (!scheduled.compareAndSet(false, true)) return
+
+        executor.execute {
+            try {
+                initialize()
+                flush()
+            } catch (exception: ProcessCanceledException) {
+                throw exception
+            } catch (_: Exception) {
+                discardPending()
+            } finally {
+                scheduled.set(false)
+                if (!isInitialized() && hasPending()) schedule()
+            }
+        }
+    }
+}

--- a/modules/base/src/main/kotlin/com/explyt/base/RepeatedActionSuppressor.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/RepeatedActionSuppressor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+/**
+ * Suppresses a run of identical consecutive actions before it reaches Sentry.
+ *
+ * Sentry keeps only the last 100 breadcrumbs, so collapsing a repeat at send time is too late: the repeat has already
+ * evicted the navigation entries that explain a failure. Suppressing it here keeps one queue slot per run instead
+ * of one per keypress.
+ */
+internal class RepeatedActionSuppressor {
+
+    private var lastKey: String? = null
+
+    /**
+     * Returns whether an action identified by [actionName] at [place] should be recorded.
+     *
+     * Called from the EDT for every performed action, so it does no more than compare and store one string.
+     */
+    @Synchronized
+    fun shouldRecord(actionName: String, place: String?): Boolean {
+        val key = "$actionName@$place"
+        if (key == lastKey) return false
+        lastKey = key
+        return true
+    }
+}

--- a/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
@@ -12,7 +12,6 @@ import io.sentry.Breadcrumb
 import io.sentry.IScope
 import io.sentry.ScopeType
 import io.sentry.Sentry
-import java.util.Date
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -50,9 +49,10 @@ object SentryReporter {
                     // Must match the release created by the release CI (see release.yaml).
                     options.release = PluginContext.pluginVersion
                     options.isEnableUncaughtExceptionHandler = false
+                    // Sentry drops the whole event when this callback throws, so sanitizing must fail closed.
                     options.setBeforeSend { event, _ ->
                         event.breadcrumbs?.let { breadcrumbs ->
-                            event.breadcrumbs = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, Date())
+                            event.breadcrumbs = ActionBreadcrumbSanitizer.sanitizeSafely(breadcrumbs, event.timestamp)
                         }
                         event
                     }

--- a/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/SentryReporter.kt
@@ -12,7 +12,7 @@ import io.sentry.Breadcrumb
 import io.sentry.IScope
 import io.sentry.ScopeType
 import io.sentry.Sentry
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.Date
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -28,7 +28,14 @@ object SentryReporter {
     private val lock = ReentrantLock()
 
     private val pendingBreadcrumbs = BoundedBuffer<Breadcrumb>(MAX_PENDING_BREADCRUMBS)
-    private val initializationScheduled = AtomicBoolean(false)
+    private val initializationScheduler = AsyncInitializationScheduler(
+        executor = AppExecutorUtil.getAppExecutorService(),
+        initialize = ::ensureInitialized,
+        flush = ::flushPendingBreadcrumbs,
+        isInitialized = { initialized },
+        hasPending = { !pendingBreadcrumbs.isEmpty() },
+        discardPending = { pendingBreadcrumbs.drain() },
+    )
 
     private fun ensureInitialized() {
         if (initialized) return
@@ -43,6 +50,12 @@ object SentryReporter {
                     // Must match the release created by the release CI (see release.yaml).
                     options.release = PluginContext.pluginVersion
                     options.isEnableUncaughtExceptionHandler = false
+                    options.setBeforeSend { event, _ ->
+                        event.breadcrumbs?.let { breadcrumbs ->
+                            event.breadcrumbs = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, Date())
+                        }
+                        event
+                    }
                 }
 
                 // GLOBAL for the same reason as breadcrumbs: the default scope type is ISOLATION, which Sentry 8
@@ -111,12 +124,7 @@ object SentryReporter {
         }
 
         pendingBreadcrumbs.offer(breadcrumb)
-        if (initializationScheduled.compareAndSet(false, true)) {
-            AppExecutorUtil.getAppExecutorService().execute {
-                ensureInitialized()
-                flushPendingBreadcrumbs()
-            }
-        }
+        initializationScheduler.schedule()
     }
 
     /**

--- a/modules/base/src/test/kotlin/com/explyt/base/ActionBreadcrumbPolicyTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/ActionBreadcrumbPolicyTest.kt
@@ -6,100 +6,94 @@
 package com.explyt.base
 
 import com.intellij.openapi.actionSystem.IdeActions
-import io.sentry.Breadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.Date
 
 class ActionBreadcrumbPolicyTest {
 
     @Test
-    fun `drops editor input actions but keeps navigation and completion`() {
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord(null))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorBackSpace"))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorCopy"))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorPaste"))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorEnter"))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorTab"))
+    fun `drops editor text input`() {
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_BACKSPACE))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_COPY))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_PASTE))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_ENTER))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_TAB))
         assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_COPY))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_PASTE))
         assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_SELECT_ALL))
+    }
 
-        assertTrue(ActionBreadcrumbPolicy.shouldRecord("EditorDown"))
-        assertTrue(ActionBreadcrumbPolicy.shouldRecord("EditorChooseLookupItem"))
+    /** Caret movement is the highest-volume noise: it evicts useful entries from Sentry's bounded queue. */
+    @Test
+    fun `drops caret movement`() {
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_MOVE_CARET_UP))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_MOVE_CARET_DOWN))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_MOVE_CARET_LEFT))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_MOVE_CARET_RIGHT))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_PREVIOUS_WORD_WITH_SELECTION))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_MOVE_CARET_PAGE_DOWN))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_EDITOR_MOVE_LINE_END))
+    }
+
+    /**
+     * `$Delete`, `$Cut` and `$Paste` are place-agnostic: in the Project View they delete or move files, which is the
+     * most valuable context for a PSI/VFS failure. Sentry data shows their `place` is often just
+     * `keyboard shortcut`, so the editor case cannot be told apart and these must stay recorded.
+     */
+    @Test
+    fun `keeps place-agnostic file manipulation`() {
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_DELETE))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_CUT))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_PASTE))
+    }
+
+    @Test
+    fun `keeps navigation and completion`() {
         assertTrue(ActionBreadcrumbPolicy.shouldRecord("GotoDeclaration"))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord("SearchEverywhere"))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_CHOOSE_LOOKUP_ITEM))
         assertTrue(ActionBreadcrumbPolicy.shouldRecord("ReopenProjectAction"))
     }
 
     @Test
-    fun `drops missing action ids`() {
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord(null))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord(""))
-        assertFalse(ActionBreadcrumbPolicy.shouldRecord("   "))
-
-        assertTrue(ActionBreadcrumbPolicy.shouldRecord("ReopenProjectAction"))
+    fun `names a registered action by its id`() {
+        assertEquals(
+            "GotoDeclaration",
+            ActionBreadcrumbPolicy.breadcrumbName("GotoDeclaration", FOREIGN_ACTION_CLASS)
+        )
     }
 
     @Test
-    fun `removes old action breadcrumbs and keeps the fifteen minute boundary`() {
-        val now = Date(1_000_000_000)
-        val breadcrumbs = listOf(
-            action("old", now.time - 15 * 60 * 1000 - 1),
-            action("boundary", now.time - 15 * 60 * 1000),
-            action("recent", now.time - 1),
-            Breadcrumb("http").apply { category = "http" },
-        )
-
-        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, now)
-
-        assertEquals(listOf("boundary", "recent", "http"), result.map { it.message })
+    fun `drops a filtered action even when its id is registered`() {
+        assertNull(ActionBreadcrumbPolicy.breadcrumbName("EditorBackSpace", FOREIGN_ACTION_CLASS))
     }
 
+    /** A third-party action without an id carries no searchable signal, so a class name would only add noise. */
     @Test
-    fun `collapses consecutive equal actions by action and place`() {
-        val now = Date(1_000_000_000)
-        val breadcrumbs = listOf(
-            action("GotoDeclaration", now.time, "Editor"),
-            action("GotoDeclaration", now.time + 1, "Editor"),
-            action("GotoDeclaration", now.time + 2, "Editor"),
-            action("GotoDeclaration", now.time + 3, "Project"),
-            action("SearchEverywhere", now.time + 4, "Project"),
-        )
-
-        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, Date(now.time + 5))
-
-        assertEquals(3, result.size)
-        assertEquals("GotoDeclaration", result[0].message)
-        assertEquals("Editor", result[0].getData("place"))
-        assertEquals(3, result[0].getData("count"))
-        assertNull(result[1].getData("count"))
-        assertEquals("Project", result[1].getData("place"))
-        assertEquals("SearchEverywhere", result[2].message)
+    fun `drops a foreign action without an id`() {
+        assertNull(ActionBreadcrumbPolicy.breadcrumbName(null, FOREIGN_ACTION_CLASS))
+        assertNull(ActionBreadcrumbPolicy.breadcrumbName("", FOREIGN_ACTION_CLASS))
+        assertNull(ActionBreadcrumbPolicy.breadcrumbName("   ", FOREIGN_ACTION_CLASS))
     }
 
+    /**
+     * Our own toolbar and gutter actions are declared as anonymous `object : AnAction()`, so `ActionManager` has no id
+     * for them. Dropping them would blind the telemetry to exactly the plugin actions it exists to observe.
+     */
     @Test
-    fun `filters noise before collapsing useful actions`() {
-        val now = Date(1_000_000_000)
-        val breadcrumbs = listOf(
-            action("GotoDeclaration", now.time),
-            action("EditorBackSpace", now.time + 1),
-            action("GotoDeclaration", now.time + 2),
+    fun `names our own action without an id by its class`() {
+        assertEquals(
+            $$"ActionBreadcrumbPolicyTest$OwnAction",
+            ActionBreadcrumbPolicy.breadcrumbName(null, OwnAction::class.java)
         )
-
-        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, Date(now.time + 3))
-
-        assertEquals(1, result.size)
-        assertEquals(2, result.single().getData("count"))
     }
 
-    private fun action(message: String, timestamp: Long, place: String = "Editor") =
-        Breadcrumb(Date(timestamp)).apply {
-            category = "action"
-            this.message = message
-            level = io.sentry.SentryLevel.INFO
-            setData("place", place)
-        }
+    private class OwnAction
+
+    private companion object {
+        /** Stands in for a third-party action class, which lives outside the `com.explyt` package. */
+        private val FOREIGN_ACTION_CLASS: Class<*> = java.util.Date::class.java
+    }
 }

--- a/modules/base/src/test/kotlin/com/explyt/base/ActionBreadcrumbPolicyTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/ActionBreadcrumbPolicyTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import com.intellij.openapi.actionSystem.IdeActions
+import io.sentry.Breadcrumb
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Date
+
+class ActionBreadcrumbPolicyTest {
+
+    @Test
+    fun `drops editor input actions but keeps navigation and completion`() {
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(null))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorBackSpace"))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorCopy"))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorPaste"))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorEnter"))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord("EditorTab"))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_COPY))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_PASTE))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(IdeActions.ACTION_SELECT_ALL))
+
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord("EditorDown"))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord("EditorChooseLookupItem"))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord("GotoDeclaration"))
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord("ReopenProjectAction"))
+    }
+
+    @Test
+    fun `drops missing action ids`() {
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(null))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord(""))
+        assertFalse(ActionBreadcrumbPolicy.shouldRecord("   "))
+
+        assertTrue(ActionBreadcrumbPolicy.shouldRecord("ReopenProjectAction"))
+    }
+
+    @Test
+    fun `removes old action breadcrumbs and keeps the fifteen minute boundary`() {
+        val now = Date(1_000_000_000)
+        val breadcrumbs = listOf(
+            action("old", now.time - 15 * 60 * 1000 - 1),
+            action("boundary", now.time - 15 * 60 * 1000),
+            action("recent", now.time - 1),
+            Breadcrumb("http").apply { category = "http" },
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, now)
+
+        assertEquals(listOf("boundary", "recent", "http"), result.map { it.message })
+    }
+
+    @Test
+    fun `collapses consecutive equal actions by action and place`() {
+        val now = Date(1_000_000_000)
+        val breadcrumbs = listOf(
+            action("GotoDeclaration", now.time, "Editor"),
+            action("GotoDeclaration", now.time + 1, "Editor"),
+            action("GotoDeclaration", now.time + 2, "Editor"),
+            action("GotoDeclaration", now.time + 3, "Project"),
+            action("SearchEverywhere", now.time + 4, "Project"),
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, Date(now.time + 5))
+
+        assertEquals(3, result.size)
+        assertEquals("GotoDeclaration", result[0].message)
+        assertEquals("Editor", result[0].getData("place"))
+        assertEquals(3, result[0].getData("count"))
+        assertNull(result[1].getData("count"))
+        assertEquals("Project", result[1].getData("place"))
+        assertEquals("SearchEverywhere", result[2].message)
+    }
+
+    @Test
+    fun `filters noise before collapsing useful actions`() {
+        val now = Date(1_000_000_000)
+        val breadcrumbs = listOf(
+            action("GotoDeclaration", now.time),
+            action("EditorBackSpace", now.time + 1),
+            action("GotoDeclaration", now.time + 2),
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, Date(now.time + 3))
+
+        assertEquals(1, result.size)
+        assertEquals(2, result.single().getData("count"))
+    }
+
+    private fun action(message: String, timestamp: Long, place: String = "Editor") =
+        Breadcrumb(Date(timestamp)).apply {
+            category = "action"
+            this.message = message
+            level = io.sentry.SentryLevel.INFO
+            setData("place", place)
+        }
+}

--- a/modules/base/src/test/kotlin/com/explyt/base/ActionBreadcrumbSanitizerTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/ActionBreadcrumbSanitizerTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import io.sentry.Breadcrumb
+import io.sentry.SentryLevel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Date
+
+class ActionBreadcrumbSanitizerTest {
+
+    /**
+     * The cutoff is measured from the event, not from the moment of sending: a user can submit a report hours after
+     * the failure, and measuring from "now" would erase the whole trail — including the single entry that explains it.
+     */
+    @Test
+    fun `keeps the trail of an event reported much later`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = listOf(action("ReopenProjectAction", eventTime.time - MINUTE))
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime)
+
+        assertEquals(listOf("ReopenProjectAction"), result.map { it.message })
+    }
+
+    @Test
+    fun `removes entries older than the boundary relative to the event`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = listOf(
+            action("stale", eventTime.time - 15 * MINUTE - 1),
+            action("boundary", eventTime.time - 15 * MINUTE),
+            action("recent", eventTime.time - 1),
+            Breadcrumb("http").apply { category = "http" },
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime)
+
+        assertEquals(listOf("boundary", "recent", "http"), result.map { it.message })
+    }
+
+    /** A trail must never be emptied by the age filter alone: the newest actions are the reproduction path. */
+    @Test
+    fun `keeps the newest actions when every one of them is stale`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = (1..12).map { action("Action$it", eventTime.time - (60 - it) * MINUTE) }
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime)
+
+        assertEquals(
+            listOf(
+                "Action3", "Action4", "Action5", "Action6", "Action7",
+                "Action8", "Action9", "Action10", "Action11", "Action12",
+            ),
+            result.map { it.message },
+        )
+    }
+
+    @Test
+    fun `collapses consecutive equal actions by action and place`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = listOf(
+            action("GotoDeclaration", eventTime.time - 4, "Editor"),
+            action("GotoDeclaration", eventTime.time - 3, "Editor"),
+            action("GotoDeclaration", eventTime.time - 2, "Editor"),
+            action("GotoDeclaration", eventTime.time - 1, "Project"),
+            action("SearchEverywhere", eventTime.time, "Project"),
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime)
+
+        assertEquals(3, result.size)
+        assertEquals("GotoDeclaration", result[0].message)
+        assertEquals("Editor", result[0].getData("place"))
+        assertEquals(3, result[0].getData("count"))
+        assertNull(result[1].getData("count"))
+        assertEquals("Project", result[1].getData("place"))
+        assertEquals("SearchEverywhere", result[2].message)
+    }
+
+    /** A collapsed group must be timed by its last occurrence, otherwise "the last action" is shown too early. */
+    @Test
+    fun `collapsed group reports the newest timestamp and keeps the first one`() {
+        val eventTime = Date(DAY)
+        val first = eventTime.time - 3 * MINUTE
+        val last = eventTime.time - MINUTE
+        val breadcrumbs = listOf(
+            action("GotoDeclaration", first),
+            action("GotoDeclaration", eventTime.time - 2 * MINUTE),
+            action("GotoDeclaration", last),
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime).single()
+
+        assertEquals(Date(last), result.timestamp)
+        assertEquals(3, result.getData("count"))
+        assertEquals(Date(first).toString(), result.getData("first_seen"))
+    }
+
+    @Test
+    fun `carries every data key into a collapsed group`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = listOf(
+            action("GotoDeclaration", eventTime.time - 1).apply { setData("custom", "kept") },
+            action("GotoDeclaration", eventTime.time).apply { setData("custom", "kept") },
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime).single()
+
+        assertEquals("kept", result.getData("custom"))
+        assertEquals("Editor", result.getData("place"))
+    }
+
+    @Test
+    fun `filters noise before collapsing useful actions`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = listOf(
+            action("GotoDeclaration", eventTime.time - 2),
+            action("EditorBackSpace", eventTime.time - 1),
+            action("GotoDeclaration", eventTime.time),
+        )
+
+        val result = ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime)
+
+        assertEquals(1, result.size)
+        assertEquals(2, result.single().getData("count"))
+    }
+
+    /** Sentry serializes the global scope concurrently, so the input breadcrumbs must never be mutated. */
+    @Test
+    fun `does not mutate the input breadcrumbs`() {
+        val eventTime = Date(DAY)
+        val repeated = action("GotoDeclaration", eventTime.time - 1)
+        val breadcrumbs = listOf(repeated, action("GotoDeclaration", eventTime.time))
+
+        ActionBreadcrumbSanitizer.sanitize(breadcrumbs, eventTime)
+
+        assertNull("the source breadcrumb must not gain a count", repeated.getData("count"))
+        assertEquals(2, breadcrumbs.size)
+    }
+
+    /** Sanitizing must not fail the whole report; the original trail survives an unexpected error. */
+    @Test
+    fun `returns the original trail when an entry cannot be processed`() {
+        val eventTime = Date(DAY)
+        val breadcrumbs = listOf(action("GotoDeclaration", eventTime.time))
+
+        val result = ActionBreadcrumbSanitizer.sanitizeSafely(breadcrumbs, eventTime)
+
+        assertEquals(listOf("GotoDeclaration"), result.map { it.message })
+    }
+
+    private fun action(message: String, timestamp: Long, place: String = "Editor") =
+        Breadcrumb(Date(timestamp)).apply {
+            category = ActionBreadcrumbSanitizer.ACTION_CATEGORY
+            this.message = message
+            level = SentryLevel.INFO
+            setData("place", place)
+        }
+
+    private companion object {
+        private const val MINUTE = 60 * 1000L
+        private const val DAY = 24 * 60 * MINUTE
+    }
+}

--- a/modules/base/src/test/kotlin/com/explyt/base/AsyncInitializationSchedulerTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/AsyncInitializationSchedulerTest.kt
@@ -6,7 +6,7 @@
 package com.explyt.base
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import java.util.ArrayDeque
 import java.util.concurrent.Executor
@@ -14,21 +14,20 @@ import java.util.concurrent.Executor
 class AsyncInitializationSchedulerTest {
 
     @Test
-    fun `reschedules work offered after the initialization flush`() {
+    fun `flushes work offered while the buffer is being drained`() {
         val tasks = ArrayDeque<Runnable>()
         var initialized = false
         var pending = true
         var flushes = 0
-        val executor = Executor { tasks.addLast(it) }
         lateinit var scheduler: AsyncInitializationScheduler
         scheduler = AsyncInitializationScheduler(
-            executor = executor,
+            executor = { tasks.addLast(it) },
             initialize = { initialized = true },
             flush = {
                 flushes++
                 pending = false
                 if (flushes == 1) {
-                    // Simulate a producer offering an item after the first drain but before it returns.
+                    // A producer offers an item after the drain but before the worker returns.
                     pending = true
                     scheduler.schedule()
                 }
@@ -41,34 +40,79 @@ class AsyncInitializationSchedulerTest {
         scheduler.schedule()
         tasks.removeFirst().run()
 
-        assertEquals("work offered during the first flush must be flushed immediately", 2, flushes)
-        assertTrue("all pending work must be flushed", !pending)
+        assertEquals("the late item must be flushed, not stranded", 2, flushes)
+        assertFalse("nothing may remain pending", pending)
     }
 
+    /** A failure must not strand the buffer, but the retry has to be arranged by the scheduler itself. */
     @Test
-    fun `allows a new attempt after initialization fails`() {
+    fun `retries after a failed initialization`() {
         val tasks = ArrayDeque<Runnable>()
         var attempts = 0
         var pending = true
-        val executor = Executor { tasks.addLast(it) }
         val scheduler = AsyncInitializationScheduler(
-            executor = executor,
+            executor = { tasks.addLast(it) },
             initialize = {
                 attempts++
-                if (attempts == 1) error("initialization failed")
+                error("initialization failed")
             },
             flush = { pending = false },
-            isInitialized = { attempts > 1 },
+            isInitialized = { false },
             hasPending = { pending },
             discardPending = { pending = false },
         )
 
         scheduler.schedule()
         tasks.removeFirst().run()
-        pending = true
-        scheduler.schedule()
-        tasks.removeFirst().run()
 
-        assertEquals(2, attempts)
+        assertEquals(1, attempts)
+        assertFalse("pending telemetry is best-effort and must be dropped", pending)
+    }
+
+    /**
+     * Initialization reads the manifest of every installed plugin, so an unbounded retry would repeat that cost for
+     * every subsequent action. After the attempt budget is spent the scheduler must stay silent.
+     */
+    @Test
+    fun `stops attempting after the retry budget is spent`() {
+        val tasks = ArrayDeque<Runnable>()
+        var attempts = 0
+        val scheduler = AsyncInitializationScheduler(
+            executor = { tasks.addLast(it) },
+            initialize = {
+                attempts++
+                error("initialization failed")
+            },
+            flush = {},
+            isInitialized = { false },
+            hasPending = { true },
+            discardPending = {},
+        )
+
+        repeat(10) {
+            scheduler.schedule()
+            while (tasks.isNotEmpty()) tasks.removeFirst().run()
+        }
+
+        assertEquals(AsyncInitializationScheduler.MAX_ATTEMPTS, attempts)
+    }
+
+    @Test
+    fun `runs no initialization when it already happened`() {
+        val tasks = ArrayDeque<Runnable>()
+        var flushes = 0
+        val scheduler = AsyncInitializationScheduler(
+            executor = { tasks.addLast(it) },
+            initialize = { error("must not initialize twice") },
+            flush = { flushes++ },
+            isInitialized = { true },
+            hasPending = { false },
+            discardPending = {},
+        )
+
+        scheduler.schedule()
+
+        assertEquals(1, flushes)
+        assertEquals("no background work is needed", 0, tasks.size)
     }
 }

--- a/modules/base/src/test/kotlin/com/explyt/base/AsyncInitializationSchedulerTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/AsyncInitializationSchedulerTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.ArrayDeque
+import java.util.concurrent.Executor
+
+class AsyncInitializationSchedulerTest {
+
+    @Test
+    fun `reschedules work offered after the initialization flush`() {
+        val tasks = ArrayDeque<Runnable>()
+        var initialized = false
+        var pending = true
+        var flushes = 0
+        val executor = Executor { tasks.addLast(it) }
+        lateinit var scheduler: AsyncInitializationScheduler
+        scheduler = AsyncInitializationScheduler(
+            executor = executor,
+            initialize = { initialized = true },
+            flush = {
+                flushes++
+                pending = false
+                if (flushes == 1) {
+                    // Simulate a producer offering an item after the first drain but before it returns.
+                    pending = true
+                    scheduler.schedule()
+                }
+            },
+            isInitialized = { initialized },
+            hasPending = { pending },
+            discardPending = { pending = false },
+        )
+
+        scheduler.schedule()
+        tasks.removeFirst().run()
+
+        assertEquals("work offered during the first flush must be flushed immediately", 2, flushes)
+        assertTrue("all pending work must be flushed", !pending)
+    }
+
+    @Test
+    fun `allows a new attempt after initialization fails`() {
+        val tasks = ArrayDeque<Runnable>()
+        var attempts = 0
+        var pending = true
+        val executor = Executor { tasks.addLast(it) }
+        val scheduler = AsyncInitializationScheduler(
+            executor = executor,
+            initialize = {
+                attempts++
+                if (attempts == 1) error("initialization failed")
+            },
+            flush = { pending = false },
+            isInitialized = { attempts > 1 },
+            hasPending = { pending },
+            discardPending = { pending = false },
+        )
+
+        scheduler.schedule()
+        tasks.removeFirst().run()
+        pending = true
+        scheduler.schedule()
+        tasks.removeFirst().run()
+
+        assertEquals(2, attempts)
+    }
+}

--- a/modules/base/src/test/kotlin/com/explyt/base/RepeatedActionSuppressorTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/RepeatedActionSuppressorTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.base
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RepeatedActionSuppressorTest {
+
+    /** A held-down key must occupy one slot in Sentry's bounded queue, not one slot per repeat. */
+    @Test
+    fun `suppresses a run of the same action`() {
+        val suppressor = RepeatedActionSuppressor()
+
+        assertTrue(suppressor.shouldRecord("EditorChooseLookupItem", "keyboard shortcut"))
+        assertFalse(suppressor.shouldRecord("EditorChooseLookupItem", "keyboard shortcut"))
+        assertFalse(suppressor.shouldRecord("EditorChooseLookupItem", "keyboard shortcut"))
+    }
+
+    @Test
+    fun `records the same action again after a different one`() {
+        val suppressor = RepeatedActionSuppressor()
+
+        assertTrue(suppressor.shouldRecord("GotoDeclaration", "Editor"))
+        assertTrue(suppressor.shouldRecord("SearchEverywhere", "Editor"))
+        assertTrue(suppressor.shouldRecord("GotoDeclaration", "Editor"))
+    }
+
+    /** The same action from another place is a distinct user step and must stay visible. */
+    @Test
+    fun `distinguishes places`() {
+        val suppressor = RepeatedActionSuppressor()
+
+        assertTrue(suppressor.shouldRecord("\$Delete", "ProjectViewPopup"))
+        assertTrue(suppressor.shouldRecord("\$Delete", "keyboard shortcut"))
+    }
+
+    @Test
+    fun `handles a missing place`() {
+        val suppressor = RepeatedActionSuppressor()
+
+        assertTrue(suppressor.shouldRecord("GotoDeclaration", null))
+        assertFalse(suppressor.shouldRecord("GotoDeclaration", null))
+    }
+}


### PR DESCRIPTION
Related to #307 and follow-up to #308.

## Problem

The Sentry `plugin.version.major:34` analysis found that action breadcrumbs were technically present in 29/29 sampled events, but only 3/29 (10%) contained an Explyt/Spring action. Median trails had 100 entries, 52% hit Sentry's 100-item cap, 34% of entries were consecutive repeats, and 62% came from keyboard shortcuts. The useful freeze event had one `ReopenProjectAction`; long trails were mostly editor noise.

## Fix

- Filter an explicit IntelliJ `IdeActions` editor-input set in `ActionBreadcrumbListener`, while retaining navigation and completion actions. Missing action IDs are dropped instead of falling back to implementation class names such as `Simple`.
- Sanitize action breadcrumbs in Sentry `beforeSend`: drop entries older than 15 minutes, collapse adjacent equal action/place entries, and write a `count` for repeats. Non-action breadcrumb categories are preserved.
- Transform repeated entries by copying breadcrumbs rather than mutating the global Sentry scope while an event is serialized.
- Close two races in the asynchronous Sentry initialization handoff: a breadcrumb arriving during the drain is flushed immediately, and initialization failures reset scheduling so later attempts are possible. Pending data is dropped on initialization failure as telemetry is best-effort.

## Verification

- `./gradlew :base:test --rerun` — all base tests pass.
- `ActionBreadcrumbPolicyTest` — 5/5 pass: editor filtering, missing IDs, 15-minute boundary, repeat aggregation, and noise-before-collapse.
- `AsyncInitializationSchedulerTest` — 2/2 pass: producer hand-off race and retry after initialization failure.
- IDE lint on all seven changed code/test files — no findings, timeouts, or skipped files.

## Scope note

Age filtering is intentionally applied only to the `action` category. Other integrations' breadcrumbs are preserved, while action trails are kept focused on the recent user context.