### PR TITLE
fix: Keep an invalidated component annotation out of the annotated-elements search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - fix: Ignore a cached bean whose PSI is no longer valid instead of failing inspections, gutters and bean search (#295)
 - fix: Reflect an edited source file in reference search results instead of returning a stale cached set
 - fix: Read the main class of a Kotlin run configuration without resolving PSI on the event dispatch thread (#185)
+- fix: Skip a cached component annotation that an edit invalidated instead of passing it to the annotated-elements search, which failed the whole bean search on it — with an `IllegalArgumentException` from the Java search executor and a message-less `AssertionError` from the Groovy one
+- fix: Recompute the bean search instead of failing it when a search executor dereferences an element invalidated while the query ran
 
 ### Spring Web
 - feat: List Actuator endpoints in the Endpoints tool window, one row per `@ReadOperation`/`@WriteOperation`/`@DeleteOperation` with its `@Selector` path variables, and navigate to the declaring class and the operation method; the path follows `management.endpoints.web.base-path`, `management.endpoints.web.path-mapping.<id>` and `management.server.port` (#315)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/service/SpringSearchService.kt
@@ -417,11 +417,26 @@ class SpringSearchService(private val project: Project) {
             .toSet()
     }
 
+    /**
+     * Whether [psiClass] satisfies the preconditions every `AnnotatedElementsSearch` executor asserts, so that
+     * passing it to the search cannot fail the pass.
+     *
+     * The executors state the contract but each signals a violation differently, and none of them return
+     * quietly: the Java one throws `IllegalArgumentException("Annotation type should be passed …")` and
+     * `IllegalArgumentException("FQN is null for …")`, while the Groovy one uses bare `assert` and produces a
+     * message-less `AssertionError`. The annotation set arrives from a cached
+     * `getComponentClassAnnotations`, so an entry invalidated by an edit reaches the search with a null
+     * qualified name and takes down the whole bean search with it.
+     */
+    internal fun isSearchableAnnotationType(psiClass: PsiClass): Boolean =
+        psiClass.isValid && psiClass.isAnnotationType && psiClass.qualifiedName != null
+
     private fun searchBeanPsiClassesByAnnotations(
         module: Module, annotationPsiClasses: Collection<PsiClass>, scope: SearchScope
     ): Set<PsiBean> {
         try {
             return annotationPsiClasses.asSequence()
+                .filter { isSearchableAnnotationType(it) }
                 .flatMap { AnnotatedElementsSearch.searchPsiClasses(it, scope) }
                 .filter { it.isValid }
                 .filter { SpringCoreUtil.isSpringBeanCandidateClass(it) }
@@ -433,6 +448,11 @@ class SpringSearchService(private val project: Project) {
             // Abort this pass via cancellation so the cached value is recomputed once PSI is
             // consistent again, instead of caching a partial result or logging a crash (issue #232).
             if (e.userMessage != FILE_TEXT_MISMATCH_MESSAGE) throw e
+            throw ProcessCanceledException(e)
+        } catch (e: PsiInvalidElementAccessException) {
+            // A search executor can dereference an element that was invalidated while the query ran —
+            // `ExternalAnnotatedElementsSearcher` asks a candidate for its containing file. Abort the pass so
+            // the cached value is recomputed against consistent PSI instead of failing every caller.
             throw ProcessCanceledException(e)
         }
     }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/service/SearchableAnnotationTypeTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/service/SearchableAnnotationTypeTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.service
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+
+/**
+ * `AnnotatedElementsSearch` executors assert their preconditions instead of returning empty, and each signals a
+ * violation differently — the Java executor throws `IllegalArgumentException("FQN is null for …")`, the Groovy
+ * one a message-less `AssertionError`. Both reached users through the cached component-annotation set, so the
+ * filter that keeps them out is pinned here.
+ */
+class SearchableAnnotationTypeTest : ExplytJavaLightTestCase() {
+
+    private fun service() = SpringSearchService.getInstance(project)
+
+    private fun classesOf(file: PsiFile): List<PsiClass> =
+        PsiTreeUtil.findChildrenOfType(file, PsiClass::class.java).toList()
+
+    fun testAnnotationTypeWithAQualifiedNameIsSearchable() {
+        val file = myFixture.addFileToProject("Marker.java", "package com.demo; public @interface Marker {}")
+        val marker = classesOf(file).single()
+
+        assertTrue("a resolvable annotation type must reach the search", service().isSearchableAnnotationType(marker))
+    }
+
+    fun testPlainClassIsNotSearchable() {
+        val file = myFixture.addFileToProject("NotAnAnnotation.java", "package com.demo; public class NotAnAnnotation {}")
+        val psiClass = classesOf(file).single()
+
+        // The Java executor throws "Annotation type should be passed to annotated members search" for this one.
+        assertFalse(service().isSearchableAnnotationType(psiClass))
+    }
+
+    fun testAnnotationWithoutAQualifiedNameIsNotSearchable() {
+        // A local class has no qualified name, which is exactly the shape the executors reject.
+        val file = myFixture.addFileToProject(
+            "WithLocal.java",
+            "package com.demo; public class WithLocal { void m() { @interface Local {} } }"
+        )
+        val local = classesOf(file).first { it.name == "Local" }
+
+        assertNull("the fixture must produce a class with no qualified name", local.qualifiedName)
+        assertTrue("the fixture must still be an annotation type", local.isAnnotationType)
+        assertFalse(service().isSearchableAnnotationType(local))
+    }
+
+    fun testInvalidatedAnnotationIsNotSearchable() {
+        val file = myFixture.addFileToProject("Stale.java", "package com.demo; public @interface Stale {}")
+        val stale = classesOf(file).single()
+        assertTrue("precondition: the annotation starts out searchable", service().isSearchableAnnotationType(stale))
+
+        WriteCommandAction.runWriteCommandAction(project) { file.virtualFile.delete(this) }
+
+        assertFalse("the deleted annotation must be invalidated", stale.isValid)
+        assertFalse(service().isSearchableAnnotationType(stale))
+    }
+}


### PR DESCRIPTION
## Summary

Found by triaging Sentry for `plugin.version.major:34`. `SpringSearchService.searchBeanPsiClassesByAnnotations` is the second-largest crash culprit on that line — 9 events across 5 issues. Reading the stacks rather than the titles splits them into three unrelated causes; this PR fixes the two that are ours.

### Passing an annotation with no qualified name to the search (2 events)

The `AnnotatedElementsSearch` executors assert their preconditions instead of returning empty, and each signals a violation differently:

```java
// AnnotatedElementsSearcher (Java, platform)
if (!annClass.isAnnotationType()) throw new IllegalArgumentException("Annotation type should be passed …");
if (annotationFQN == null)        throw new IllegalArgumentException("FQN is null for " + annClass);

// AnnotatedMembersSearcher (Groovy plugin)
assert annClass.isAnnotationType() : "Annotation type should be passed to annotated members search";
assert annotationFQN != null;
```

We fed them the set from `getComponentClassAnnotations` unchecked. That set is **cached**, so a class invalidated by an edit reaches the search and answers `null` to `getQualifiedName()` — and the executor fails the entire bean search on it. In Sentry that surfaced as two unrelated-looking issues with one cause:

| Issue | Type | Value |
|---|---|---|
| SPRING-PLUGIN-C7 | `IllegalArgumentException` | `FQN is null for PsiClass:AopBindOperKey` |
| SPRING-PLUGIN-C8 | `AssertionError` | *(empty — the Groovy `assert` carries no message)* |

Same family as the invalid cached PSI already fixed for the beans themselves.

`AssertionError` is deliberately **not** caught. The filter removes its cause, and catching it would mask genuine platform assertions.

### An element invalidated while the query ran (1 event)

SPRING-PLUGIN-C9: `PsiInvalidElementAccessException` thrown from inside `ExternalAnnotatedElementsSearcher.execute`, which asks a candidate for its containing file. The existing `.filter { it.isValid }` cannot help — the throw happens inside the search, before any element reaches the filter. Converted to `ProcessCanceledException` so the cached value is recomputed, the same treatment `RuntimeExceptionWithAttachments` already gets two lines above.

### Not fixed here, and not fixable (6 events)

SPRING-PLUGIN-77 and -5V, `unable to get stub builder for file`, are **logged, not thrown** — the innermost frame is `Logger.error` reached through `StubProcessingHelperBase.handleNonPsiStubs`, after which the platform calls `onInternalError` and continues. Nothing propagates into plugin code, so a `catch` there would be dead code that merely looks like a fix. Same mechanism as #188 and #195, both closed as platform defects. All six events come from one machine and one file.

## Related issue

No issue — found directly in Sentry triage.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --tests "*SearchableAnnotationTypeTest*" --tests "*SpringSearchServiceTest*" --tests "*NativeSearchServiceTest*" --tests "*SpringBeanIncorrectAutowiring*" --tests "*BeanLineMarker*" --tests "*SpringBean*"
```

**398 tests across 39 classes, 0 failures, 0 errors.**

New `SearchableAnnotationTypeTest` pins the filter against real PSI shapes rather than mocks: a resolvable annotation passes; a plain class is rejected; a **local** annotation is rejected, since a local class genuinely has no qualified name — the exact shape the executors reject; and an annotation whose file was deleted is rejected once invalidated.

Mutation-checked rather than trusted: dropping `qualifiedName != null` from the predicate fails `testAnnotationWithoutAQualifiedNameIsNotSearchable`.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change.
- [x] I updated relevant documentation (CHANGELOG entries added).

> Note for whoever merges: this and #336 both append to the `[Unreleased]` CHANGELOG section, so expect a trivial conflict there if they land out of order. No source file overlaps.