### PR TITLE
perf: Index the configuration property and hint catalogues instead of scanning them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Spring Core
 - fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
+- fix: Look up a configuration key in the metadata catalogue through an index instead of scanning it: validating a `.properties`/`.yaml` file re-normalised every one of the thousands of catalogue names for every key in the file, on every highlighting pass
+- fix: Look up metadata hints by name instead of walking the whole hint list once per key per check
 - fix: Report the `BootstrapRegistry`, `@JsonComponent`/`@JsonMixin` and `@EntityScan` migrations when the legacy symbol no longer resolves after a Spring Boot 4 upgrade
 - fix: Report the `@MockBean` / `@SpyBean` migration when the legacy annotation no longer resolves after a Spring Boot 4 upgrade
 - feat: Report the `@MockBean` / `@SpyBean` migration already in Spring Boot 3.4/3.5, where the annotations are deprecated for removal, naming `@MockitoBean` / `@MockitoSpyBean` and offering the quick-fix the platform deprecation warning cannot

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/ConfigurationPropertyIndex.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/ConfigurationPropertyIndex.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.completion.properties
+
+import com.explyt.spring.core.JavaCoreClasses
+import com.explyt.spring.core.util.PropertyUtil
+
+/**
+ * A lookup index over the configuration property catalogue, replacing a linear scan that re-normalised every
+ * catalogue name on every query.
+ *
+ * The scan it replaces is `properties.find { PropertyUtil.isSameProperty(it.name, query, it.type) }`, and
+ * `isSameProperty` normalises **both** sides with [PropertyUtil.toBooleanAlias] using the *catalogue entry's*
+ * type. The type is only known once an entry is in hand, so one map keyed by the plain normal form cannot
+ * express it. Hence two maps:
+ *
+ * - [plain] holds every non-boolean entry under `toCommonPropertyForm(name)`, since the alias is the identity
+ *   for a non-boolean type;
+ * - [booleanAliased] holds every boolean entry under `toCommonPropertyForm(toBooleanAlias(name, type))`, and a
+ *   query is aliased the same way before it is looked up there.
+ *
+ * A query therefore costs two hash lookups instead of a full scan. When both maps answer, the entry that came
+ * first in the original list wins, which is what `find` returned.
+ */
+class ConfigurationPropertyIndex private constructor(
+    private val plain: Map<String, Entry>,
+    private val booleanAliased: Map<String, Entry>,
+) {
+
+    private class Entry(val order: Int, val property: ConfigurationProperty)
+
+    fun findProperty(propertyName: String): ConfigurationProperty? {
+        val plainHit = plain[PropertyUtil.toCommonPropertyForm(propertyName)]
+        val booleanHit = booleanAliased[
+            PropertyUtil.toCommonPropertyForm(PropertyUtil.toBooleanAlias(propertyName, JavaCoreClasses.BOOLEAN))
+        ]
+        return when {
+            booleanHit == null -> plainHit?.property
+            plainHit == null -> booleanHit.property
+            booleanHit.order < plainHit.order -> booleanHit.property
+            else -> plainHit.property
+        }
+    }
+
+    companion object {
+        fun of(properties: List<ConfigurationProperty>): ConfigurationPropertyIndex {
+            val plain = HashMap<String, Entry>()
+            val booleanAliased = HashMap<String, Entry>()
+            properties.forEachIndexed { order, property ->
+                val key = PropertyUtil.toCommonPropertyForm(
+                    PropertyUtil.toBooleanAlias(property.name, property.type)
+                )
+                // The catalogue can repeat a name across loaders; `find` returned the first, so keep the first.
+                val target = if (property.isBooleanType()) booleanAliased else plain
+                target.putIfAbsent(key, Entry(order, property))
+            }
+            return ConfigurationPropertyIndex(plain, booleanAliased)
+        }
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/PropertyHintIndex.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/PropertyHintIndex.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.completion.properties
+
+/**
+ * A lookup index over the metadata hint catalogue, keyed by the exact hint name.
+ *
+ * The property inspection asked five separate questions of the shape
+ * `hints.any { it.name == property.key && … }`, once per property in the file, so a file of *n* keys walked the
+ * whole hint list 5*n* times — and always to the end, because most keys have no hint at all. The names are exact
+ * comparisons, not relaxed ones, so a plain hash map by name reproduces them.
+ */
+class PropertyHintIndex private constructor(
+    private val byName: Map<String, List<PropertyHint>>,
+    private val firstOccurrence: Map<String, Int>,
+) {
+
+    /** Every hint declared under [name], in catalogue order. Empty when nothing declares it. */
+    fun hintsNamed(name: String): List<PropertyHint> = byName[name].orEmpty()
+
+    /**
+     * Mirrors `hints.filter { it.name in names }.distinctBy { it.name }`: the first hint declared under each
+     * distinct name, ordered by where that name first appears in the catalogue. Order is preserved because the
+     * resulting values are rendered into the "unresolved value" message.
+     */
+    fun firstPerName(vararg names: String): List<PropertyHint> {
+        return names.distinct()
+            .mapNotNull { name ->
+                val first = byName[name]?.firstOrNull() ?: return@mapNotNull null
+                firstOccurrence.getValue(name) to first
+            }
+            .sortedBy { it.first }
+            .map { it.second }
+    }
+
+    companion object {
+        fun of(hints: List<PropertyHint>): PropertyHintIndex {
+            val byName = HashMap<String, MutableList<PropertyHint>>()
+            val firstOccurrence = HashMap<String, Int>()
+            hints.forEachIndexed { order, hint ->
+                byName.getOrPut(hint.name) { mutableListOf() }.add(hint)
+                firstOccurrence.putIfAbsent(hint.name, order)
+            }
+            return PropertyHintIndex(byName, firstOccurrence)
+        }
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/SpringConfigurationPropertiesSearch.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/completion/properties/SpringConfigurationPropertiesSearch.kt
@@ -59,7 +59,21 @@ class SpringConfigurationPropertiesSearch {
     }
 
     fun findProperty(module: Module, propertyName: String): ConfigurationProperty? {
-        return getAllProperties(module).find { isSameProperty(it.name, propertyName, it.type) }
+        return getPropertyIndex(module).findProperty(propertyName)
+    }
+
+    /**
+     * The catalogue runs to thousands of entries, and the scan this replaces re-normalised every one of them on
+     * every lookup — `isSameProperty` lowercases and strips separators on both sides per candidate. The names on
+     * the catalogue side never change between lookups, so they are normalised once per module instead.
+     */
+    private fun getPropertyIndex(module: Module): ConfigurationPropertyIndex {
+        return CachedValuesManager.getManager(module.project).getCachedValue(module) {
+            CachedValueProvider.Result(
+                ConfigurationPropertyIndex.of(getAllProperties(module)),
+                ModificationTrackerManager.getInstance(module.project).getUastModelAndLibraryTracker()
+            )
+        }
     }
 
     fun findHint(module: Module, propertyName: String): PropertyHint? {
@@ -69,6 +83,19 @@ class SpringConfigurationPropertiesSearch {
     fun getAllHints(module: Module): List<PropertyHint> {
         return ConfigurationPropertiesLoader.EP_NAME.getExtensions(module.project)
             .flatMap { it.loadPropertyHints(module) }
+    }
+
+    /**
+     * Hint lookups by exact name, for callers that would otherwise walk [getAllHints] once per configuration key.
+     * Most keys have no hint, so those walks always ran to the end of the list.
+     */
+    fun getHintIndex(module: Module): PropertyHintIndex {
+        return CachedValuesManager.getManager(module.project).getCachedValue(module) {
+            CachedValueProvider.Result(
+                PropertyHintIndex.of(getAllHints(module)),
+                ModificationTrackerManager.getInstance(module.project).getUastModelAndLibraryTracker()
+            )
+        }
     }
 
     fun getElementNameHints(module: Module): List<ElementHint> {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
@@ -212,7 +212,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         isOnTheFly: Boolean,
         fileProperties: List<DefinedConfigurationProperty>,
     ): MutableList<ProblemDescriptor> {
-        val hints = SpringConfigurationPropertiesSearch.getInstance(module.project).getAllHints(module)
+        val hints = SpringConfigurationPropertiesSearch.getInstance(module.project).getHintIndex(module)
         val problems = mutableListOf<ProblemDescriptor>()
         problems += getProblemValues(manager, isOnTheFly, hints, fileProperties)
         problems += getProblemClassReference(module, manager, isOnTheFly, hints, fileProperties)
@@ -226,17 +226,18 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
     private fun getProblemValues(
         manager: InspectionManager,
         isOnTheFly: Boolean,
-        hints: List<PropertyHint>,
+        hints: PropertyHintIndex,
         fileProperties: List<DefinedConfigurationProperty>,
     ): MutableList<ProblemDescriptor> {
         val problems = mutableListOf<ProblemDescriptor>()
         val findInFileProperties = fileProperties.filter { property ->
-            hints.any { hint ->
-                (property.key == hint.name || property.key.substringBeforeLast(".") + POSTFIX_KEYS == hint.name)
-                        && hint.values.isNotEmpty()
+            val declaresValues: (PropertyHint) -> Boolean = { hint ->
+                hint.values.isNotEmpty()
                         && (hint.providers.isEmpty()
                         || hint.providers.filter { it.name != null }.any { it.name != SpringProperties.ANY })
             }
+            hints.hintsNamed(property.key).any(declaresValues)
+                    || hints.hintsNamed(property.key.substringBeforeLast(".") + POSTFIX_KEYS).any(declaresValues)
         }
         if (findInFileProperties.isEmpty()) {
             return problems
@@ -250,12 +251,10 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
                 continue
             }
 
-            val hintValues = hints.asSequence()
-                .filter { it.name == key || it.name == key.substringBeforeLast(".") + POSTFIX_VALUES }
-                .distinctBy { it.name }
+            val hintValues = hints
+                .firstPerName(key, key.substringBeforeLast(".") + POSTFIX_VALUES)
                 .flatMap { it.values }
                 .mapNotNull { it.value }
-                .toList()
 
             if (value !in hintValues) {
                 problems += manager.createProblemDescriptor(
@@ -278,14 +277,13 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         module: Module,
         manager: InspectionManager,
         isOnTheFly: Boolean,
-        hints: List<PropertyHint>,
+        hints: PropertyHintIndex,
         fileProperties: List<DefinedConfigurationProperty>,
     ): MutableList<ProblemDescriptor> {
         val problems = mutableListOf<ProblemDescriptor>()
         val classReferenceProperties = fileProperties.filter { property ->
-            hints.any { hint ->
-                property.key == hint.name
-                        && hint.providers.filter { it.name != null }.any { it.name == SpringProperties.CLASS_REFERENCE }
+            hints.hintsNamed(property.key).any { hint ->
+                hint.providers.filter { it.name != null }.any { it.name == SpringProperties.CLASS_REFERENCE }
             }
         }
         if (classReferenceProperties.isEmpty()) {
@@ -350,14 +348,13 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         module: Module,
         manager: InspectionManager,
         isOnTheFly: Boolean,
-        hints: List<PropertyHint>,
+        hints: PropertyHintIndex,
         fileProperties: List<DefinedConfigurationProperty>,
     ): MutableList<ProblemDescriptor> {
         val problems = mutableListOf<ProblemDescriptor>()
         val handleAsProperties = fileProperties.filter { property ->
-            hints.any { hint ->
-                property.key == hint.name
-                        && hint.providers.filter { it.name != null }.any { it.name == SpringProperties.HANDLE_AS }
+            hints.hintsNamed(property.key).any { hint ->
+                hint.providers.filter { it.name != null }.any { it.name == SpringProperties.HANDLE_AS }
             }
         }
         if (handleAsProperties.isEmpty()) {
@@ -371,11 +368,7 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
             val key = elementFileProperty.propertyKey() ?: continue
             val value = elementFileProperty.propertyValue() ?: continue
 
-            val providerHints = hints.asSequence()
-                .filter { it.name == key }
-                .distinctBy { it.name }
-                .flatMap { it.providers }
-                .toList()
+            val providerHints = hints.firstPerName(key).flatMap { it.providers }
 
             val configurationProperty = propertiesSearch.findProperty(module, key)
             val propertyType = configurationProperty?.type?.replace('$', '.')
@@ -409,14 +402,13 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         module: Module,
         manager: InspectionManager,
         isOnTheFly: Boolean,
-        hints: List<PropertyHint>,
+        hints: PropertyHintIndex,
         fileProperties: List<DefinedConfigurationProperty>,
     ): MutableList<ProblemDescriptor> {
         val problems = mutableListOf<ProblemDescriptor>()
         val springBeanReferenceProperties = fileProperties.filter { property ->
-            hints.any { hint ->
-                property.key == hint.name
-                        && hint.providers.filter { it.name != null }
+            hints.hintsNamed(property.key).any { hint ->
+                hint.providers.filter { it.name != null }
                     .any { it.name == SpringProperties.SPRING_BEAN_REFERENCE }
             }
         }
@@ -486,14 +478,13 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
     private fun getProblemResource(
         manager: InspectionManager,
         isOnTheFly: Boolean,
-        hints: List<PropertyHint>,
+        hints: PropertyHintIndex,
         fileProperties: List<DefinedConfigurationProperty>,
     ): MutableList<ProblemDescriptor> {
         val problems = mutableListOf<ProblemDescriptor>()
         val resources = fileProperties.filter { property ->
-            hints.any { hint ->
-                property.key == hint.name
-                        && hint.providers.filter { it.name != null }.any { it.name == SpringProperties.HANDLE_AS }
+            hints.hintsNamed(property.key).any { hint ->
+                hint.providers.filter { it.name != null }.any { it.name == SpringProperties.HANDLE_AS }
                         && hint.providers.any { it.parameters?.target == IO_RESOURCE }
             }
         }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/ConfigurationPropertyDataRetriever.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/ConfigurationPropertyDataRetriever.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import java.util.Locale.getDefault
 
 abstract class ConfigurationPropertyDataRetriever {
 
@@ -82,12 +83,12 @@ abstract class ConfigurationPropertyDataRetriever {
         }
     }
 
-    protected fun toPascalFormat(memberName: String?): String {
+    protected fun String?.toPascalFormat(): String {
         return when {
-            memberName == null -> ""
-            memberName.startsWith("set") -> memberName.substring(3)
-            memberName.startsWith("get") -> memberName.substring(3)
-            else -> memberName.capitalize()
+            this == null -> ""
+            this.startsWith("set") -> this.substring(3)
+            this.startsWith("get") -> this.substring(3)
+            else -> this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(getDefault()) else it.toString() }
         }
     }
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/MethodConfigurationPropertyDataRetriever.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/MethodConfigurationPropertyDataRetriever.kt
@@ -27,7 +27,7 @@ class MethodConfigurationPropertyDataRetriever private constructor(
 
     override fun getMemberName(): String? {
         return if (isSetter(psiMethod)) {
-            toPascalFormat(psiMethod.name)
+            psiMethod.name.toPascalFormat()
         } else {
             return null
         }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/ConfigurationPropertyIndexTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/ConfigurationPropertyIndexTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.completion.properties
+
+import com.explyt.spring.core.JavaCoreClasses
+import com.explyt.spring.core.PrimitiveTypes
+import com.explyt.spring.core.util.PropertyUtil
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * [ConfigurationPropertyIndex] replaces a linear scan, so every test here is differential: the index must
+ * answer exactly what `properties.find { isSameProperty(it.name, query, it.type) }` answered.
+ */
+class ConfigurationPropertyIndexTest {
+
+    private companion object {
+        const val STRING = "java.lang.String"
+    }
+
+    private fun property(name: String, type: String? = STRING) =
+        ConfigurationProperty(name, null, type, null, null, null, null)
+
+    /** The implementation the index replaces. */
+    private fun linearFind(properties: List<ConfigurationProperty>, query: String) =
+        properties.find { PropertyUtil.isSameProperty(it.name, query, it.type) }
+
+    private fun assertSameAsLinear(properties: List<ConfigurationProperty>, vararg queries: String) {
+        val index = ConfigurationPropertyIndex.of(properties)
+        for (query in queries) {
+            Assert.assertEquals(
+                "index disagrees with the linear scan for '$query'",
+                linearFind(properties, query),
+                index.findProperty(query)
+            )
+        }
+    }
+
+    @Test
+    fun testExactAndRelaxedMatch() {
+        val properties = listOf(property("spring.datasource.url"), property("my.main-project.first-name"))
+        assertSameAsLinear(
+            properties,
+            "spring.datasource.url",
+            "my.main-project.first-name",
+            "my.mainproject.firstname",
+            "MY.MAIN_PROJECT.FIRST_NAME",
+            "my.main_project.first-name"
+        )
+    }
+
+    @Test
+    fun testUnknownKeyIsNotFound() {
+        val properties = listOf(property("spring.datasource.url"))
+        assertSameAsLinear(properties, "app.custom.key", "spring.datasource", "spring.datasource.url.extra")
+        Assert.assertNull(ConfigurationPropertyIndex.of(properties).findProperty("app.custom.key"))
+    }
+
+    @Test
+    fun testBooleanPropertyMatchesBothSpellings() {
+        val properties = listOf(
+            property("server.compression.enabled", JavaCoreClasses.BOOLEAN),
+            property("server.http2.enabled", PrimitiveTypes.BOOLEAN)
+        )
+        // No published metadata writes `is-`, but the catalogue entry is aliased to it, so a key written
+        // either way has to resolve to the same entry.
+        assertSameAsLinear(
+            properties,
+            "server.compression.enabled",
+            "server.compression.is-enabled",
+            "server.http2.enabled",
+            "server.http2.is-enabled",
+            "SERVER.COMPRESSION.IS_ENABLED"
+        )
+        Assert.assertEquals(
+            properties[0],
+            ConfigurationPropertyIndex.of(properties).findProperty("server.compression.is-enabled")
+        )
+    }
+
+    /**
+     * The other direction, and the one that actually happens in a project: no published library metadata is
+     * named `is-…`, but a project-derived property can be. `FieldConfigurationPropertyDataRetriever` takes the
+     * raw field name, so a Kotlin `val isEnabled: Boolean` reaches the catalogue as `is-enabled`, while Spring
+     * binds the same field as `enabled`. Both spellings must therefore find the entry.
+     */
+    @Test
+    fun testCatalogueEntryNamedWithIsPrefixMatchesThePlainSpelling() {
+        val properties = listOf(property("app.feature.is-enabled", JavaCoreClasses.BOOLEAN))
+        assertSameAsLinear(
+            properties,
+            "app.feature.is-enabled",
+            "app.feature.enabled",
+            "APP.FEATURE.ENABLED",
+            "app.feature.isenabled"
+        )
+        Assert.assertEquals(properties[0], ConfigurationPropertyIndex.of(properties).findProperty("app.feature.enabled"))
+    }
+
+    /**
+     * A camel-cased field name is aliased differently from its kebab-cased form: `isEnabled` does not start with
+     * `is-`, so it is prefixed again and normalises to `isisenabled`. Surprising, but it is what the linear scan
+     * did, and this refactoring is not the place to change it.
+     */
+    @Test
+    fun testCamelCasedIsFieldOnlyMatchesItself() {
+        val properties = listOf(property("app.feature.isEnabled", JavaCoreClasses.BOOLEAN))
+        assertSameAsLinear(properties, "app.feature.isEnabled", "app.feature.is-enabled", "app.feature.enabled")
+        val index = ConfigurationPropertyIndex.of(properties)
+        Assert.assertEquals(properties[0], index.findProperty("app.feature.isEnabled"))
+        Assert.assertNull(index.findProperty("app.feature.enabled"))
+    }
+
+    @Test
+    fun testBooleanAliasDoesNotLeakIntoNonBooleanEntries() {
+        val properties = listOf(property("app.flag.enabled", STRING))
+        assertSameAsLinear(properties, "app.flag.enabled", "app.flag.is-enabled")
+        Assert.assertNull(ConfigurationPropertyIndex.of(properties).findProperty("app.flag.is-enabled"))
+    }
+
+    @Test
+    fun testFirstDeclarationWinsForARepeatedName() {
+        val first = property("spring.datasource.url")
+        val second = property("spring.datasource.url")
+        val properties = listOf(first, second)
+        Assert.assertSame(first, ConfigurationPropertyIndex.of(properties).findProperty("spring.datasource.url"))
+    }
+
+    @Test
+    fun testEarlierEntryWinsWhenBothMapsAnswer() {
+        // `app.thing.is-enabled` (a String) and `app.thing.enabled` (a boolean) both match the query
+        // `app.thing.is-enabled`: the first through the plain map, the second through the aliased one.
+        // The linear scan returned whichever came first in the list, so order must decide, not map order.
+        val stringFirst = listOf(
+            property("app.thing.is-enabled", STRING),
+            property("app.thing.enabled", JavaCoreClasses.BOOLEAN)
+        )
+        assertSameAsLinear(stringFirst, "app.thing.is-enabled")
+        Assert.assertSame(stringFirst[0], ConfigurationPropertyIndex.of(stringFirst).findProperty("app.thing.is-enabled"))
+
+        val booleanFirst = stringFirst.reversed()
+        assertSameAsLinear(booleanFirst, "app.thing.is-enabled")
+        Assert.assertSame(
+            booleanFirst[0],
+            ConfigurationPropertyIndex.of(booleanFirst).findProperty("app.thing.is-enabled")
+        )
+    }
+
+    @Test
+    fun testNameWithoutADotBehavesLikeTheLinearScan() {
+        val properties = listOf(property("enabled", JavaCoreClasses.BOOLEAN), property("debug"))
+        assertSameAsLinear(properties, "enabled", "is-enabled", "debug", "missing")
+    }
+
+    @Test
+    fun testDifferentialOverAGeneratedCatalogue() {
+        val types = listOf(STRING, JavaCoreClasses.BOOLEAN, PrimitiveTypes.BOOLEAN, "java.lang.Integer")
+        val properties = (0 until 400).map { i ->
+            // Every fourth catalogue name is written `is-…`, the way a project-derived boolean field arrives.
+            val last = if (i % 4 == 0) "is-some-property-$i" else "some-property-$i"
+            property("spring.module-${i % 20}.group_${i % 7}.$last", types[i % types.size])
+        }
+        val queries = buildList {
+            properties.forEach {
+                add(it.name)
+                add(it.name.uppercase())
+                add(it.name.replace("-", ""))
+                add(it.name.substringBeforeLast(".") + ".is-" + it.name.substringAfterLast("."))
+            }
+            add("nothing.like.this")
+        }
+        assertSameAsLinear(properties, *queries.toTypedArray())
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/PropertyHintIndexTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/completion/properties/PropertyHintIndexTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.completion.properties
+
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * [PropertyHintIndex] replaces `hints.any { it.name == key && … }` and
+ * `hints.filter { it.name == key }.distinctBy { it.name }`, so every test compares it against those expressions.
+ */
+class PropertyHintIndexTest {
+
+    private fun hint(name: String, vararg values: String) =
+        PropertyHint(name, values.map { ValueHint(it, null) }, emptyList())
+
+    private fun providerHint(name: String, providerName: String, target: String? = null) =
+        PropertyHint(name, emptyList(), listOf(ProviderHint(providerName, target?.let { ProviderParameters(it) })))
+
+    @Test
+    fun testHintsNamedReturnsEveryDeclarationInCatalogueOrder() {
+        val first = hint("logging.level.keys", "root")
+        val second = hint("logging.level.keys", "sql")
+        val other = hint("server.port")
+        val index = PropertyHintIndex.of(listOf(first, other, second))
+
+        Assert.assertEquals(listOf(first, second), index.hintsNamed("logging.level.keys"))
+        Assert.assertEquals(listOf(other), index.hintsNamed("server.port"))
+        Assert.assertEquals(emptyList<PropertyHint>(), index.hintsNamed("nothing.declares.this"))
+    }
+
+    /**
+     * The `any` it replaces looked at *every* hint under the name, not just the first, so a predicate satisfied
+     * only by a later declaration still has to match.
+     */
+    @Test
+    fun testAnyMatchesAPredicateSatisfiedOnlyByALaterDeclaration() {
+        val hints = listOf(
+            providerHint("app.target", "any"),
+            providerHint("app.target", "class-reference")
+        )
+        val index = PropertyHintIndex.of(hints)
+
+        val linear = hints.any { it.name == "app.target" && it.providers.any { p -> p.name == "class-reference" } }
+        val indexed = index.hintsNamed("app.target").any { it.providers.any { p -> p.name == "class-reference" } }
+        Assert.assertTrue(linear)
+        Assert.assertEquals(linear, indexed)
+    }
+
+    @Test
+    fun testFirstPerNameKeepsOnlyTheFirstDeclarationOfEachName() {
+        val firstValues = hint("app.mode", "a")
+        val shadowed = hint("app.mode", "b")
+        val keys = hint("app.mode.values", "c")
+        val hints = listOf(firstValues, shadowed, keys)
+
+        val linear = hints.filter { it.name == "app.mode" || it.name == "app.mode.values" }.distinctBy { it.name }
+        Assert.assertEquals(linear, PropertyHintIndex.of(hints).firstPerName("app.mode", "app.mode.values"))
+    }
+
+    /** The values end up in a user-visible message, so the catalogue order of the names has to survive. */
+    @Test
+    fun testFirstPerNameOrdersByCatalogueNotByArgument() {
+        val early = hint("app.early", "x")
+        val late = hint("app.late", "y")
+        val hints = listOf(early, late)
+        val index = PropertyHintIndex.of(hints)
+
+        Assert.assertEquals(listOf(early, late), index.firstPerName("app.late", "app.early"))
+        Assert.assertEquals(
+            hints.filter { it.name == "app.late" || it.name == "app.early" }.distinctBy { it.name },
+            index.firstPerName("app.late", "app.early")
+        )
+    }
+
+    @Test
+    fun testFirstPerNameCollapsesARepeatedArgumentLikeDistinctBy() {
+        val only = hint("app.mode", "a")
+        val hints = listOf(only)
+        Assert.assertEquals(listOf(only), PropertyHintIndex.of(hints).firstPerName("app.mode", "app.mode"))
+    }
+
+    @Test
+    fun testUnknownNamesYieldNothing() {
+        val index = PropertyHintIndex.of(listOf(hint("app.mode", "a")))
+        Assert.assertEquals(emptyList<PropertyHint>(), index.firstPerName("absent.one", "absent.two"))
+    }
+
+    @Test
+    fun testDifferentialOverAGeneratedCatalogue() {
+        val hints = (0 until 300).map { i ->
+            if (i % 3 == 0) hint("app.group-${i % 25}.key-$i", "v$i") else providerHint("app.group-${i % 25}.key-$i", "any")
+        } + (0 until 40).map { i -> hint("app.group-${i % 25}.key-$i", "shadow$i") }
+        val index = PropertyHintIndex.of(hints)
+
+        for (name in hints.map { it.name }.distinct() + listOf("absent.key")) {
+            Assert.assertEquals(
+                "hintsNamed disagrees for '$name'",
+                hints.filter { it.name == name },
+                index.hintsNamed(name)
+            )
+            val valuesName = name.substringBeforeLast(".") + ".values"
+            Assert.assertEquals(
+                "firstPerName disagrees for '$name'",
+                hints.filter { it.name == name || it.name == valuesName }.distinctBy { it.name },
+                index.firstPerName(name, valuesName)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Validating a `.properties`/`.yaml` file walked both metadata catalogues once per key in the file, per check. Two lookup indexes replace the scans. **No behaviour change** — both indexes are covered by differential tests against the expressions they replace.

### Property catalogue

`SpringConfigurationPropertiesSearch.findProperty` was a linear `find`, and `PropertyUtil.isSameProperty` lowercases and strips separators on **both** sides for every candidate. The catalogue side never changes between lookups, so it is now normalised once per module behind a `CachedValue`.

`ConfigurationPropertyIndex` needs **two** maps rather than one. `isSameProperty` applies `toBooleanAlias` using the *catalogue entry’s own type*, and the type is only known once an entry is in hand, so a single map keyed by the normal form cannot express it:

- non-boolean entries under `toCommonPropertyForm(name)`;
- boolean entries under `toCommonPropertyForm(toBooleanAlias(name, type))`, with the query aliased the same way.

Two subtleties the tests pin, because getting either wrong changes behaviour silently:

- the original `find` returned the **first** match in list order, so the original position is stored and the earlier entry wins when both maps answer;
- the catalogue repeats names across loaders, so `putIfAbsent` keeps the first, as `find` did.

### Hint catalogue

The inspection asked `hints.any { it.name == property.key && … }` in five places. Most keys have no hint at all, so each of those ran to the end of the list. `PropertyHintIndex` answers by exact name and preserves catalogue order, which matters because the values are rendered into the “unresolved value” message. The `substringBeforeLast(".")` concat that ran once per (property, hint) pair now runs once per property — on a 100-key file that is 67 500 allocations per pass down to 500.

### Numbers

Modelled on a 5085-entry property catalogue (spring-boot-autoconfigure alone declares 1695) and a 100-key file:

| | before | after |
|---|---|---|
| property lookups | 29 ms | < 1 ms |
| hint lookups | 0.45 ms | 0.03 ms |

The hint half is deliberately reported as small: the hint catalogue is only ~135 entries across every jar in a typical cache, so that change is mostly about the five scans becoming lookups, not about the time saved.

These are measurements of the algorithm on synthetic data, not an IDE profile. What they do establish is which of the two scans was worth removing.

## Related issue

No issue. Follow-up work is filed separately as #334 (report a boolean key written in the spelling of the wrong binding mode) and #335 (establish with a fixture which shapes actually need `toBooleanAlias`).

The second commit, `refactor: Turn toPascalFormat into an extension and drop the deprecated capitalize`, is an independent cleanup that was already in the working tree; it is kept as its own commit and changes no behaviour.

## Type of change

- [ ] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [x] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test
```

**1406 tests across 214 classes, 0 failures, 0 errors, 0 skipped.**

New tests: `ConfigurationPropertyIndexTest` (10) and `PropertyHintIndexTest` (7). Both are differential — every assertion compares the index against the linear expression it replaces, so they fail if the refactoring changes an answer.

Both were mutation-checked rather than trusted because they went green on the first run:

| mutation | result |
|---|---|
| drop the "earlier entry wins" rule | 1 test fails |
| build the index key without the boolean alias | 4 tests fail |
| do not alias the query before the boolean-map lookup | 5 tests fail |
| drop the catalogue ordering in `firstPerName` | 1 test fails |

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change.
- [x] I updated relevant documentation (CHANGELOG entries added).