### PR TITLE
Open the Explyt Spring tool window after linking, and make generated build wrappers executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 - fix: Ignore a cached bean whose PSI is no longer valid instead of failing inspections, gutters and bean search (#295)
 - fix: Reflect an edited source file in reference search results instead of returning a stale cached set
 - fix: Read the main class of a Kotlin run configuration without resolving PSI on the event dispatch thread (#185)
+- feat: Open the Explyt Spring tool window after linking a Spring Boot project from a run configuration, including when the project was already linked and the click only refreshes it (#197)
+
+### Spring Initializr
+- fix: Make `gradlew` and `mvnw` executable in a project generated through Spring Initializr, so the first `./gradlew` in a terminal no longer fails with "permission denied" (#60)
 
 ### Spring Web
 - feat: List Actuator endpoints in the Endpoints tool window, one row per `@ReadOperation`/`@WriteOperation`/`@DeleteOperation` with its `@Selector` path variables, and navigate to the declaring class and the operation method; the path follows `management.endpoints.web.base-path`, `management.endpoints.web.path-mapping.<id>` and `management.server.port` (#315)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootProjectAction.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootProjectAction.kt
@@ -29,6 +29,7 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
+import com.intellij.openapi.wm.ToolWindowManager
 
 class AttachSpringBootProjectAction : DumbAwareAction() {
     init {
@@ -53,6 +54,13 @@ class AttachSpringBootProjectAction : DumbAwareAction() {
     }
 
     companion object {
+
+        /**
+         * Must equal the `id` of the `toolWindow` registered in `spring-core-plugin.xml`: the platform looks a tool
+         * window up by that exact string and returns `null` for anything else, so a rename on either side would
+         * disable the activation silently. `AttachSpringBootProjectActionToolWindowIdTest` pins the two together.
+         */
+        internal const val TOOL_WINDOW_ID = "Explyt Spring"
         fun attachProject(project: Project) {
             val selectedRunConfiguration = ApplicationManager.getApplication().runReadAction(
                 Computable { RunManager.getInstance(project).selectedConfiguration?.configuration }
@@ -86,11 +94,29 @@ class AttachSpringBootProjectAction : DumbAwareAction() {
                 ExternalProjectsManagerImpl.getInstance(project).runWhenInitialized {
                     ExternalSystemUtil.refreshProject(canonicalPath, ImportSpecBuilder(project, SYSTEM_ID))
                 }
+                // The action reports success only through the tool window, so an already-linked project has to open it
+                // too — otherwise clicking the button looks like nothing happened at all (issue #197).
+                activateToolWindow(project)
                 return
             }
 
             SpringBootOpenProjectProvider().linkToExistingProject(
                 mainFile, selectedRunConfiguration, mainClass.qualifiedName, project
+            )
+            activateToolWindow(project)
+        }
+
+        /**
+         * Brings the Explyt Spring tool window to the front. Not called from the early-return paths above: those
+         * already explain themselves with a balloon, and opening an empty tool window on top of it would only add
+         * noise.
+         */
+        private fun activateToolWindow(project: Project) {
+            ApplicationManager.getApplication().invokeLater(
+                {
+                    ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID)?.activate(null)
+                },
+                project.disposed
             )
         }
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootProjectActionToolWindowIdTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/externalsystem/action/AttachSpringBootProjectActionToolWindowIdTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.externalsystem.action
+
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * `ToolWindowManager.getToolWindow` matches the registered `id` exactly and returns `null` for anything else, so a
+ * mismatch between the constant the attach action activates and the `id` declared in `spring-core-plugin.xml` would
+ * turn the activation into a silent no-op — the exact symptom issue #197 reported in the first place.
+ *
+ * Activation itself cannot be asserted in a headless test: `ToolWindowHeadlessManagerImpl.MockToolWindow` hardcodes
+ * `isActive()` and `isVisible()` to `false` and its `activate` only runs the callback. The identifier is the part
+ * that can silently drift, so it is the part pinned here.
+ */
+class AttachSpringBootProjectActionToolWindowIdTest {
+
+    @Test
+    fun testActivatedIdMatchesTheRegisteredToolWindow() {
+        val descriptor = javaClass.getResource("/META-INF/spring-core-plugin.xml")
+            ?: Assert.fail("spring-core-plugin.xml is not on the test classpath").let { error("unreachable") }
+        val declaredIds = TOOL_WINDOW_ID_REGEX.findAll(descriptor.readText())
+            .map { it.groupValues[1] }
+            .toList()
+
+        Assert.assertTrue(
+            "spring-core-plugin.xml declares no toolWindow; the descriptor or this test is out of date",
+            declaredIds.isNotEmpty()
+        )
+        Assert.assertTrue(
+            "the attach action activates '${AttachSpringBootProjectAction.TOOL_WINDOW_ID}', " +
+                    "which no toolWindow in spring-core-plugin.xml declares: $declaredIds",
+            AttachSpringBootProjectAction.TOOL_WINDOW_ID in declaredIds
+        )
+    }
+
+    private companion object {
+        val TOOL_WINDOW_ID_REGEX = Regex("""<toolWindow\s+id="([^"]+)"""")
+    }
+}

--- a/modules/spring-initializr/spring-initializr.gradle.kts
+++ b/modules/spring-initializr/spring-initializr.gradle.kts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
 plugins {
     java
     id("org.jetbrains.intellij.platform.module")
@@ -45,7 +47,12 @@ dependencies {
             useInstaller = false
         }
         bundledPlugins(springCoreProject.ext["intellijPlugins"] as List<String> + intellijPlugins)
+        // Without a test framework the `test` task cannot resolve the IDE distribution it runs against and fails
+        // with "Cannot resolve 'product-info.json'", which is why this module had no tests at all.
+        testFramework(TestFrameworkType.Platform)
     }
+    testImplementation("junit:junit:4.13.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 kotlin {

--- a/modules/spring-initializr/src/main/kotlin/com/explyt/spring/initializr/ExplytSpringInitializrModuleBuilder.kt
+++ b/modules/spring-initializr/src/main/kotlin/com/explyt/spring/initializr/ExplytSpringInitializrModuleBuilder.kt
@@ -125,6 +125,7 @@ class ExplytSpringInitializrModuleBuilder : ModuleBuilder() {
         val zipDirectory = extractDirectory.resolve(FileUtil.getNameWithoutExtension(zip))
         val file = File(zipDirectory.toString())
         if (file.isDirectory) {
+            ProjectWrapperScripts.makeRunnable(zipDirectory)
             return file.canonicalPath
         }
 

--- a/modules/spring-initializr/src/main/kotlin/com/explyt/spring/initializr/ProjectWrapperScripts.kt
+++ b/modules/spring-initializr/src/main/kotlin/com/explyt/spring/initializr/ProjectWrapperScripts.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.initializr
+
+import com.intellij.execution.wsl.WslPath
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.SystemInfo
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+
+/**
+ * start.spring.io serves the build wrappers inside a zip, and the zip entry permissions do not survive
+ * [com.intellij.util.io.ZipUtil.extract]. The generated project therefore arrives with a non-executable `gradlew`,
+ * and the first `./gradlew` in a terminal fails with "permission denied" until the user chmods it by hand.
+ */
+internal object ProjectWrapperScripts {
+
+    /** Only the POSIX shell wrappers: `gradlew.bat` and `mvnw.cmd` are launched by cmd.exe and need no bit. */
+    private val EXECUTABLE_NAMES = listOf("gradlew", "mvnw")
+
+    private val logger = Logger.getInstance(ProjectWrapperScripts::class.java)
+
+    fun makeRunnable(projectDirectory: Path) {
+        // setPosixFilePermissions throws on a non-POSIX file system, so skip Windows unless the target is a WSL path.
+        if (SystemInfo.isWindows && !WslPath.isWslUncPath(projectDirectory.absolutePathString())) return
+
+        val permissions = PosixFilePermissions.fromString("rwxr-xr-x")
+        for (name in EXECUTABLE_NAMES) {
+            val script = projectDirectory.resolve(name).takeIf { it.exists() } ?: continue
+            try {
+                Files.setPosixFilePermissions(script, permissions)
+            } catch (e: IOException) {
+                // A generated project is still usable without the bit, so report and carry on rather than failing
+                // project creation over a chmod.
+                logger.warn("Cannot make '$name' executable in $projectDirectory", e)
+            } catch (e: UnsupportedOperationException) {
+                logger.warn("File system of $projectDirectory does not support POSIX permissions", e)
+            }
+        }
+    }
+}

--- a/modules/spring-initializr/src/test/kotlin/com/explyt/spring/initializr/ProjectWrapperScriptsTest.kt
+++ b/modules/spring-initializr/src/test/kotlin/com/explyt/spring/initializr/ProjectWrapperScriptsTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.initializr
+
+import com.intellij.openapi.util.SystemInfo
+import org.junit.Assert
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectory
+import kotlin.io.path.isExecutable
+import kotlin.io.path.writeText
+
+class ProjectWrapperScriptsTest {
+
+    private lateinit var projectDirectory: Path
+
+    @Before
+    fun setUp() {
+        // Every assertion is about a POSIX permission bit, which a Windows file system does not carry.
+        Assume.assumeFalse(SystemInfo.isWindows)
+        projectDirectory = Files.createTempDirectory("initializr-project")
+    }
+
+    private fun file(name: String): Path =
+        projectDirectory.resolve(name).also { it.writeText("#!/bin/sh\n") }
+
+    @Test
+    fun testGradleWrapperBecomesExecutable() {
+        val gradlew = file("gradlew")
+        Assert.assertFalse("precondition: an extracted wrapper is not executable", gradlew.isExecutable())
+
+        ProjectWrapperScripts.makeRunnable(projectDirectory)
+
+        Assert.assertTrue("gradlew must be runnable from a terminal", gradlew.isExecutable())
+    }
+
+    @Test
+    fun testMavenWrapperBecomesExecutable() {
+        val mvnw = file("mvnw")
+
+        ProjectWrapperScripts.makeRunnable(projectDirectory)
+
+        Assert.assertTrue("mvnw must be runnable from a terminal", mvnw.isExecutable())
+    }
+
+    @Test
+    fun testWindowsWrappersAndUnrelatedFilesAreLeftAlone() {
+        val batch = file("gradlew.bat")
+        val cmd = file("mvnw.cmd")
+        val settings = file("settings.gradle.kts")
+
+        ProjectWrapperScripts.makeRunnable(projectDirectory)
+
+        Assert.assertFalse("gradlew.bat is launched by cmd.exe and needs no bit", batch.isExecutable())
+        Assert.assertFalse("mvnw.cmd is launched by cmd.exe and needs no bit", cmd.isExecutable())
+        Assert.assertFalse("an unrelated project file must not be touched", settings.isExecutable())
+    }
+
+    @Test
+    fun testMissingWrapperIsNotAnError() {
+        // A Maven project has no gradlew and vice versa, so the absent one must simply be skipped.
+        val mvnw = file("mvnw")
+
+        ProjectWrapperScripts.makeRunnable(projectDirectory)
+
+        Assert.assertTrue(mvnw.isExecutable())
+    }
+
+    @Test
+    fun testDirectoryNamedLikeAWrapperIsNotFollowed() {
+        // Guards against a zip that contains a `gradlew/` entry: chmodding it would be harmless but the call must
+        // not fail project creation either way.
+        projectDirectory.resolve("gradlew").createDirectory()
+
+        ProjectWrapperScripts.makeRunnable(projectDirectory)
+    }
+}


### PR DESCRIPTION
## Summary

Two small, unrelated fixes; one commit each.

### #197 — the tool window stays closed after linking

`AttachSpringBootProjectAction` reports success only by populating the tool window, so clicking the button while that window was closed looked like nothing happened at all. It now activates on **both** success paths, including the already-linked one the issue calls out explicitly — a refresh produces no visible change either.

The early returns keep their balloon and deliberately do not activate: opening an empty tool window on top of an error message would only add noise. Activation is posted to the EDT with `project.disposed` as the expiry condition, because `attachProject` runs from a background thread.

### #60 — `gradlew` arrives non-executable

Zip entry permissions do not survive `ZipUtil.extract`, so a project generated through Spring Initializr had a non-executable `gradlew` and the first `./gradlew` in a terminal failed with `permission denied`.

Only the POSIX wrappers get the bit — `gradlew.bat` and `mvnw.cmd` are launched by `cmd.exe` and need none. Windows is skipped unless the target is a WSL path, since `setPosixFilePermissions` throws on a non-POSIX file system, and a failure is logged rather than propagated: a generated project is still usable without the bit.

This also gives `spring-initializr` its **first test**. The module declared no test framework, so its `test` task could not resolve the IDE distribution it runs against — which is why it had no test source root at all. The build file now declares the platform test framework and JUnit.

## Related issue

Closes #197
Closes #60

## Type of change

- [x] Bug fix
- [x] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --rerun-tasks --tests "*AttachSpringBoot*"
./gradlew :spring-initializr:test --tests "*ProjectWrapperScriptsTest*"
```

- spring-core: **6 tests, 0 failures** (`AttachSpringBootProjectActionToolWindowIdTest`, `AttachSpringBootToolbarProjectActionTest`)
- spring-initializr: **5 tests, 0 failures** — counts read from the JUnit XML, not from `BUILD SUCCESSFUL`

`ProjectWrapperScriptsTest` asserts the bit lands on `gradlew` and `mvnw`, that `gradlew.bat`, `mvnw.cmd` and unrelated project files are untouched, that a missing wrapper is not an error (a Maven project has no `gradlew`), and that a directory named like a wrapper does not break creation. It is skipped on Windows, where the assertions have no meaning.

For #197 only the tool window **identifier** is covered. `getToolWindow` matches the registered id exactly and returns `null` otherwise, so a rename on either side would disable the activation silently — precisely the symptom being fixed — and the test parses `spring-core-plugin.xml` to pin the two together. Activation itself is not assertable in a headless test: `ToolWindowHeadlessManagerImpl.MockToolWindow` hardcodes `isActive()` and `isVisible()` to `false`. Mutation-checked: pointing the constant at a non-existent id fails the test.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change.
- [x] I updated relevant documentation (CHANGELOG entries added).

> Note for whoever merges: like #336 and #337, this appends to the `[Unreleased]` CHANGELOG section — expect a trivial conflict there if they land out of order. No source file overlaps.