### PR TITLE
fix: Require a configuration key's owner to end at a segment boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fix: Skip a cached component annotation that an edit invalidated instead of passing it to the annotated-elements search, which failed the whole bean search on it — with an `IllegalArgumentException` from the Java search executor and a message-less `AssertionError` from the Groovy one
 - fix: Recompute the bean search instead of failing it when a search executor dereferences an element invalidated while the query ran
 - feat: Open the Explyt Spring tool window after linking a Spring Boot project from a run configuration, including when the project was already linked and the click only refreshes it (#197)
+- fix: Require a configuration key's owning declaration to end at a segment boundary, so a declared `foo.bar` no longer owns the unrelated `foo.barbaz` — it decided the value type, the map-entry completion, the kebab-case exemption and whether an unknown key was reported at all
 
 ### Spring Initializr
 - fix: Make `gradlew` and `mvnw` executable in a project generated through Spring Initializr, so the first `./gradlew` in a terminal no longer fails with "permission denied" (#60)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringBasePropertyInspection.kt
@@ -639,22 +639,29 @@ abstract class SpringBasePropertyInspection : SpringBaseLocalInspectionTool() {
         }.distinct()
 
 
+    /**
+     * The declared maps that would accept [fileProperty] as an entry. A map entry name is arbitrary, so a key with
+     * no declaration of its own is still legal when a map owns it — but only when ownership ends at a segment
+     * boundary. A bare prefix match makes the map `foo.bar` legalise the misspelled `foo.barbaz`, suppressing the
+     * unresolved-key report the inspection exists to produce.
+     */
     private fun getMapKeys(
         fileProperty: DefinedConfigurationProperty,
         properties: List<ConfigurationProperty>
     ): List<ConfigurationProperty> {
         val commonFormKey = PropertyUtil.toCommonPropertyForm(fileProperty.key)
         return properties.asSequence().filter { it.isMap() }
-            .filter { commonFormKey.startsWith(PropertyUtil.toCommonPropertyForm(it.name)) }.toList()
+            .filter { PropertyUtil.isOwnedBy(commonFormKey, PropertyUtil.toCommonPropertyForm(it.name)) }.toList()
     }
 
+    /** The declared collections that would accept [fileProperty] as an element. See [getMapKeys] on the boundary. */
     private fun getListKeys(
         fileProperty: DefinedConfigurationProperty,
         properties: List<ConfigurationProperty>
     ): List<ConfigurationProperty> {
         val commonFormKey = PropertyUtil.toCommonPropertyForm(fileProperty.key)
         return properties.asSequence().filter { it.isList() || it.isArray() }
-            .filter { commonFormKey.startsWith(PropertyUtil.toCommonPropertyForm(it.name)) }.toList()
+            .filter { PropertyUtil.isOwnedBy(commonFormKey, PropertyUtil.toCommonPropertyForm(it.name)) }.toList()
     }
 
     private fun checkDuplicateKeys(

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/ConfigurationPropertyDataRetriever.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/dataRetriever/ConfigurationPropertyDataRetriever.kt
@@ -39,8 +39,12 @@ abstract class ConfigurationPropertyDataRetriever {
             DefinedConfigurationPropertiesSearch.getInstance(module.project)
                 .getAllProperties(module).asSequence()
                 .filter {
-                    PropertyUtil.toCommonPropertyForm(it.key)
-                        .startsWith(PropertyUtil.toCommonPropertyForm(propertyFqn))
+                    // Entries and elements of this member, not every key that merely shares its spelling:
+                    // `foo.bar` must not collect the unrelated `foo.barbaz`.
+                    PropertyUtil.isOwnedBy(
+                        PropertyUtil.toCommonPropertyForm(it.key),
+                        PropertyUtil.toCommonPropertyForm(propertyFqn)
+                    )
                 }
                 .mapNotNull { it.psiElement }.toList()
         } else {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/PropertyUtil.kt
@@ -17,6 +17,7 @@ import com.explyt.spring.core.completion.properties.ConfigurationPropertiesLoade
 import com.explyt.spring.core.properties.dataRetriever.ConfigurationPropertyDataRetriever
 import com.explyt.spring.core.properties.dataRetriever.ConfigurationPropertyDataRetrieverFactory
 import com.explyt.spring.core.properties.providers.ConfigKeyPsiElement
+import com.explyt.spring.core.properties.references.ConfigurationPropertyListElementReference
 import com.explyt.spring.core.references.FileReferenceSetWithPrefixSupport
 import com.explyt.spring.core.references.ReferenceType
 import com.explyt.spring.core.service.SpringSearchService
@@ -235,7 +236,7 @@ object PropertyUtil {
         val commonKey = toCommonPropertyForm(propertyKey)
         return search.getAllProperties(module).asSequence()
             .filter { it.isMap() }
-            .filter { commonKey.startsWith(toCommonPropertyForm(it.name)) }
+            .filter { isOwnedBy(commonKey, toCommonPropertyForm(it.name)) }
             // The longest declared prefix is the closest declaration; a shorter one may be an unrelated ancestor.
             .maxByOrNull { it.name.length }
     }
@@ -412,6 +413,31 @@ object PropertyUtil {
         return toCommonPropertyForm(property1) == toCommonPropertyForm(property2)
     }
 
+    /**
+     * Whether [propertyKey] belongs to the declaration [declaredName] — the same key, or a key that continues with a
+     * new segment.
+     *
+     * The relation cannot be a plain `startsWith`: that accepts `foo.bar` as the owner of `foo.barbaz`, two keys
+     * sharing seven characters and no relation. A bogus owner then decides the value type, the map-entry completion
+     * and whether an unknown key is reported at all, so the over-match turns into both false positives and
+     * suppressed warnings.
+     *
+     * The boundary is not the dot alone. A collection element and a bracket-notation map entry open with `[`, so
+     * `ingest.s3-logs.sources[0].enabled` belongs to `ingest.s3-logs.sources`; requiring `.` would drop collection
+     * ownership entirely.
+     *
+     * Callers that honour relaxed binding pass both arguments through [toCommonPropertyForm] first — it strips `-`
+     * and `_` but leaves both boundary characters intact, so the rule holds on canonical forms too.
+     */
+    fun isOwnedBy(propertyKey: String, declaredName: String): Boolean {
+        if (!propertyKey.startsWith(declaredName)) return false
+        if (propertyKey.length == declaredName.length) return true
+        // An empty declaration would otherwise own every key whose first character happens to be a boundary.
+        if (declaredName.isEmpty()) return false
+        val boundary = propertyKey[declaredName.length]
+        return boundary == DOT.single() || boundary == ConfigurationPropertyListElementReference.INDEX_START
+    }
+
     fun guessTypeFromValue(value: String?): String {
         return when {
             value == null -> CommonClassNames.JAVA_LANG_STRING
@@ -514,8 +540,13 @@ object PropertyUtil {
             .joinToString(".")
     }
 
+    /**
+     * Whether [key] is an entry of a declared map, whose entry names are arbitrary and so exempt from the
+     * kebab-case rule. Ownership has to respect the segment boundary: a map `foo.bar` does not make `foo.barBaz`
+     * an entry, and treating it as one silently drops a genuine warning.
+     */
     fun isKebabCaseInMapKey(key: String, properties: List<ConfigurationProperty>): Boolean {
-        return properties.any { it.isMap() && key.startsWith(it.name) && key != it.name }
+        return properties.any { it.isMap() && isOwnedBy(key, it.name) && key != it.name }
     }
 
     fun getValueClassNameInMap(propertyType: String?): String? {
@@ -800,7 +831,7 @@ object PropertyUtil {
     fun longestPrefixProperty(
         properties: List<ConfigurationProperty>, propertyKey: String
     ): ConfigurationProperty? = properties.asSequence()
-        .filter { propertyKey.startsWith(it.name) }
+        .filter { isOwnedBy(propertyKey, it.name) }
         .maxByOrNull { it.name.length }
 
     fun resolveResults(sourceMember: PsiMember): Array<ResolveResult> {

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/LongestPrefixPropertyTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/LongestPrefixPropertyTest.kt
@@ -74,4 +74,69 @@ class LongestPrefixPropertyTest {
             PropertyUtil.longestPrefixProperty(properties, "management.endpoint.health.show-details")
         )
     }
+
+    /**
+     * A textual prefix is not an ownership relation: `foo.bar` and `foo.barbaz` are unrelated keys that happen to
+     * share their first seven characters. Owning the key requires the match to end where a new segment begins.
+     */
+    @Test
+    fun testPrefixEndingInsideASegmentOwnsNothing() {
+        Assert.assertNull(PropertyUtil.longestPrefixProperty(listOf(property("foo.bar")), "foo.barbaz"))
+    }
+
+    /**
+     * The case the longest-prefix selection cannot mask: the mid-segment match is longer than the genuine ancestor,
+     * so length alone hands the key to the wrong declaration.
+     */
+    @Test
+    fun testGenuineAncestorBeatsALongerMidSegmentPrefix() {
+        val ancestor = property("foo")
+        Assert.assertEquals(
+            ancestor,
+            PropertyUtil.longestPrefixProperty(listOf(ancestor, property("foo.bar")), "foo.barbaz")
+        )
+    }
+
+    /** The case it did mask, kept as a regression: the deeper genuine ancestor must still win. */
+    @Test
+    fun testDeeperGenuineAncestorStillWinsOverAMidSegmentPrefix() {
+        val owner = property("foo.barbaz")
+        Assert.assertEquals(
+            owner,
+            PropertyUtil.longestPrefixProperty(listOf(property("foo.bar"), owner), "foo.barbaz.qux")
+        )
+    }
+
+    /**
+     * A collection element opens with `[`, not `.`, so the boundary cannot be the dot alone — requiring one would
+     * drop collection ownership entirely.
+     */
+    @Test
+    fun testIndexedKeyIsOwnedByTheCollectionDeclaration() {
+        val sources = property("ingest.s3-logs.sources")
+        Assert.assertEquals(
+            sources,
+            PropertyUtil.longestPrefixProperty(
+                listOf(property("ingest"), sources), "ingest.s3-logs.sources[0].enabled"
+            )
+        )
+    }
+
+    /** A map entry may be written in bracket notation, which ends the owner's match at `[` as well. */
+    @Test
+    fun testBracketNotationEntryIsOwnedByTheMapDeclaration() {
+        val levels = property("logging.level")
+        Assert.assertEquals(
+            levels,
+            PropertyUtil.longestPrefixProperty(listOf(levels), "logging.level[com.example.Dao]")
+        )
+    }
+
+    /** A declaration that only shares a prefix with the collection name must not capture its elements. */
+    @Test
+    fun testIndexedKeyIgnoresAMidSegmentPrefixOfTheCollection() {
+        Assert.assertNull(
+            PropertyUtil.longestPrefixProperty(listOf(property("ingest.source")), "ingest.sources[0].enabled")
+        )
+    }
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/PropertyOwnershipBoundaryTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/util/PropertyOwnershipBoundaryTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.util
+
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * The boundary rule shared by every lookup that resolves a key with no exact declaration to the declaration that
+ * owns it — map entries, collection elements and the inspections that decide whether an unknown key is legal.
+ *
+ * A plain `startsWith` answers a different question: it accepts `foo.bar` as the owner of `foo.barbaz`, two keys
+ * that share seven characters and nothing else. The match has to end where a new segment begins, and the segment
+ * opener is `.` for a nested key but `[` for a collection element or a bracket-notation map entry, so neither
+ * character alone is the rule.
+ */
+class PropertyOwnershipBoundaryTest {
+
+    @Test
+    fun testDeclarationOwnsItself() {
+        Assert.assertTrue(PropertyUtil.isOwnedBy("logging.level", "logging.level"))
+    }
+
+    @Test
+    fun testDeclarationOwnsANestedSegment() {
+        Assert.assertTrue(PropertyUtil.isOwnedBy("logging.level.sql", "logging.level"))
+    }
+
+    @Test
+    fun testDeclarationOwnsADeeplyNestedSegment() {
+        Assert.assertTrue(PropertyUtil.isOwnedBy("logging.level.com.example.Dao", "logging.level"))
+    }
+
+    @Test
+    fun testDeclarationOwnsAnIndexedElement() {
+        Assert.assertTrue(PropertyUtil.isOwnedBy("ingest.s3-logs.sources[0].enabled", "ingest.s3-logs.sources"))
+    }
+
+    @Test
+    fun testDeclarationOwnsABracketNotationEntry() {
+        Assert.assertTrue(PropertyUtil.isOwnedBy("logging.level[com.example.Dao]", "logging.level"))
+    }
+
+    /** The defect: the match ends in the middle of the `barbaz` segment, so the two keys are unrelated. */
+    @Test
+    fun testPrefixEndingInsideASegmentOwnsNothing() {
+        Assert.assertFalse(PropertyUtil.isOwnedBy("foo.barbaz", "foo.bar"))
+    }
+
+    /** The same defect one level down, where the shared prefix spans several whole segments first. */
+    @Test
+    fun testPrefixEndingInsideADeeperSegmentOwnsNothing() {
+        Assert.assertFalse(PropertyUtil.isOwnedBy("spring.datasource.urls", "spring.datasource.url"))
+    }
+
+    /** A collection declaration must not capture elements of a differently named collection. */
+    @Test
+    fun testPrefixEndingInsideASegmentOwnsNoIndexedElement() {
+        Assert.assertFalse(PropertyUtil.isOwnedBy("ingest.sources[0].enabled", "ingest.source"))
+    }
+
+    @Test
+    fun testUnrelatedKeyIsNotOwned() {
+        Assert.assertFalse(PropertyUtil.isOwnedBy("app.custom.key", "logging.level"))
+    }
+
+    @Test
+    fun testShorterKeyIsNotOwnedByALongerDeclaration() {
+        Assert.assertFalse(PropertyUtil.isOwnedBy("logging", "logging.level"))
+    }
+
+    /**
+     * An empty declared name is not a universal owner. Metadata should never carry one, but the previous
+     * `startsWith` accepted it for every key, which is the widest possible false match.
+     */
+    @Test
+    fun testEmptyDeclarationOwnsNothingButItself() {
+        Assert.assertFalse(PropertyUtil.isOwnedBy("logging.level", ""))
+        Assert.assertTrue(PropertyUtil.isOwnedBy("", ""))
+    }
+
+    /**
+     * The rule is applied to canonical forms at the call sites that honour relaxed binding, so the boundary
+     * characters must survive [PropertyUtil.toCommonPropertyForm] — it strips `-` and `_` but not `.` or `[`.
+     */
+    @Test
+    fun testBoundaryCharactersSurviveCanonicalisation() {
+        val declaration = PropertyUtil.toCommonPropertyForm("ingest.s3-logs.sources")
+        val key = PropertyUtil.toCommonPropertyForm("ingest.s3-logs.sources[0].enabled")
+        Assert.assertTrue(PropertyUtil.isOwnedBy(key, declaration))
+        Assert.assertFalse(
+            PropertyUtil.isOwnedBy(PropertyUtil.toCommonPropertyForm("ingest.s3-logs.sourcesets"), declaration)
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`PropertyUtil.longestPrefixProperty` and the five lookups beside it accepted any declaration whose name is a string prefix of the key:

```kotlin
.filter { propertyKey.startsWith(it.name) }
```

Nothing required the match to stop where a segment begins, so a declared `foo.bar` owned `foo.barbaz` — a key it has no relation to. Selecting the longest prefix (#339) masks that only when a genuine deeper ancestor happens to be declared as well; when the mid-segment match is the *longer* candidate, length alone hands it the key.

The owner decides the value type, the map-entry completion, the kebab-case exemption and whether an unknown key is reported at all.

## Why the boundary is not just `.`

An indexed key such as `ingest.s3-logs.sources[0].enabled` is owned by `ingest.s3-logs.sources`, where the next character is `[`. A naive `startsWith("${it.name}.")` would drop collection ownership entirely, which is why this was left out of #339 and tracked separately.

`PropertyUtil.isOwnedBy` accepts both characters and is shared by all six sites. It holds on canonical forms too: `toCommonPropertyForm` strips `-` and `_` but leaves `.` and `[` intact.

## The six sites

| Site | Effect of the over-match |
|---|---|
| `longestPrefixProperty` | wrong value type, wrong map-key completion |
| `findValueOwner` | wrong enum value type |
| `isKebabCaseInMapKey` | **suppressed** a real kebab-case warning |
| `SpringBasePropertyInspection.getMapKeys` | **suppressed** "cannot resolve key" for a misspelled key |
| `SpringBasePropertyInspection.getListKeys` | same |
| `ConfigurationPropertyDataRetriever.getRelatedProperties` | line marker collected unrelated keys |

Three are inspections, where the over-match *suppressed* a report rather than raising one — so this fix makes some genuine warnings appear that were previously swallowed.

`ConfigurationPropertyListElementReference` already sliced at `[` correctly, and its KDoc warned that a `startsWith` search over all properties is ambiguous for nested keys. That warning is now enforced everywhere instead of in one class.

## Testing

- `PropertyOwnershipBoundaryTest` (new, 12 tests) — the boundary rule over map, list, indexed and bracket-notation keys, plus canonicalisation.
- `LongestPrefixPropertyTest` (+6 tests) — covers both the case longest-prefix masks and the case it cannot.
- Ran **before** wiring `isOwnedBy` in: the matrix passed and exactly 3 selection tests failed, confirming the tests detect the defect rather than merely agreeing with the new code.
- `./gradlew :spring-core:test` green. The properties/YAML inspection suites (`SpringPropertiesInspectionTest`, `SpringYamlInspectionTest`, `SpringYamlInspectionCrossModuleTest`) pass unchanged, which is the regression check that matters for the three tightened inspection sites.
- `lint_files` on the touched files reports nothing new.

Follow-up to #339.