### PR TITLE
fix: Filter invalid cached PSI on the source bean-search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fix: Keep the Spring Boot toolbar button responsive by not creating the run configuration manager while the action updates
 - fix: Do not show the Spring Boot debug value hint in an editor that has no file behind it (#186)
 - fix: Ignore a cached bean whose PSI is no longer valid instead of failing inspections, gutters and bean search (#295)
+- fix: Apply that same filter on the source bean-search path, not only the native one, so a bean invalidated by an edit no longer breaks the autowiring inspection and bean navigation in a project without an external Spring model (#205)
 - fix: Reflect an edited source file in reference search results instead of returning a stale cached set
 - fix: Read the main class of a Kotlin run configuration without resolving PSI on the event dispatch thread (#185)
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchServiceFacade.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchServiceFacade.kt
@@ -45,7 +45,9 @@ class SpringSearchServiceFacade(private val project: Project) {
         return if (isNative || isExternalProjectExist(project)) {
             nativeSearchService.getAllActiveBeans()
         } else {
-            springSearchService.getActiveBeansClasses(module)
+            // The source path caches beans too, so it can hand out a bean whose PSI was invalidated by an edit just
+            // like the native path can. Filter it here as well: callers dereference `psiClass` without a guard.
+            nativeSearchService.filterValidBeans(springSearchService.getActiveBeansClasses(module))
         }
     }
 
@@ -102,7 +104,7 @@ class SpringSearchServiceFacade(private val project: Project) {
             nativeSearchService.findActiveBeanDeclarations(beans, byBeanName, language, byBeanPsiType, qualifier)
         } else {
             val isTestSource = ExplytPsiUtil.isTestFiles(psiElement)
-            val beans = springSearchService.getActiveBeansClasses(module)
+            val beans = nativeSearchService.filterValidBeans(springSearchService.getActiveBeansClasses(module))
             nativeSearchService.findActiveBeanDeclarations(
                 beans, byBeanName, language, byBeanPsiType, qualifier, module
             ).filter { filterBeanByTest(it, psiElement, isTestSource) }


### PR DESCRIPTION
## Summary

`SpringSearchServiceFacade` applied the invalid-PSI filter to the native bean-search path only. The source path returned `springSearchService.getActiveBeansClasses(module)` unfiltered, and its callers dereference `psiClass` without a guard:

- `SpringBeanIncorrectAutowiringInspection.isBeanExist` reads `it.psiClass.qualifiedName` on every cached bean;
- `NativeSearchService.findActiveBeanDeclarations` takes the collection as given and does not filter it either.

So in a project without an external Spring model, a bean whose PSI an edit had invalidated threw `PsiInvalidElementAccessException` out of inspections, gutters and bean search.

Both source-path call sites now go through the same `filterValidBeans` the native path already uses. The `isValid` guard added earlier to `isBeanExist` covered only the class being inspected, not the cached set it is compared against.

## Related issue

Closes #205

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --tests "*NativeSearchServiceTest*" --tests "*SpringSearchServiceTest*" --tests "*SpringBeanIncorrectAutowiring*" --tests "*AutowiringInspection*"
```

17 tests, 0 failures, across `SpringBeanIncorrectAutowiringInspectionTest` (Java and Kotlin), `SpringSearchServiceTest` (Java and Kotlin) and `NativeSearchServiceTest`.

**No new regression test.** The invalidated bean has to survive inside the cached set to reproduce, and `getActiveBeansClasses` is cached against modification trackers: anything that invalidates a class also ticks the tracker and recomputes the cache, so a test written against this path passes on the unfixed code too. The project has no mocking library to substitute the bean supplier. The semantics of `filterValidBeans` itself are already covered by `NativeSearchServiceTest.testFilterValidBeansExcludesInvalidCachedBean`; this change only widens where it is applied.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. (no new files)
- [ ] I added or updated tests for my change — explained above.
- [x] I updated relevant documentation (CHANGELOG entry added).