### PR TITLE
fix: Resolve a key with no exact declaration to its longest declared prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - fix: Apply that same filter on the source bean-search path, not only the native one, so a bean invalidated by an edit no longer breaks the autowiring inspection and bean navigation in a project without an external Spring model (#205)
 - fix: Reflect an edited source file in reference search results instead of returning a stale cached set
 - fix: Read the main class of a Kotlin run configuration without resolving PSI on the event dispatch thread (#185)
+- fix: Resolve a configuration key with no exact declaration to the longest declared prefix that owns it, instead of whichever prefix the metadata catalogue happened to list first
 - fix: Skip a cached component annotation that an edit invalidated instead of passing it to the annotated-elements search, which failed the whole bean search on it — with an `IllegalArgumentException` from the Java search executor and a message-less `AssertionError` from the Groovy one
 - fix: Recompute the bean search instead of failing it when a search executor dereferences an element invalidated while the query ran
 - feat: Open the Explyt Spring tool window after linking a Spring Boot project from a run configuration, including when the project was already linked and the click only refreshes it (#197)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -47,6 +47,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.childrenOfType
 import com.intellij.psi.util.parentOfType
 import com.intellij.util.text.PlaceholderTextRanges
+import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.uast.*
 import org.jetbrains.yaml.YAMLUtil
 import org.jetbrains.yaml.psi.YAMLKeyValue
@@ -779,11 +780,28 @@ object PropertyUtil {
         val findProperty = SpringConfigurationPropertiesSearch.getInstance(module.project)
             .findProperty(module, propertyKey)
         if (findProperty == null) {
-            return SpringConfigurationPropertiesSearch.getInstance(module.project).getAllProperties(module)
-                .find { propertyKey.startsWith(it.name) }
+            return longestPrefixProperty(
+                SpringConfigurationPropertiesSearch.getInstance(module.project).getAllProperties(module),
+                propertyKey
+            )
         }
         return findProperty
     }
+
+    /**
+     * The declared property that owns [propertyKey] when no exact declaration exists — a map or collection entry
+     * such as `logging.level.sql`, whose arbitrary suffix is absent from the metadata.
+     *
+     * Several declarations can be prefixes of the same key, and only the longest is the owner: a shorter one is an
+     * unrelated ancestor that happens to share a namespace. [findValueOwner] already selects that way; this one used
+     * `find`, which returns whichever candidate the catalogue happened to list first.
+     */
+    @VisibleForTesting
+    fun longestPrefixProperty(
+        properties: List<ConfigurationProperty>, propertyKey: String
+    ): ConfigurationProperty? = properties.asSequence()
+        .filter { propertyKey.startsWith(it.name) }
+        .maxByOrNull { it.name.length }
 
     fun resolveResults(sourceMember: PsiMember): Array<ResolveResult> {
         val uElement = sourceMember.toUElement() ?: return emptyArray()

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/LongestPrefixPropertyTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/LongestPrefixPropertyTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.util
+
+import com.explyt.spring.core.completion.properties.ConfigurationProperty
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * The fallback that resolves a key with no exact declaration to the property that owns it. Several declarations can
+ * be prefixes of one key; only the longest is the owner, and the previous `find` returned whichever the catalogue
+ * listed first — an order that depends on which loader contributed the entry.
+ */
+class LongestPrefixPropertyTest {
+
+    private fun property(name: String) = ConfigurationProperty(name, null, null, null, null, null, null)
+
+    @Test
+    fun testLongestPrefixWinsOverAShorterAncestor() {
+        val ancestor = property("logging")
+        val owner = property("logging.level")
+        Assert.assertEquals(
+            owner,
+            PropertyUtil.longestPrefixProperty(listOf(ancestor, owner), "logging.level.sql")
+        )
+    }
+
+    /** The defect: with `find`, catalogue order decided the answer, so the reversed list gave the other result. */
+    @Test
+    fun testResultDoesNotDependOnCatalogueOrder() {
+        val ancestor = property("logging")
+        val owner = property("logging.level")
+        val key = "logging.level.sql"
+
+        Assert.assertEquals(
+            PropertyUtil.longestPrefixProperty(listOf(ancestor, owner), key),
+            PropertyUtil.longestPrefixProperty(listOf(owner, ancestor), key)
+        )
+        Assert.assertEquals(owner, PropertyUtil.longestPrefixProperty(listOf(owner, ancestor), key))
+    }
+
+    @Test
+    fun testExactDeclarationIsItsOwnOwner() {
+        val exact = property("spring.datasource.url")
+        Assert.assertEquals(
+            exact,
+            PropertyUtil.longestPrefixProperty(listOf(property("spring"), exact), "spring.datasource.url")
+        )
+    }
+
+    @Test
+    fun testUnrelatedKeyHasNoOwner() {
+        val properties = listOf(property("logging.level"), property("spring.datasource"))
+        Assert.assertNull(PropertyUtil.longestPrefixProperty(properties, "app.custom.key"))
+    }
+
+    @Test
+    fun testEmptyCatalogueHasNoOwner() {
+        Assert.assertNull(PropertyUtil.longestPrefixProperty(emptyList(), "logging.level.sql"))
+    }
+
+    @Test
+    fun testDeepestOfThreeNestedPrefixesWins() {
+        val properties = listOf(
+            property("management"),
+            property("management.endpoint"),
+            property("management.endpoint.health")
+        )
+        Assert.assertEquals(
+            properties[2],
+            PropertyUtil.longestPrefixProperty(properties, "management.endpoint.health.show-details")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`PropertyUtil.configurationProperty` falls back to a prefix match when the metadata declares no exact key — the map and collection case, where the suffix is arbitrary, as in `logging.level.sql`. The fallback was:

```kotlin
getAllProperties(module).find { propertyKey.startsWith(it.name) }
```

`find` returns whichever candidate the catalogue listed first, and catalogue order is just the order the loaders contributed entries in. With both `logging` and `logging.level` declared, `logging.level.sql` could resolve to `logging` — an unrelated ancestor — and the answer would flip if a loader changed order.

`PropertyUtil.findValueOwner`, two hundred lines above, already selects the longest prefix and carries the comment explaining why: *"The longest declared prefix is the closest declaration; a shorter one may be an unrelated ancestor."* This applies the same rule to the other fallback.

The selection is extracted as `longestPrefixProperty` so it can be tested without a module fixture.

## Related issue

No issue — recorded in the engineering ledger as the last remaining OPEN entry, now removed from it.

Worth knowing for whoever picks this area up next: both prefix matchers accept a match that does **not** end at a segment boundary, so a declared `foo.bar` is treated as the owner of `foo.barbaz`. Selecting the longest prefix masks that whenever a genuine ancestor is also declared, but not when the bogus prefix is the only candidate. It is deliberately out of scope here: the boundary is not simply `.` — an indexed key such as `ingest.s3-logs.sources[0].enabled` is owned by `ingest.s3-logs.sources`, where the next character is `[`, so a naive `startsWith("${name}.")` would drop collection ownership entirely. It needs its own test matrix and is left recorded in the ledger.

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

```
./gradlew :spring-core:test --rerun-tasks --tests "*LongestPrefixPropertyTest*" --tests "*PropertyUtil*" --tests "*ConfigurationPropert*" --tests "*PropertyKeyReference*" --tests "*SpringPropertiesInspection*" --tests "*SpringYamlInspection*"
```

**195 tests across 31 classes, 0 failures, 0 errors** — counts read from the JUnit XML rather than from `BUILD SUCCESSFUL`.

`LongestPrefixPropertyTest` covers the longest prefix winning over a shorter ancestor, three nested prefixes, the exact declaration, an unrelated key, an empty catalogue, and — the one that pins the actual defect — that the answer no longer depends on the order of the catalogue list.

Mutation-checked: reverting the selection to `firstOrNull()` fails 4 of the 6 tests. The run was forced with `--rerun-tasks`, because Gradle otherwise reports `UP-TO-DATE` against a file rewritten in place and the mutation silently proves nothing.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change.
- [x] I updated relevant documentation (CHANGELOG entry added).