### PR TITLE
docs: Record the 253 unified-distribution boundary and drop dead edition config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded (#307)
 - fix: Keep Sentry action breadcrumbs useful by dropping editor typing and caret movement, recording a repeated action once, and trimming a captured report to the actions that led to it
 - fix: Bring error reporting back up when the pooled executor rejects the initialization task, instead of leaving it disabled for the rest of the session
+- docs: Correct the contributor quickstart, which named the wrong sandbox IDE and JDK: since 2025.3 IntelliJ IDEA is a single unified distribution, so `253` and newer build against it rather than against Community
+- chore: Drop the `defaultIdeaType` property and its sixteen unused declarations, inert since the platform dependency stopped taking an edition argument on `253`
 
 ## [262.34.101] - 2026-08-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ We want the repository to be contribution-friendly **without putting important f
 ## 3. Quickstart (5 minutes)
 
 ### Prerequisites
-- **JDK 21.** The build targets Java 21. Gradle's toolchain support (foojay resolver) can auto-provision it, but having a JDK 21 installed avoids surprises.
+- **JDK 25.** This branch targets Java 25 (`261` and older target 21). Gradle's toolchain support (foojay resolver) can auto-provision it, but having a JDK 25 installed avoids surprises.
 - **Git** and a **GitHub account** (fork + PR workflow).
-- **IntelliJ IDEA** (Community is fine) to edit the code. The sandbox the plugin launches into is **IntelliJ IDEA Community 2026.1** by default (`defaultIdeaVersion` / `defaultIdeaType=IC` in `gradle.properties`).
+- **IntelliJ IDEA** (the free tier is fine) to edit the code. The sandbox the plugin launches into is **IntelliJ IDEA 2026.2** by default (`defaultIdeaVersion` in `gradle.properties`). Since 2025.3 IntelliJ IDEA ships as a single unified distribution, so the sandbox identifies itself as `IU-262.…` even without a subscription — Ultimate-only functionality stays gated behind one.
 
 ### Clone and launch a sandbox IDE
 ```bash

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,8 @@ gradleIntellijPluginVersion=2.18.1
 #defaultIdeaVersion=2025.2
 #defaultIdeaVersion=2026.1
 defaultIdeaVersion=2026.2
-defaultIdeaType=IC
+# No defaultIdeaType: since 253 IntelliJ IDEA is a single unified distribution and
+# intellijIdea(defaultIdeaVersion) takes no edition argument. Lines 242-252 still need it.
 org.jetbrains.intellij.platform.selfUpdateCheck=false
 org.jetbrains.intellij.platform.downloadSources=true
 sinceVersion=262

--- a/modules/base/base.gradle.kts
+++ b/modules/base/base.gradle.kts
@@ -20,7 +20,6 @@ ext {
 
 evaluationDependsOn(":test-framework")
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 intellijPlatform {

--- a/modules/jpa/jpa.gradle.kts
+++ b/modules/jpa/jpa.gradle.kts
@@ -53,7 +53,6 @@ tasks {
 val baseProject = project(":base")
 val testFramework = project(":test-framework")
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/quarkus-core/quarkus-core.gradle.kts
+++ b/modules/quarkus-core/quarkus-core.gradle.kts
@@ -44,7 +44,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-ai/spring-ai.gradle.kts
+++ b/modules/spring-ai/spring-ai.gradle.kts
@@ -41,7 +41,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-aop/spring-aop.gradle.kts
+++ b/modules/spring-aop/spring-aop.gradle.kts
@@ -35,7 +35,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-bootstrap/spring-bootstrap.gradle.kts
+++ b/modules/spring-bootstrap/spring-bootstrap.gradle.kts
@@ -79,8 +79,6 @@ val distFilePostfix = rootProject.optProperty("distFilePostfix") ?: version
 
 val buildArchiveName = "${springPluginName}-${distFilePostfix}.zip"
 
-val launchUltimate = rootProject.hasProperty("launchUltimate")
-
 val springBootstrapModule = project(":spring-bootstrap")
 val testFramework = project(":test-framework")
 
@@ -139,7 +137,6 @@ configurations {
     }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-cloud/spring-cloud.gradle.kts
+++ b/modules/spring-cloud/spring-cloud.gradle.kts
@@ -33,7 +33,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-core/spring-core.gradle.kts
+++ b/modules/spring-core/spring-core.gradle.kts
@@ -53,7 +53,6 @@ tasks {
 
 val baseProject = project(":base")
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-data/spring-data.gradle.kts
+++ b/modules/spring-data/spring-data.gradle.kts
@@ -39,7 +39,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-gradle/spring-gradle.gradle.kts
+++ b/modules/spring-gradle/spring-gradle.gradle.kts
@@ -37,7 +37,6 @@ tasks {
 val springCore = project(":spring-core")
 val testFramework = project(":test-framework")
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-initializr/spring-initializr.gradle.kts
+++ b/modules/spring-initializr/spring-initializr.gradle.kts
@@ -37,7 +37,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-integration/spring-integration.gradle.kts
+++ b/modules/spring-integration/spring-integration.gradle.kts
@@ -34,7 +34,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-messaging/spring-messaging.gradle.kts
+++ b/modules/spring-messaging/spring-messaging.gradle.kts
@@ -34,7 +34,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-security/spring-security.gradle.kts
+++ b/modules/spring-security/spring-security.gradle.kts
@@ -36,7 +36,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/spring-web/spring-web.gradle.kts
+++ b/modules/spring-web/spring-web.gradle.kts
@@ -45,7 +45,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {

--- a/modules/test-framework/test-framework.gradle.kts
+++ b/modules/test-framework/test-framework.gradle.kts
@@ -31,7 +31,6 @@ tasks {
     verifyPlugin { enabled = false }
 }
 
-val defaultIdeaType: String by rootProject
 val defaultIdeaVersion: String by rootProject
 
 dependencies {


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` told contributors the sandbox is **IntelliJ IDEA Community 2026.1** and that the build targets **Java 21**. Both IDEA artifacts this branch resolves report `IU-262.8665.258`, and the toolchain is 25 — so the quickstart was wrong on edition, version and JDK.

The cause is the `253` boundary. IntelliJ IDEA became a [single unified distribution in 2025.3](https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/), so `intellijIdea(defaultIdeaVersion)` takes no edition argument and resolves `com.jetbrains.intellij.idea:idea`, whose `build.txt` reads `IU-…` regardless of subscription. That is also why the `262` test sandbox has to disable the bundled JB Spring/JPA plugins in `PrepareSandboxTask`.

`defaultIdeaType` consequently stopped doing anything on `253`. It survived as a `gradle.properties` entry plus sixteen `val defaultIdeaType: String by rootProject` declarations that no module read. `launchUltimate` was dead the same way — assigned once in `spring-bootstrap.gradle.kts`, referenced nowhere in the tree.

### Do not cherry-pick the removal backwards

Lines `242`–`252` still pass the edition explicitly via `create(defaultIdeaType, defaultIdeaVersion)` and genuinely need `IC`. Backporting this commit to them fails with `Cannot get property defaultIdeaType`. `gradle.properties` carries a comment stating that, since fixes flow from `main` outward.

| Lines | Distribution | Selected by | `build.txt` |
|---|---|---|---|
| `242` – `252` | IntelliJ IDEA **Community** | `create(defaultIdeaType, defaultIdeaVersion)`, `defaultIdeaType=IC` | `IC-<build>` |
| `253` and newer | the **unified** IntelliJ IDEA | `intellijIdea(defaultIdeaVersion)` | `IU-<build>` |

## Related issue

n/a

## Type of change

- [ ] Bug fix
- [ ] New feature / inspection
- [x] Documentation
- [x] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

No Kotlin sources are touched, so there are no new tests.

- `./gradlew projects` — reconfigures all sixteen subprojects and stores a **fresh** configuration-cache entry. This is the check that matters: `by rootProject` delegates fail at property-access time, not at compile time, so a leftover declaration would surface here.
- `./gradlew :base:dependencies --configuration intellijPlatformDependency` and the same for `:spring-bootstrap` — platform resolution unchanged at `com.jetbrains.intellij.idea:idea:2026.2`.
- `rg defaultIdeaType|launchUltimate` — no remaining references outside the explanatory comment and the compatibility table.

Note that `modules/**/*.gradle.kts` sits outside every content root, so IDE inspections do not cover these files; the configuration run is the only real verification available for them.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header. *(no new files)*
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed.
