### PR TITLE
chore: Open plugin generation 35 with the release-34 stability fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,15 @@ Tests are IntelliJ Platform tests (headless IDE fixture) — slow and single-for
 - Inspection tests use `test-framework` base classes (`ExplytInspectionKotlinTestCase`, …), declare `libraries: Array<TestLibrary>`, and usually have Java and Kotlin twins under `inspections/java/` and `inspections/kotlin/`. Add or update tests for any behavior change.
 - Track new user-facing actions via `StatisticActionId` + `StatisticService.addActionUsage(...)`.
 
+## Releases, branches and versions
+
+- `main` is the trunk and targets the **latest supported IDEA line** (currently 2026.2 / `262`). Every release branch is an ancestor of `main`; fixes land on `main` first and are cherry-picked outward, never the reverse.
+- `pluginVersion` in `gradle.properties` is the **generation** of the *next* release, not of the last one. `main` opens the next generation right after a release; release branches keep the generation they shipped.
+- A published version is `<line>.<generation>.<CI run>` — e.g. `262.34.101` = line 262, generation 34, run 101. The tag is named after the **newest** line in that release, but one release ships **one asset per supported line** (`262.34.101` shipped `242`, `243`, `251`, `252`, `253`, `261`, `262`).
+- A generation is released **once**. Re-releasing an already-published generation is reserved for hotfixes and is not the normal flow; ordinary fixes go into the next generation.
+- `CHANGELOG.md`: only `[Unreleased]` and the **current** release carry brackets; older sections are plain (`## 261.33.80 - 2026-04-28`). `[Unreleased]` must contain only entries for the generation now in `pluginVersion` — never mix them into an already-shipped section.
+- When cutting a release, add the released section on `main`, bump `pluginVersion`, and pin `untilVersion` on the older-line branches (`untilVersion=261.*`, not `265.*`).
+
 ## Commits and pull requests
 
 - Conventional commit prefixes: `feat:`, `fix:`, `docs:`, `chore:`, `ci:`; reference issues/PRs, e.g. `fix: EDT while navigation (#227)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,22 @@
 - fix: Evaluate the IntelliJ IDEA Ultimate line marker suppression once per highlighting batch instead of once per PSI element
 - fix: Do not freeze the UI while a project opens: the linked-project self-healing pass no longer requests the run configuration manager on the event dispatch thread
 - fix: Stop resolving PSI in the Spring Boot toolbar action update, which caused multi-second action-update delays
+- fix: Keep the Spring Boot toolbar button responsive by not creating the run configuration manager while the action updates
+- fix: Do not show the Spring Boot debug value hint in an editor that has no file behind it
+- fix: Ignore a cached bean whose PSI is no longer valid instead of failing inspections, gutters and bean search
+- fix: Reflect an edited source file in reference search results instead of returning a stale cached set
+- fix: Read the main class of a Kotlin run configuration without resolving PSI on the event dispatch thread
 
 ### Spring Web
 - feat: List Actuator endpoints in the Endpoints tool window, one row per `@ReadOperation`/`@WriteOperation`/`@DeleteOperation` with its `@Selector` path variables, and navigate to the declaring class and the operation method; the path follows `management.endpoints.web.base-path`, `management.endpoints.web.path-mapping.<id>` and `management.server.port`
 - fix: Register the web additional-beans discoverer under the extension namespace that declares the extension point, so framework-provided web beans such as `WebApplicationContext` are resolved again
 - fix: Resolve `MockMvc` and `WebTestClient` autowired in tests as beans provided by test auto-configuration
+- fix: Inject the regular expression of a `@RequestMapping` path built by concatenation into the literal that actually contains it
 
 ### Other
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded
 - fix: Keep Sentry action breadcrumbs useful by dropping editor typing and caret movement, recording a repeated action once, and trimming a captured report to the actions that led to it
+- fix: Bring error reporting back up when the pooled executor rejects the initialization task, instead of leaving it disabled for the rest of the session
 
 ## [262.34.101] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - feat: Report the `@MockBean` / `@SpyBean` migration already in Spring Boot 3.4/3.5, where the annotations are deprecated for removal, naming `@MockitoBean` / `@MockitoSpyBean` and offering the quick-fix the platform deprecation warning cannot
 - feat: Report the renamed `management.endpoint.httptrace.*` configuration keys in Spring Boot 3, with a quick-fix to `httpexchanges`
 - fix: Navigate from an indexed collection key such as `ingest.s3-logs.sources[0].enabled` to the member of the collection's element class
-
 - fix: Resolve a configuration value against the enum element type of a collection property such as `java.util.Set<...>`
 - fix: Accept an enum configuration value in any relaxed form, so `request-headers` resolves to `REQUEST_HEADERS` and is no longer reported as invalid
 - fix: Complete an enum configuration value from any relaxed spelling and insert Spring's recommended one, so `r`, `request-h`, `request_h` and `REQ` all insert `request-headers`
@@ -29,6 +28,7 @@
 - fix: Do not report `@Autowired` members of `@ContextConfiguration` test classes as not being a Spring bean
 - fix: Evaluate the IntelliJ IDEA Ultimate line marker suppression once per highlighting batch instead of once per PSI element
 - fix: Do not freeze the UI while a project opens: the linked-project self-healing pass no longer requests the run configuration manager on the event dispatch thread
+- fix: Stop resolving PSI in the Spring Boot toolbar action update, which caused multi-second action-update delays
 
 ### Spring Web
 - feat: List Actuator endpoints in the Endpoints tool window, one row per `@ReadOperation`/`@WriteOperation`/`@DeleteOperation` with its `@Selector` path variables, and navigate to the declaring class and the operation method; the path follows `management.endpoints.web.base-path`, `management.endpoints.web.path-mapping.<id>` and `management.server.port`
@@ -39,7 +39,7 @@
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded
 - fix: Keep Sentry action breadcrumbs useful by dropping editor typing and caret movement, recording a repeated action once, and trimming a captured report to the actions that led to it
 
-## 262.34.101 - 2026-08-18
+## [262.34.101] - 2026-08-19
 
 ### Spring Core
 - fix: Keep renamed Spring Boot run configurations linked without ambiguous fallback (#229) (#279)
@@ -75,7 +75,6 @@
 - fix: Resolve Kotlin `const val` package names in component-scan annotations
 - fix: Resolve `@Value` placeholder keys whose default is a SpEL or nested placeholder expression, such as `${my.key:#{null}}`
 - fix: Resolve property keys consumed only from a dependency module (#276)
-- fix: Stop resolving PSI in the Spring Boot toolbar action update, which caused multi-second action-update delays
 
 ### Spring Data
 - fix: Fail closed on stale PSI in SQL injector (#235) (#242)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,7 @@ Please make sure your pull request (PR) meets the following criteria:
 - **Code style:** clean, well-structured, Kotlin-idiomatic, SPDX header present.
 - **Documentation:** update relevant docs (README / wiki / messages) when behavior or usage changes.
 - **Testing:** include or update tests; state how you verified the change.
+- **Changelog:** add your entry under `## [Unreleased]`, never into an already-released section. Maintainers handle release sections and version bumps.
 
 ## 8. Review and approval process
 After you submit a pull request, the Explyt team will:

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ org.jetbrains.intellij.platform.downloadSources=true
 sinceVersion=262
 untilVersion=265.*
 kotlin.daemon.jvmargs=-Xmx2G
-pluginVersion=34
+pluginVersion=35

--- a/modules/base/src/main/kotlin/com/explyt/base/AsyncInitializationScheduler.kt
+++ b/modules/base/src/main/kotlin/com/explyt/base/AsyncInitializationScheduler.kt
@@ -8,6 +8,7 @@ package com.explyt.base
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProcessCanceledException
 import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -36,23 +37,32 @@ internal class AsyncInitializationScheduler(
         if (attempts.get() >= MAX_ATTEMPTS) return
         if (!running.compareAndSet(false, true)) return
 
-        executor.execute {
-            var failed = false
-            try {
-                attempts.incrementAndGet()
-                initialize()
-                flush()
-            } catch (exception: ProcessCanceledException) {
-                throw exception
-            } catch (exception: Exception) {
-                failed = true
-                // Best-effort telemetry: buffered data is dropped rather than retained until the process exits.
-                discardPending()
-                logger.warn("Failed to initialize error reporting, attempt ${attempts.get()} of $MAX_ATTEMPTS", exception)
-            } finally {
-                running.set(false)
-                if (!failed && !isInitialized() && hasPending()) schedule()
+        try {
+            executor.execute {
+                var shouldScheduleFollowUp = true
+                try {
+                    attempts.incrementAndGet()
+                    initialize()
+                    flush()
+                } catch (exception: ProcessCanceledException) {
+                    // Cancellation is not an initialization failure: rethrow it, but do not spend the retry budget on
+                    // a follow-up pass the caller never asked for.
+                    shouldScheduleFollowUp = false
+                    throw exception
+                } catch (exception: Exception) {
+                    shouldScheduleFollowUp = false
+                    // Best-effort telemetry: buffered data is dropped rather than retained until the process exits.
+                    discardPending()
+                    logger.warn("Failed to initialize error reporting, attempt ${attempts.get()} of $MAX_ATTEMPTS", exception)
+                } finally {
+                    running.set(false)
+                    if (shouldScheduleFollowUp && !isInitialized() && hasPending()) schedule()
+                }
             }
+        } catch (_: RejectedExecutionException) {
+            // No task was accepted, so clear the in-flight flag and let a later producer retry instead of surfacing
+            // the rejection on the calling thread, which is the EDT.
+            running.set(false)
         }
     }
 

--- a/modules/base/src/main/kotlin/com/explyt/util/ExplytPsiUtil.kt
+++ b/modules/base/src/main/kotlin/com/explyt/util/ExplytPsiUtil.kt
@@ -111,6 +111,7 @@ object ExplytPsiUtil {
                 && (method.containingFile?.name !in setOf("Annotation.class", "Object.class"))
 
     fun PsiClass.isEqualOrInheritor(baseClass: PsiClass, checkDeep: Boolean = true): Boolean {
+        if (!isValid || !baseClass.isValid) return false
         return this.qualifiedName == baseClass.qualifiedName || this.isInheritor(baseClass, checkDeep)
     }
 

--- a/modules/base/src/test/kotlin/com/explyt/base/AsyncInitializationSchedulerTest.kt
+++ b/modules/base/src/test/kotlin/com/explyt/base/AsyncInitializationSchedulerTest.kt
@@ -5,11 +5,14 @@
 
 package com.explyt.base
 
+import com.intellij.openapi.progress.ProcessCanceledException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.util.ArrayDeque
 import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
 
 class AsyncInitializationSchedulerTest {
 
@@ -95,6 +98,64 @@ class AsyncInitializationSchedulerTest {
         }
 
         assertEquals(AsyncInitializationScheduler.MAX_ATTEMPTS, attempts)
+    }
+
+    /**
+     * A rejected task never runs, so the in-flight flag would stay set forever and error reporting would never come
+     * up again. The rejection must also not escape onto the calling thread, which is the EDT.
+     */
+    @Test
+    fun `executor rejection allows a later initialization attempt`() {
+        val tasks = ArrayDeque<Runnable>()
+        var reject = true
+        var initializations = 0
+        val scheduler = AsyncInitializationScheduler(
+            executor = {
+                if (reject) throw RejectedExecutionException("executor is shutting down")
+                tasks.addLast(it)
+            },
+            initialize = { initializations++ },
+            flush = {},
+            isInitialized = { initializations > 0 },
+            hasPending = { true },
+            discardPending = {},
+        )
+
+        scheduler.schedule()
+        assertEquals("a rejected task must not run", 0, initializations)
+
+        reject = false
+        scheduler.schedule()
+        tasks.removeFirst().run()
+
+        assertEquals("the next producer must be able to retry", 1, initializations)
+    }
+
+    /**
+     * Cancellation is not a failure of the initialization itself, so it must neither be swallowed nor spend the retry
+     * budget by scheduling a follow-up pass.
+     */
+    @Test
+    fun `cancellation is rethrown without scheduling a follow-up`() {
+        val tasks = ArrayDeque<Runnable>()
+        var attempts = 0
+        val scheduler = AsyncInitializationScheduler(
+            executor = { tasks.addLast(it) },
+            initialize = {
+                attempts++
+                throw ProcessCanceledException()
+            },
+            flush = {},
+            isInitialized = { false },
+            hasPending = { true },
+            discardPending = {},
+        )
+
+        scheduler.schedule()
+        assertThrows(ProcessCanceledException::class.java) { tasks.removeFirst().run() }
+
+        assertEquals("cancellation must not trigger a follow-up pass", 1, attempts)
+        assertEquals("no follow-up task may be queued", 0, tasks.size)
     }
 
     @Test

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectAction.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectAction.kt
@@ -34,7 +34,7 @@ class AttachSpringBootToolbarProjectAction : DumbAwareAction() {
     override fun update(e: AnActionEvent) {
         val presentation = e.presentation
         val project = e.project ?: return
-        val selectedConfiguration = RunManager.getInstance(project).selectedConfiguration?.configuration
+        val selectedConfiguration = RunManager.getInstanceIfCreated(project)?.selectedConfiguration?.configuration
         presentation.isVisible = selectedConfiguration.supportsSpringBootAttach()
         // Attaching resolves the main class through indexes, so keep the button in place but inert while indexing.
         presentation.isEnabled = presentation.isVisible && !DumbService.isDumb(project)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/hint/PropertyDebugValueCodeVisionProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/hint/PropertyDebugValueCodeVisionProvider.kt
@@ -43,13 +43,14 @@ import java.util.concurrent.TimeUnit
 
 private val PROPERTY_FILE_TYPES = setOf(PropertiesFileType.INSTANCE, YAMLFileType.YML)
 
-class PropertyDebugValueCodeVisionProvider : CodeVisionProvider<VirtualFile> {
+class PropertyDebugValueCodeVisionProvider : CodeVisionProvider<VirtualFile?> {
 
     override fun isAvailableFor(project: Project) = true
 
-    override fun precomputeOnUiThread(editor: Editor) = editor.virtualFile!!
+    override fun precomputeOnUiThread(editor: Editor) = editor.virtualFile
 
-    override fun computeCodeVision(editor: Editor, virtualFile: VirtualFile): CodeVisionState {
+    override fun computeCodeVision(editor: Editor, virtualFile: VirtualFile?): CodeVisionState {
+        if (virtualFile == null) return READY_EMPTY
         val project = editor.project ?: return READY_EMPTY
         if (virtualFile.fileType !in PROPERTY_FILE_TYPES) return READY_EMPTY
         if (!SpringCoreUtil.isExplytDebug(project)) return READY_EMPTY

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBeanIncorrectAutowiringInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBeanIncorrectAutowiringInspection.kt
@@ -317,6 +317,7 @@ class SpringBeanIncorrectAutowiringInspection : SpringBaseUastLocalInspectionToo
     }
 
     private fun isBeanExist(module: Module, psiClass: PsiClass): Boolean {
+        if (!psiClass.isValid) return false
         if (SpringCoreUtil.isComponentCandidate(psiClass)) return true
         if (psiClass.isSpringTestClass()) return true
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/DebugBeanDefinitionLineMarkerProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/providers/DebugBeanDefinitionLineMarkerProvider.kt
@@ -28,6 +28,7 @@ class DebugBeanDefinitionLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         val uClass = getUParentForIdentifier(element) as? UClass ?: return null
         val psiClass = uClass.javaPsi
+        if (!psiClass.isValid) return null
         val qualifiedName = psiClass.qualifiedName ?: return null
         val project = psiClass.project
         if (!SpringCoreUtil.isExplytDebug(project)) return null

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/RunConfigurationUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/runconfiguration/RunConfigurationUtil.kt
@@ -65,6 +65,7 @@ object RunConfigurationUtil {
     fun getRunClassNameInner(runConfiguration: RunConfiguration?): String? {
         return when (runConfiguration) {
             is SpringBootRunConfiguration -> runConfiguration.mainClassName
+            is KotlinRunConfiguration -> runConfiguration.mainClassName
             is CommonJavaRunConfigurationParameters -> runConfiguration.runClass
             else -> null
         }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/NativeSearchService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/NativeSearchService.kt
@@ -57,14 +57,19 @@ import java.util.concurrent.atomic.AtomicBoolean
 class NativeSearchService(private val project: Project) {
 
     fun getAllActiveBeans(): Set<PsiBean> {
-        return CachedValuesManager.getManager(project).getCachedValue(project) {
-            CachedValueProvider.Result(
-                getBeans(),
-                ModificationTrackerManager.getInstance(project).getExternalSystemTracker(),
-                ModificationTrackerManager.getInstance(project).getUastModelAndLibraryTracker()
-            )
-        }
+        return filterValidBeans(
+            CachedValuesManager.getManager(project).getCachedValue(project) {
+                CachedValueProvider.Result(
+                    getBeans(),
+                    ModificationTrackerManager.getInstance(project).getExternalSystemTracker(),
+                    ModificationTrackerManager.getInstance(project).getUastModelAndLibraryTracker()
+                )
+            }
+        )
     }
+
+    internal fun filterValidBeans(beans: Collection<PsiBean>): Set<PsiBean> =
+        beans.filterTo(mutableSetOf()) { it.psiClass.isValid && it.psiMember.isValid }
 
     private fun getBeans(): Set<PsiBean> {
         val projectBeans = getProjectBeans()

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
@@ -753,15 +753,8 @@ object SpringSearchUtils {
         }
     }
 
-    fun getAllReferencesToElement(element: PsiElement): Set<PsiReference> {
-        val project = element.project
-        return CachedValuesManager.getManager(project).getCachedValue(element) {
-            CachedValueProvider.Result(
-                ReferencesSearch.search(element).toSet(),
-                ModificationTrackerManager.getInstance(project).getUastModelAndLibraryTracker()
-            )
-        }
-    }
+    fun getAllReferencesToElement(element: PsiElement): Set<PsiReference> =
+        ReferencesSearch.search(element).toSet()
 
     /**
      * Finds references to [element], also looking into the modules the containing module depends on.

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectActionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectActionTest.kt
@@ -15,6 +15,7 @@ import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.testFramework.DumbModeTestUtils
 import com.intellij.testFramework.TestActionEvent
 
@@ -36,6 +37,34 @@ class AttachSpringBootToolbarProjectActionTest : ExplytKotlinLightTestCase() {
             mainClassName = "missing.Application"
         }
         assertUpdateVisible(configuration)
+    }
+
+    /**
+     * The toolbar action is updated on every frame refresh, long before anything in the project asked for the run
+     * configuration model, so `update()` must never be the code that initializes the `RunManager` service: creating a
+     * project service parks the calling thread until initialization completes.
+     *
+     * Any opened project — including the light fixture one — already holds a created `RunManager`, so the check uses the
+     * default project: a real project whose services stay uncreated until someone asks for them.
+     */
+    fun testUpdateDoesNotCreateRunManagerService() {
+        val projectWithLazyServices = ProjectManager.getInstance().defaultProject
+        assertNull(
+            "RunManager must not be created before update()",
+            RunManager.getInstanceIfCreated(projectWithLazyServices)
+        )
+
+        val action = AttachSpringBootToolbarProjectAction()
+        val event = TestActionEvent.createTestEvent(
+            action,
+            SimpleDataContext.builder().add(CommonDataKeys.PROJECT, projectWithLazyServices).build()
+        )
+        action.update(event)
+
+        assertNull(
+            "update() must not create the RunManager service",
+            RunManager.getInstanceIfCreated(projectWithLazyServices)
+        )
     }
 
     fun testUpdateHidesConfigurationWithoutMainClass() {

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectActionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootToolbarProjectActionTest.kt
@@ -61,6 +61,8 @@ class AttachSpringBootToolbarProjectActionTest : ExplytKotlinLightTestCase() {
         )
         action.update(event)
 
+        assertFalse(event.presentation.isVisible)
+        assertFalse(event.presentation.isEnabled)
         assertNull(
             "update() must not create the RunManager service",
             RunManager.getInstanceIfCreated(projectWithLazyServices)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/hint/PropertyDebugValueCodeVisionProviderTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/hint/PropertyDebugValueCodeVisionProviderTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.hint
+
+import com.explyt.spring.test.ExplytBaseLightTestCase
+import com.intellij.codeInsight.codeVision.CodeVisionState.Companion.READY_EMPTY
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.impl.DocumentImpl
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+
+class PropertyDebugValueCodeVisionProviderTest : ExplytBaseLightTestCase() {
+
+    fun testReturnsNullForEditorWithoutVirtualFile() {
+        val editor = EditorFactory.getInstance().createEditor(DocumentImpl(""))
+        try {
+            assertNull(editor.virtualFile)
+            val provider = PropertyDebugValueCodeVisionProvider()
+            assertNull(provider.precomputeOnUiThread(editor))
+            assertSame(READY_EMPTY, provider.computeCodeVision(editor, null))
+        } finally {
+            EditorFactory.getInstance().releaseEditor(editor)
+        }
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/runconfiguration/RunConfigurationUtilTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/runconfiguration/RunConfigurationUtilTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.runconfiguration
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.intellij.execution.configurations.JavaRunConfigurationModule
+import org.jetbrains.kotlin.idea.run.KotlinRunConfiguration
+import org.jetbrains.kotlin.idea.run.KotlinRunConfigurationType
+
+class RunConfigurationUtilTest : ExplytJavaLightTestCase() {
+
+    fun testKotlinRunClassNameDoesNotResolvePsi() {
+        val mainClassName = "com.example.MainKt"
+        val configuration = object : KotlinRunConfiguration(
+            "test",
+            JavaRunConfigurationModule(project, true),
+            KotlinRunConfigurationType.instance
+        ) {
+            override fun getRunClass(): String? = error("Kotlin run class must not be resolved")
+        }.apply {
+            this.mainClassName = mainClassName
+        }
+
+        assertEquals(mainClassName, RunConfigurationUtil.getRunClassName(configuration))
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/service/NativeSearchServiceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/service/NativeSearchServiceTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.service
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+
+class NativeSearchServiceTest : ExplytJavaLightTestCase() {
+
+    fun testFilterValidBeansExcludesInvalidCachedBean() {
+        val validBean = PsiBean(psiClass(myFixture.configureByText("ValidBean.java", "public class ValidBean {}")))
+        val invalidFile = myFixture.addFileToProject("InvalidBean.java", "public class InvalidBean {}")
+        val invalidBean = PsiBean(psiClass(invalidFile))
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            invalidFile.virtualFile.delete(this)
+        }
+        myFixture.addFileToProject("InvalidBean.java", "public class ReplacementBean {}")
+
+        assertTrue("the unchanged bean must stay valid", validBean.psiClass.isValid)
+        assertFalse("the deleted bean must be invalidated", invalidBean.psiClass.isValid)
+        assertEquals(
+            setOf(validBean),
+            NativeSearchService(project).filterValidBeans(setOf(validBean, invalidBean))
+        )
+    }
+
+    private fun psiClass(file: PsiFile): PsiClass = PsiTreeUtil.findChildOfType(file, PsiClass::class.java)!!
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/service/java/SpringSearchServiceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/service/java/SpringSearchServiceTest.kt
@@ -7,11 +7,16 @@ package com.explyt.spring.core.service.java
 
 import com.explyt.spring.core.service.SpringSearchService
 import com.explyt.spring.core.service.SpringSearchServiceFacade
+import com.explyt.spring.core.service.SpringSearchUtils
 import com.explyt.spring.test.ExplytJavaLightTestCase
 import com.explyt.spring.test.TestLibrary
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.util.registry.Registry
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.util.PsiTreeUtil
 import junit.framework.TestCase
 
 class SpringSearchServiceTest : ExplytJavaLightTestCase() {
@@ -75,5 +80,31 @@ class SpringSearchServiceTest : ExplytJavaLightTestCase() {
         val psiBean = beanTestClass[0]
         assertTrue(psiBean.psiMember is PsiMethod)
         assertTrue((psiBean.psiMember as PsiMethod).containingClass?.qualifiedName == "com.app.AppConfiguration")
+    }
+
+    fun testAllReferencesToElementReflectSourceChanges() {
+        val file = myFixture.configureByText(
+            "References.java",
+            """
+            class References {
+                void setPrefix(String value) {}
+                void first() { setPrefix(\"first\"); }
+            }
+            """.trimIndent()
+        )
+        val method = PsiTreeUtil.findChildrenOfType(file, PsiMethod::class.java)
+            .single { it.name == "setPrefix" }
+
+        assertEquals(1, SpringSearchUtils.getAllReferencesToElement(method).size)
+
+        val document = file.viewProvider.document!!
+        WriteCommandAction.runWriteCommandAction(project) {
+            val insertionOffset = document.text.lastIndexOf('}')
+            document.insertString(insertionOffset, "    void second() { setPrefix(\\\"second\\\"); }\\n")
+        }
+        PsiDocumentManager.getInstance(project).commitDocument(document)
+        PsiManager.getInstance(project).dropPsiCaches()
+
+        assertEquals(2, SpringSearchUtils.getAllReferencesToElement(method).size)
     }
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/java/ExplytPsiUtilTypeCheckJavaTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/java/ExplytPsiUtilTypeCheckJavaTest.kt
@@ -7,11 +7,16 @@ package com.explyt.spring.core.util.java
 
 import com.explyt.spring.test.ExplytJavaLightTestCase
 import com.explyt.util.ExplytPsiUtil.isCollection
+import com.explyt.util.ExplytPsiUtil.isEqualOrInheritor
 import com.explyt.util.ExplytPsiUtil.isList
 import com.explyt.util.ExplytPsiUtil.isMap
 import com.explyt.util.ExplytPsiUtil.isOptional
 import com.explyt.util.ExplytPsiUtil.isString
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiField
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 
 class ExplytPsiUtilTypeCheckJavaTest : ExplytJavaLightTestCase() {
@@ -98,5 +103,20 @@ class ExplytPsiUtilTypeCheckJavaTest : ExplytJavaLightTestCase() {
 
     fun testJavaPrimitiveIsNotMap() {
         assertFalse("int should not be isMap", fieldType("javaPrimitive").isMap)
+    }
+
+    fun testInvalidClassIsNotEqualOrInheritor() {
+        val sourceFile = myFixture.file
+        val invalidClass = PsiTreeUtil.findChildOfType(sourceFile, PsiClass::class.java)!!
+        val baseClass = JavaPsiFacade.getInstance(project)
+            .findClass("java.lang.Object", GlobalSearchScope.allScope(project))!!
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            sourceFile.virtualFile.delete(this)
+        }
+        myFixture.addFileToProject("psiutil/TypeChecks.java", "public class Reconfigured {}")
+
+        assertFalse("the original class must be invalidated", invalidClass.isValid)
+        assertFalse("an invalid class must fail closed", invalidClass.isEqualOrInheritor(baseClass))
     }
 }

--- a/modules/spring-web/src/main/kotlin/com/explyt/spring/web/langinjection/PathRegexpInjector.kt
+++ b/modules/spring-web/src/main/kotlin/com/explyt/spring/web/langinjection/PathRegexpInjector.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.impl.source.tree.injected.changesHandler.contentRange
+import kotlinx.coroutines.CancellationException
 import org.intellij.lang.regexp.RegExpLanguage
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UastFacade
@@ -85,6 +86,8 @@ class PathRegexpInjector : MultiHostInjector {
         val valueRange = try {
             contentRange
         } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
             return null

--- a/modules/spring-web/src/main/kotlin/com/explyt/spring/web/langinjection/PathRegexpInjector.kt
+++ b/modules/spring-web/src/main/kotlin/com/explyt/spring/web/langinjection/PathRegexpInjector.kt
@@ -11,9 +11,11 @@ import com.explyt.spring.web.util.SpringWebUtil
 import com.intellij.lang.injection.MultiHostInjector
 import com.intellij.lang.injection.MultiHostRegistrar
 import com.intellij.openapi.module.ModuleUtil
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.impl.source.tree.injected.changesHandler.contentRange
 import org.intellij.lang.regexp.RegExpLanguage
 import org.jetbrains.uast.UAnnotation
@@ -37,41 +39,57 @@ class PathRegexpInjector : MultiHostInjector {
         val urlPaths = mahRequestMapping.getAnnotationMemberValues(uElement, setOf("value", "path"))
         for (memberValue in urlPaths) {
             memberValue.evaluateString() ?: continue
-            val urlPath = memberValue.asSourceString()
+            val valueSourcePsi = memberValue.sourcePsi ?: continue
+            val valueRange = valueSourcePsi.textRange ?: continue
+            // offsets below are relative to the source text of the whole member value expression,
+            // which may be a concatenation of several injection hosts
+            val urlPath = valueSourcePsi.text ?: continue
 
-            val ranges = SpringWebUtil.NameInBracketsRx.findAll(urlPath)
+            val regexpRanges = SpringWebUtil.NameInBracketsRx.findAll(urlPath)
                 .mapNotNull { it.groups["name"] }
                 .filter { it.value.contains(":") }
                 .mapTo(mutableListOf()) {
-                    val range = TextRange(it.range.first + 1, it.range.last + 2)
-                    val delimiterRegexp = it.value.indexOf(":")
-                    val regexpRange = TextRange(range.startOffset + delimiterRegexp + 1, range.endOffset)
-                    if (urlPath.startsWith("\"")) regexpRange.shiftLeft(1) else regexpRange
+                    val regexpStart = it.range.first + it.value.indexOf(":") + 1
+                    TextRange(regexpStart, it.range.last + 1)
                 }
-            if (ranges.isEmpty()) continue
+            if (regexpRanges.isEmpty()) continue
 
             val flattenExpression = memberValue !is UInjectionHost
             val concatenationsFacade =
                 UStringConcatenationsFacade.createFromUExpression(memberValue, flattenExpression) ?: return
-            val host = concatenationsFacade.psiLanguageInjectionHosts
+            val hostContentRanges = concatenationsFacade.psiLanguageInjectionHosts
                 .distinct()
-                .filter { it.isValid && it.isValidHost }
-                .filter { host ->
-                    try {
-                        val range = host.contentRange.shiftLeft(host.textOffset)
-                        range.startOffset >= 0 && range.endOffset >= range.startOffset
-                    } catch (_: Exception) {
-                        false
-                    }
-                }
-                .firstOrNull() ?: return
+                .mapNotNull { host -> host.absoluteContentRange()?.let { host to it } }
+                .toList()
+            if (hostContentRanges.isEmpty()) return
 
-            ranges.toString()
+            val places = regexpRanges.mapNotNull { regexpRange ->
+                val absoluteRange = regexpRange.shiftRight(valueRange.startOffset)
+                val (host, _) = hostContentRanges.firstOrNull { (_, content) -> content.contains(absoluteRange) }
+                    ?: return@mapNotNull null
+                host to absoluteRange.shiftLeft(host.textRange.startOffset)
+            }
+            if (places.isEmpty()) continue
+
             registrar.startInjecting(RegExpLanguage.INSTANCE)
-            ranges.forEach { registrar.addPlace(null, null, host, it) }
+            places.forEach { (host, rangeInsideHost) -> registrar.addPlace(null, null, host, rangeInsideHost) }
             registrar.doneInjecting()
             return
         }
+    }
+
+    /** Content range of the host in file coordinates, or null if the host cannot be injected into. */
+    private fun PsiLanguageInjectionHost.absoluteContentRange(): TextRange? {
+        if (!isValid || !isValidHost) return null
+        val hostRange = textRange ?: return null
+        val valueRange = try {
+            contentRange
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (_: Exception) {
+            return null
+        }
+        return valueRange.takeIf { hostRange.contains(it) }
     }
 
     override fun elementsToInjectIn(): List<Class<out PsiElement>> {

--- a/modules/spring-web/src/test/kotlin/com/explyt/spring/web/langinjection/java/PathRegexpInjectorTest.kt
+++ b/modules/spring-web/src/test/kotlin/com/explyt/spring/web/langinjection/java/PathRegexpInjectorTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.web.langinjection.java
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.testFramework.fixtures.InjectionTestFixture
+import org.intellij.lang.annotations.Language
+
+class PathRegexpInjectorTest : ExplytJavaLightTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springWeb_6_0_7,
+    )
+
+    fun testRegexpInjectedInSingleStringPath() {
+        @Language("JAVA") val code = """
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @Controller
+            public class TestController {
+
+                @RequestMapping("/products/{id:[0-9]+}")
+                public String getProduct() { return "product"; }
+            }
+            """
+
+        myFixture.configureByText("TestController.java", code.trimIndent())
+
+        InjectionTestFixture(myFixture).assertInjectedContent("[0-9]+")
+    }
+
+    fun testRegexpInjectedInConcatenatedStringPath() {
+        @Language("JAVA") val code = """
+            import org.springframework.stereotype.Controller;
+            import org.springframework.web.bind.annotation.RequestMapping;
+
+            @Controller
+            public class TestController {
+
+                @RequestMapping("/products" + "/{id:[0-9]+}")
+                public String getProduct() { return "product"; }
+            }
+            """
+
+        myFixture.configureByText("TestController.java", code.trimIndent())
+
+        InjectionTestFixture(myFixture).assertInjectedContent("[0-9]+")
+    }
+}

--- a/modules/spring-web/src/test/kotlin/com/explyt/spring/web/langinjection/kotlin/PathRegexpInjectorTest.kt
+++ b/modules/spring-web/src/test/kotlin/com/explyt/spring/web/langinjection/kotlin/PathRegexpInjectorTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.web.langinjection.kotlin
+
+import com.explyt.spring.test.ExplytKotlinLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.testFramework.fixtures.InjectionTestFixture
+import org.intellij.lang.annotations.Language
+
+class PathRegexpInjectorTest : ExplytKotlinLightTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(
+        TestLibrary.springContext_6_0_7,
+        TestLibrary.springWeb_6_0_7,
+    )
+
+    fun testRegexpInjectedInSingleStringPath() {
+        @Language("kotlin") val code = """
+            import org.springframework.stereotype.Controller
+            import org.springframework.web.bind.annotation.RequestMapping
+
+            @Controller
+            class TestController {
+
+                @RequestMapping("/products/{id:[0-9]+}")
+                fun getProduct(): String = "product"
+            }
+            """
+
+        myFixture.configureByText("TestController.kt", code.trimIndent())
+
+        InjectionTestFixture(myFixture).assertInjectedContent("[0-9]+")
+    }
+
+    fun testRegexpInjectedInConcatenatedStringPath() {
+        @Language("kotlin") val code = """
+            import org.springframework.stereotype.Controller
+            import org.springframework.web.bind.annotation.RequestMapping
+
+            @Controller
+            class TestController {
+
+                @RequestMapping("/products" + "/{id:[0-9]+}")
+                fun getProduct(): String = "product"
+            }
+            """
+
+        myFixture.configureByText("TestController.kt", code.trimIndent())
+
+        InjectionTestFixture(myFixture).assertInjectedContent("[0-9]+")
+    }
+}


### PR DESCRIPTION
Prepares plugin generation 35 on the trunk: corrects the changelog split at the release boundary, documents the release model, and lands the generation-34 stability fixes that were previously authored on release branches.

## Changelog and version
- Bracket the current release (`## [262.34.101] - 2026-08-19`) and correct its date to the publish date. Older sections stay unbracketed by convention.
- Move the toolbar entry that had leaked into the already-shipped `262.34.101` section back into `[Unreleased]`.
- Bump `pluginVersion` to `35`, so the trunk carries the generation being prepared.

## Documentation
- `AGENTS.md`: new "Releases, branches and versions" section covering the trunk-first rule, generation semantics, the `<line>.<generation>.<CI run>` format, one-asset-per-line releases, and the changelog bracket convention.
- `CONTRIBUTING.md`: contributors add entries under `[Unreleased]` only.

## Stability fixes
- Keep the Spring Boot toolbar `update()` off blocking service creation via `RunManager.getInstanceIfCreated`.
- Map `@RequestMapping` regexp injections to the host that actually contains them, fixing `rangeInsideHost` failures on concatenated paths.
- Return an empty Code Vision state for an editor without a `VirtualFile` instead of throwing.
- Fail closed on invalid cached PSI in bean search, autowiring inspection and the debug gutter.
- Stop caching mutable reference-search results that went stale after an edit.
- Read the Kotlin run-configuration main class without resolving PSI on the EDT.
- Recover error reporting when the pooled executor rejects the initialization task, and stop scheduling a follow-up pass after cancellation.

## Verification
- `:spring-core:test --rerun-tasks` — BUILD SUCCESSFUL, exit code 0, 985 tests.
- New regression tests were red-green verified; the two scheduler cases failed for the expected reasons before the fix and pass after it.

Supersedes #320, #321 and #322, which were closed because they authored these fixes on release branches instead of the trunk. Backports to the supported lines will be cut from these commits.
