### PR TITLE
perf: Reject a call by argument count before resolving it in the resource inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Spring Core
 - fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
+- fix: Stop resolving every call in the file to decide whether it looks up a resource: the resource-reference inspection now rejects a call by its argument count first, so highlighting no longer walks into unrelated library PSI on calls it was always going to ignore
 - fix: Report the `BootstrapRegistry`, `@JsonComponent`/`@JsonMixin` and `@EntityScan` migrations when the legacy symbol no longer resolves after a Spring Boot 4 upgrade
 - fix: Report the `@MockBean` / `@SpyBean` migration when the legacy annotation no longer resolves after a Spring Boot 4 upgrade
 - feat: Report the `@MockBean` / `@SpyBean` migration already in Spring Boot 3.4/3.5, where the annotations are deprecated for removal, naming `@MockitoBean` / `@MockitoSpyBean` and offering the quick-fix the platform deprecation warning cannot

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/PsiFileReferenceInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/PsiFileReferenceInspection.kt
@@ -66,6 +66,10 @@ private class PsiFileReferenceVisitor(
 
     private fun checkCallExpression(node: UCallExpression) {
         if (node.kind != UastCallKind.METHOD_CALL) return
+        // Each check below needs exactly one value argument, so decide that syntactically before resolving.
+        // Resolution is the expensive half and it is what pulls this inspection into unrelated library PSI —
+        // every call in every file was resolved just to discover it is not `getResource` or a `ResourceUtils` call.
+        if (node.valueArgumentCount != 1) return
         val methodName = node.methodName
         val psiMethod = node.resolve() ?: return
         val targetClass = psiMethod.containingClass ?: return
@@ -77,6 +81,8 @@ private class PsiFileReferenceVisitor(
 
     private fun checkConstructorCallExpression(node: UCallExpression) {
         if (node.kind != UastCallKind.CONSTRUCTOR_CALL) return
+        // `checkResourceLoaderGetResource` is the only check reached from here, and it too needs one argument.
+        if (node.valueArgumentCount != 1) return
         val psiMethod = node.resolve() ?: return
         val targetClass = psiMethod.containingClass ?: return
         checkResourceLoaderGetResource(node, targetClass)


### PR DESCRIPTION
## Summary

`PsiFileReferenceInspection.checkCallExpression` resolved **every** method call in the file before asking whether the target was interesting:

```kotlin
if (node.kind != UastCallKind.METHOD_CALL) return
val methodName = node.methodName
val psiMethod = node.resolve() ?: return   // ← every call, everywhere
```

Resolution is the expensive half, and on compiled dependencies it walks into library PSI unrelated to Spring.

All three checks reached from there already require exactly one value argument, and so does the single check reached from `checkConstructorCallExpression`:

| check | existing guard |
|---|---|
| `checkResourceLoaderGetResource` | `if (node.valueArgumentCount != 1) return` |
| `checkResourceClassGetResource` | `if (methodName != GET_RESOURCE \|\| node.valueArgumentCount != 1) return` |
| `checkResourceUtil` | `if (!isInheritor(targetClass, RESOURCE_UTILS) \|\| node.valueArgumentCount != 1) return` |

Hoisting that test above `resolve()` is behaviour-preserving — it only changes the order in which two guards are evaluated — and skips resolution for every call that could never have been reported.

## Related issue

No issue. Found while investigating #195, where this inspection appears in the stack of a platform-side stub-index error because it was resolving `kotlin.jvm.functions.Function0` out of a dependency jar. That report is a platform defect and this change does not fix it; the resolve reduction stands on its own.

## Type of change

- [ ] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [x] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --tests "*PsiFileReferenceInspectionTest*"
```

2 tests, 0 failures — the Java and Kotlin `PsiFileReferenceInspectionTest`.

No new test: the change is behaviour-preserving by construction, so a new test could only re-assert what the existing fixtures already pin. Those fixtures are the right guard here — `testdata/{java,kotlin}/inspection/fileResource` exercises every reachable check with one-argument calls (`new ClassPathResource(...)`, `new FileUrlResource(...)`, `Class.getResource(...)`, `ClassLoader.getResource(...)`, `resourceLoader.getResource(...)`, `applicationContext.getResource(...)`) and compares the full problem set against `expected.xml`, 18 problems on the Java side. If the hoisted guard were wrong for any of those shapes, the fixture would drop problems and the test would fail.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. (no new files)
- [ ] I added or updated tests for my change — explained above.
- [x] I updated relevant documentation (CHANGELOG entry added).