### PR TITLE
feat: Resolve the bean and the property of a SpEL reference in @Value and @Scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fix: Skip a cached component annotation that an edit invalidated instead of passing it to the annotated-elements search, which failed the whole bean search on it — with an `IllegalArgumentException` from the Java search executor and a message-less `AssertionError` from the Groovy one
 - fix: Recompute the bean search instead of failing it when a search executor dereferences an element invalidated while the query ran
 - feat: Open the Explyt Spring tool window after linking a Spring Boot project from a run configuration, including when the project was already linked and the click only refreshes it (#197)
+- feat: Navigate from a SpEL bean reference in `@Value` and `@Scheduled` to the bean and to the property it reads, so `#{@myProps.cron}` resolves both halves and completes the property name (#44)
 
 ### Spring Initializr
 - fix: Make `gradlew` and `mvnw` executable in a project generated through Spring Initializr, so the first `./gradlew` in a terminal no longer fails with "permission denied" (#60)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/SpringProperties.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/SpringProperties.kt
@@ -66,4 +66,7 @@ object SpringProperties {
     const val PLACEHOLDER_PREFIX = "\${"
     const val PLACEHOLDER_SUFFIX = "}"
 
+    /** The opener of a SpEL block, which an annotation value resolves after its placeholders. */
+    const val SPEL_PREFIX = "#{"
+
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringValueAnnotationInspection.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/inspections/SpringValueAnnotationInspection.kt
@@ -71,7 +71,13 @@ class SpringValueAnnotationInspection : SpringBaseUastLocalInspectionTool() {
         val attributeValue = annotation.findAttributeValue(annoParameterName) ?: return null
         val sourcePsi = attributeValue.sourcePsi ?: return null
         val valueText = attributeValue.evaluateString() ?: return null
-        if (valueText.isEmpty() || valueText.startsWith("\${") || valueText.startsWith("#{")) return null
+        // A SpEL value is not a bare property key that needs wrapping: `EmbeddedValueResolver` evaluates the
+        // expression after placeholder resolution, so `#{@myProps.cron}` is already a working shape. Reporting it
+        // would flag idiomatic code; its bean and member get references instead (issue #44).
+        if (valueText.isEmpty()
+            || valueText.startsWith(SpringProperties.PLACEHOLDER_PREFIX)
+            || valueText.startsWith(SpringProperties.SPEL_PREFIX)
+        ) return null
         val module = ModuleUtilCore.findModuleForPsiElement(sourcePsi) ?: return null
 
         val findProperties = DefinedConfigurationPropertiesSearch.getInstance(sourcePsi.project)

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/ValueConfigurationPropertyReferenceProvider.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/properties/providers/ValueConfigurationPropertyReferenceProvider.kt
@@ -5,7 +5,11 @@
 
 package com.explyt.spring.core.properties.providers
 
+import com.explyt.spring.core.SpringProperties.PLACEHOLDER_PREFIX
+import com.explyt.spring.core.SpringProperties.SPEL_PREFIX
 import com.explyt.spring.core.properties.references.ExplytPropertyReference
+import com.explyt.spring.core.references.SpelBeanMemberReference
+import com.explyt.spring.core.references.SpelBeanReference
 import com.explyt.spring.core.util.SpringCoreUtil.removeDummyIdentifier
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiLanguageInjectionHost
@@ -38,6 +42,26 @@ class ValueConfigurationPropertyReferenceProvider : UastInjectionHostReferencePr
          */
         val PROPERTIES_PATTERN =
             """\$\{([.A-z\d_-]+)(:(?:[^{}$]|\$(?!\{)|\$\{[^{}]*+}|\{[^{}]*+})*+)?\s*+}""".toPattern()
+
+        /**
+         * A SpEL block in an annotation value. Group 1 is its body, so a bean reference is searched only inside
+         * `#{...}` and never in surrounding literal text — an `@` elsewhere in the value is not a bean.
+         *
+         * Nested braces are not matched on purpose: a SpEL default inside a placeholder
+         * (`$\{key:#{null}}`) still yields its inner block, and the possessive quantifier keeps the scan linear
+         * while the user edits the annotation.
+         */
+        val SPEL_PATTERN = """#\{([^{}]*+)}""".toPattern()
+
+        /**
+         * A bean reference inside a SpEL block: `@beanName` and, optionally, the single property access that
+         * follows it. Group 1 is the bean name, group 2 the member.
+         *
+         * Only the first access is captured — `#{@myProps.cron}` is the shape issue #44 is about. A longer chain
+         * such as `#{@a.b.c}` needs the type of `b` to resolve `c`, which the flat name index cannot supply, and
+         * offering a reference that never resolves is worse than offering none.
+         */
+        val SPEL_BEAN_PATTERN = """@(\w++)(?:\s*+\.\s*+(\w++))?""".toPattern()
     }
 
     override fun getReferencesForInjectionHost(
@@ -50,7 +74,7 @@ class ValueConfigurationPropertyReferenceProvider : UastInjectionHostReferencePr
         val valueText = uExpression.evaluateString()?.removeDummyIdentifier() ?: return EMPTY_ARRAY
         val referenceProperties = extractReferenceProperty(valueText)
 
-        if (referenceProperties.isEmpty() && valueText.startsWith("\${")) {
+        if (referenceProperties.isEmpty() && valueText.startsWith(PLACEHOLDER_PREFIX)) {
             val startPosition =
                 if (uExpression.lang == KotlinLanguage.INSTANCE) 4 else 3
             return arrayOf(
@@ -60,7 +84,7 @@ class ValueConfigurationPropertyReferenceProvider : UastInjectionHostReferencePr
             )
         }
 
-        return referenceProperties
+        val propertyReferences = referenceProperties
             .mapNotNull { referenceProperty ->
                 val text = host.text.removeDummyIdentifier()
                 val startOffset = text.indexOf(referenceProperty.key)
@@ -74,7 +98,44 @@ class ValueConfigurationPropertyReferenceProvider : UastInjectionHostReferencePr
                     host, referenceProperty.key,
                     TextRange.from(startOffset, referenceProperty.key.length)
                 )
-            }.toTypedArray()
+            }
+
+        return (propertyReferences + spelBeanReferences(host)).toTypedArray()
+    }
+
+    /**
+     * The bean references, and the members they read, inside every SpEL block of the value (issue #44).
+     *
+     * Matched against the raw host text rather than the evaluated string: the offsets a reference needs are
+     * offsets into the host, and taking them straight from the matcher keeps them valid by construction. The
+     * placeholder path above has to search for its key instead, because a placeholder may be assembled from a
+     * constant and so not appear literally in the host — and that search is what produced the invalid ranges of
+     * issue #236. A bean name in a SpEL block is always written out, so the search is unnecessary here.
+     */
+    private fun spelBeanReferences(host: PsiLanguageInjectionHost): List<PsiReference> {
+        val hostText = host.text
+        if (!hostText.contains(SPEL_PREFIX)) return emptyList()
+
+        val references = mutableListOf<PsiReference>()
+        val spelMatcher = SPEL_PATTERN.matcher(hostText)
+        while (spelMatcher.find()) {
+            val blockStart = spelMatcher.start(1)
+            val beanMatcher = SPEL_BEAN_PATTERN.matcher(spelMatcher.group(1))
+            while (beanMatcher.find()) {
+                val beanName = beanMatcher.group(1)
+                references += SpelBeanReference(
+                    host, beanName,
+                    TextRange(blockStart + beanMatcher.start(1), blockStart + beanMatcher.end(1))
+                )
+
+                val memberName = beanMatcher.group(2) ?: continue
+                references += SpelBeanMemberReference(
+                    host, beanName, memberName,
+                    TextRange(blockStart + beanMatcher.start(2), blockStart + beanMatcher.end(2))
+                )
+            }
+        }
+        return references
     }
 
     private fun extractReferenceProperty(text: String): List<ReferenceProperty> {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/references/SpelBeanMemberReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/references/SpelBeanMemberReference.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.references
+
+import com.explyt.util.ExplytPsiUtil
+import com.explyt.util.ExplytPsiUtil.isPublic
+import com.intellij.codeInsight.highlighting.HighlightedReference
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.PropertyUtilBase
+
+/**
+ * The member read by a SpEL property access on a bean reference — the `cron` of `@Scheduled(cron = "#{@myProps.cron}")`.
+ *
+ * The shape is idiomatic, not a mistake: `ScheduledAnnotationBeanPostProcessor` passes the attribute through
+ * `EmbeddedValueResolver.resolveStringValue`, which evaluates SpEL after placeholder resolution, so a bean-backed
+ * cron expression works at runtime. It therefore deserves the same navigation a `${...}` placeholder key already
+ * gets (issue #44).
+ *
+ * Resolution follows SpEL's own property accessor order: the getter first, then a public field, and finally a
+ * no-argument method of that name, which covers the `#{@bean.compute}` form written without parentheses.
+ */
+class SpelBeanMemberReference(
+    element: PsiElement,
+    private val beanName: String,
+    private val memberName: String,
+    rangeInElement: TextRange
+) : PsiReferenceBase<PsiElement>(element, rangeInElement), PsiPolyVariantReference, HighlightedReference {
+
+    /**
+     * Poly-variant because a bean name can be contributed by more than one declaration in a module — the same
+     * class registered by both a `@Component` scan and a `@Bean` method, or two profile-specific definitions.
+     * Resolving to one of them arbitrarily would send navigation to whichever the index happened to list first.
+     */
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> = beanClasses()
+        .mapNotNull { findMember(it, memberName) }
+        .distinct()
+        .map { PsiElementResolveResult(it) }
+        .toTypedArray()
+
+    override fun resolve(): PsiElement? {
+        val resolveResults = multiResolve(false)
+        return if (resolveResults.size == 1) resolveResults[0].element else null
+    }
+
+    override fun getVariants(): Array<Any> = beanClasses().asSequence()
+        .flatMap { PropertyUtilBase.getAllProperties(it, false, true).keys.asSequence() }
+        .distinct()
+        .map { LookupElementBuilder.create(it).withIcon(AllIcons.Nodes.Property) }
+        .toList().toTypedArray()
+
+    /**
+     * The classes behind [beanName], looked up by name alone through the same helper the bean half of the
+     * expression uses, so both references agree on which bean is meant.
+     */
+    private fun beanClasses(): List<PsiClass> =
+        SpelBeanReference.beansNamed(element, beanName).map { it.psiClass }
+
+    private fun findMember(psiClass: PsiClass, name: String): PsiMember? =
+        PropertyUtilBase.findPropertyGetter(psiClass, name, false, true)
+            ?: psiClass.findFieldByName(name, true)?.takeIf { it.isPublic }
+            ?: psiClass.allMethods.firstOrNull { it.name == name && ExplytPsiUtil.fitsForReference(it) }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/references/SpelBeanReference.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/references/SpelBeanReference.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.references
+
+import com.explyt.spring.core.service.PsiBean
+import com.explyt.spring.core.service.SpringSearchServiceFacade
+import com.intellij.codeInsight.highlighting.HighlightedReference
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+
+/**
+ * The bean named by `@beanName` inside a SpEL block, as in `@Value("#{@myProps.cron}")` (issue #44).
+ *
+ * Deliberately not [ExplytBeanReference]: that one is built for an injection point, where a name is only a hint on
+ * top of a required type, so when the name matches nothing it falls back to every candidate it found by type
+ * (`NativeSearchService.findActiveBeanDeclarations`). SpEL carries no type — the name is the entire query — and
+ * that fallback would resolve a misspelled `#{@myPropz.cron}` to every bean in the module, which is worse than
+ * not resolving it: navigation lands somewhere unrelated and the typo looks intentional.
+ */
+class SpelBeanReference(
+    element: PsiElement,
+    private val beanName: String,
+    rangeInElement: TextRange
+) : PsiReferenceBase<PsiElement>(element, rangeInElement), PsiPolyVariantReference, HighlightedReference {
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> =
+        beansNamed(element, beanName)
+            .map { PsiElementResolveResult(it.psiMember) }
+            .toTypedArray()
+
+    override fun resolve(): PsiElement? {
+        val resolveResults = multiResolve(false)
+        return if (resolveResults.size == 1) resolveResults[0].element else null
+    }
+
+    override fun getVariants(): Array<Any> {
+        val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return emptyArray()
+        return SpringSearchServiceFacade.getInstance(element.project).getAllActiveBeans(module)
+            .map {
+                LookupElementBuilder.create(it.name)
+                    .withIcon(AllIcons.Nodes.Class)
+                    .withTypeText(it.psiClass.containingFile?.name)
+            }
+            .toTypedArray()
+    }
+
+    companion object {
+        /**
+         * The beans registered under [beanName], matched by name and nothing else.
+         *
+         * Shared with [SpelBeanMemberReference] so the bean and the member read from it are resolved against the
+         * same set — otherwise the two halves of one expression could disagree about which bean is meant.
+         */
+        fun beansNamed(element: PsiElement, beanName: String): List<PsiBean> {
+            val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return emptyList()
+            return SpringSearchServiceFacade.getInstance(element.project)
+                .getAllBeanByNames(module)[beanName]
+                ?: emptyList()
+        }
+    }
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/UastUtil.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/util/UastUtil.kt
@@ -5,6 +5,9 @@
 
 package com.explyt.spring.core.util
 
+import com.explyt.spring.core.SpringProperties.PLACEHOLDER_PREFIX
+import com.explyt.spring.core.SpringProperties.PLACEHOLDER_SUFFIX
+import com.explyt.spring.core.SpringProperties.SPEL_PREFIX
 import com.explyt.spring.core.completion.properties.DefinedConfigurationPropertiesSearch
 import com.intellij.openapi.module.ModuleUtilCore
 import org.jetbrains.uast.UCallExpression
@@ -16,8 +19,10 @@ import org.jetbrains.uast.evaluateString
 object UastUtil {
     fun UExpression.getPropertyValue(): String? {
         val value = this.evaluateString() ?: return null
-        if (value.startsWith("#{")) return null
-        if (value.startsWith("\${") && value.endsWith("}")) {
+        // SpEL is evaluated at runtime against the bean graph, so the value is not statically known and every
+        // caller here validates a literal. Returning null stops the validation rather than reporting a guess.
+        if (value.startsWith(SPEL_PREFIX)) return null
+        if (value.startsWith(PLACEHOLDER_PREFIX) && value.endsWith(PLACEHOLDER_SUFFIX)) {
             val matchResult = PropertyUtil.VALUE_REGEX.matchEntire(value) ?: return null
             val (key, defaultValue) = matchResult.destructured
 

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/SpelBeanReferenceTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/java/SpelBeanReferenceTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.properties.java
+
+import com.explyt.spring.test.ExplytJavaLightTestCase
+import com.explyt.spring.test.TestLibrary
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPolyVariantReference
+
+/**
+ * The Java half of the SpEL bean references added for issue #44.
+ *
+ * Worth its own file rather than a case in the Kotlin test: the provider takes its offsets from the raw injection
+ * host text, and the host differs between the two languages — a `KtStringTemplateExpression` in Kotlin, a
+ * `PsiLiteralExpression` in Java. An off-by-one in that arithmetic resolves the wrong span and is invisible from
+ * the Kotlin side alone.
+ */
+class SpelBeanReferenceTest : ExplytJavaLightTestCase() {
+
+    override val libraries: Array<TestLibrary> = arrayOf(TestLibrary.springContext_6_0_7)
+
+    fun testSpelBeanNameResolvesToTheBean() {
+        configureSpelFixture("#{@myPr<caret>ops.cron}")
+
+        assertEquals(
+            "Expected the SpEL bean name to resolve to MyProps alone",
+            listOf("MyProps"),
+            resolveAtCaret().map { (it as? PsiClass)?.name }
+        )
+    }
+
+    fun testSpelMemberResolvesToTheBeanProperty() {
+        configureSpelFixture("#{@myProps.cr<caret>on}")
+
+        val resolved = resolveAtCaret()
+        assertTrue(
+            "Expected the SpEL member to resolve to the cron getter, got ${resolved.map { (it as? PsiMember)?.name }}",
+            resolved.any { it is PsiMethod && it.name == "getCron" }
+        )
+    }
+
+    /** The bean reference must cover the name only — not the `@`, and not the member after it. */
+    fun testBeanReferenceSpansExactlyTheBeanName() {
+        configureSpelFixture("#{@myPr<caret>ops.cron}")
+
+        val reference = file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected a reference at the caret", reference)
+        assertEquals(
+            "The bean reference must span the bean name exactly",
+            "myProps",
+            reference!!.rangeInElement.substring(reference.element.text)
+        )
+    }
+
+    /** And the member reference must cover the member name only, not the dot before it. */
+    fun testMemberReferenceSpansExactlyTheMemberName() {
+        configureSpelFixture("#{@myProps.cr<caret>on}")
+
+        val reference = file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected a reference at the caret", reference)
+        assertEquals(
+            "The member reference must span the member name exactly",
+            "cron",
+            reference!!.rangeInElement.substring(reference.element.text)
+        )
+    }
+
+    /** A `@Value` host resolves through the same provider as `@Scheduled`. */
+    fun testValueSpelMemberResolvesToTheBeanProperty() {
+        myFixture.configureByText(
+            "TestComponent.java",
+            """
+            import org.springframework.beans.factory.annotation.Value;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class TestComponent {
+                @Value("#{@myProps.cr<caret>on}")
+                private String injected;
+            }
+            """.trimIndent()
+        )
+        addPropsBean()
+
+        val resolved = resolveAtCaret()
+        assertTrue(
+            "Expected the SpEL member to resolve to the cron getter, got ${resolved.map { (it as? PsiMember)?.name }}",
+            resolved.any { it is PsiMethod && it.name == "getCron" }
+        )
+    }
+
+    private fun configureSpelFixture(spel: String) {
+        myFixture.configureByText(
+            "TestComponent.java",
+            """
+            import org.springframework.scheduling.annotation.Scheduled;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class TestComponent {
+                @Scheduled(cron = "$spel")
+                public void run() {
+                }
+            }
+            """.trimIndent()
+        )
+        addPropsBean()
+    }
+
+    private fun addPropsBean() {
+        myFixture.addClass(
+            """
+            import org.springframework.stereotype.Component;
+
+            @Component("myProps")
+            public class MyProps {
+                public String getCron() {
+                    return "0 0 * * * *";
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun resolveAtCaret(): List<PsiElement?> {
+        val reference = file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected a reference at the caret", reference)
+        return when (reference) {
+            is PsiPolyVariantReference -> reference.multiResolve(false).map { it.element }
+            else -> listOfNotNull(reference?.resolve())
+        }
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/kotlin/ValueConfigurationPropertyReferenceProviderTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/properties/kotlin/ValueConfigurationPropertyReferenceProviderTest.kt
@@ -8,7 +8,12 @@ package com.explyt.spring.core.properties.kotlin
 import com.explyt.spring.core.properties.providers.ValueConfigurationPropertyReferenceProvider
 import com.explyt.spring.test.ExplytKotlinLightTestCase
 import com.explyt.spring.test.TestLibrary
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.util.PsiTreeUtil
 import kotlin.system.measureTimeMillis
 
@@ -126,6 +131,171 @@ class ValueConfigurationPropertyReferenceProviderTest : ExplytKotlinLightTestCas
             elapsedMs < 2000
         )
     }
+
+    //region SpEL bean references (issue #44)
+
+    /** A bean reference with one property access is the shape the issue is about. */
+    fun testSpelBeanPatternExtractsBeanAndMember() {
+        assertExtractedBeanMembers("#{@myProps.cron}", "myProps.cron")
+    }
+
+    /** A bare bean reference has no member to read, and must still offer the bean. */
+    fun testSpelBeanPatternExtractsABareBeanReference() {
+        assertExtractedBeanMembers("#{@myProps}", "myProps")
+    }
+
+    /** SpEL tolerates whitespace around the accessor, so the pattern has to as well. */
+    fun testSpelBeanPatternToleratesWhitespace() {
+        assertExtractedBeanMembers("#{ @myProps . cron }", "myProps.cron")
+    }
+
+    /** Every bean named in a composite expression contributes its own pair. */
+    fun testSpelBeanPatternExtractsEveryBeanInOneBlock() {
+        assertExtractedBeanMembers("#{@first.alpha + '-' + @second.beta}", "first.alpha", "second.beta")
+    }
+
+    /** A bean referenced from a placeholder's SpEL default is a real reference too. */
+    fun testSpelBeanPatternExtractsFromAPlaceholderDefault() {
+        assertExtractedBeanMembers("${'$'}{my.property:#{@fallbackProps.cron}}", "fallbackProps.cron")
+    }
+
+    /** `#{null}` is the common SpEL default and names no bean. */
+    fun testSpelDefaultWithoutABeanExtractsNothing() {
+        assertExtractedBeanMembers("${'$'}{my.property:#{null}}")
+    }
+
+    /** An `@` outside a SpEL block is literal text — an e-mail address, not a bean. */
+    fun testAtSignOutsideSpelExtractsNothing() {
+        assertExtractedBeanMembers("support@example.com")
+        assertExtractedBeanMembers("${'$'}{mail.from:support@example.com}")
+    }
+
+    /** A SpEL block that reads something other than a bean must not be misread as one. */
+    fun testSpelWithoutABeanReferenceExtractsNothing() {
+        assertExtractedBeanMembers("#{systemProperties['user.name']}")
+        assertExtractedBeanMembers("#{T(java.lang.Math).random()}")
+    }
+
+    /**
+     * The bean named in a SpEL block must navigate. `@Scheduled` resolves the attribute through
+     * `EmbeddedValueResolver`, which evaluates SpEL after placeholder resolution, so this value works at runtime
+     * and previously produced no references at all.
+     */
+    fun testScheduledSpelBeanNameResolvesToTheBean() {
+        configureSpelFixture("#{@myPr<caret>ops.cron}")
+
+        val resolved = resolveAtCaret()
+        // Exactly one: the fixture declares a second bean (TestComponent), and a name-only lookup that fell back
+        // to every candidate — as the injection-point reference does — would return both.
+        assertEquals(
+            "Expected the SpEL bean name to resolve to MyProps alone",
+            listOf("MyProps"),
+            resolved.map { (it as? PsiClass)?.name }
+        )
+    }
+
+    /** The member read from the bean must navigate to the property it reads. */
+    fun testScheduledSpelMemberResolvesToTheBeanProperty() {
+        configureSpelFixture("#{@myProps.cr<caret>on}")
+
+        val resolved = resolveAtCaret()
+        assertTrue(
+            "Expected the SpEL member to resolve to the cron getter, got ${resolved.map { (it as? PsiMember)?.name }}",
+            resolved.any { it is PsiMethod && it.name == "getCron" }
+        )
+    }
+
+    /** The same value in `@Value` goes through the same provider, so it must resolve identically. */
+    fun testValueSpelMemberResolvesToTheBeanProperty() {
+        myFixture.configureByText(
+            "TestComponent.kt",
+            """
+            import org.springframework.beans.factory.annotation.Value
+            import org.springframework.stereotype.Component
+
+            @Component("myProps")
+            class MyProps {
+                val cron: String = "0 0 * * * *"
+            }
+
+            @Component
+            class TestComponent {
+                @Value("#{@myProps.cr<caret>on}")
+                private val injected: String = ""
+            }
+            """.trimIndent()
+        )
+
+        val resolved = resolveAtCaret()
+        assertTrue(
+            "Expected the SpEL member to resolve to the cron getter, got ${resolved.map { (it as? PsiMember)?.name }}",
+            resolved.any { it is PsiMethod && it.name == "getCron" }
+        )
+    }
+
+    /** An unknown bean name yields a reference that resolves to nothing, never an exception. */
+    fun testUnknownSpelBeanResolvesToNothing() {
+        configureSpelFixture("#{@noSuch<caret>Bean.cron}")
+
+        assertNotNull("Expected a reference even for an unknown bean", file.findReferenceAt(myFixture.caretOffset))
+        assertTrue("An unknown bean must not resolve", resolveAtCaret().isEmpty())
+        // The reference is still computed for the whole file, which must not throw.
+        myFixture.doHighlighting()
+    }
+
+    /** Configures a component whose `@Scheduled` cron is the given SpEL expression, plus the bean it names. */
+    private fun configureSpelFixture(spel: String) {
+        myFixture.configureByText(
+            "TestComponent.kt",
+            """
+            import org.springframework.scheduling.annotation.Scheduled
+            import org.springframework.stereotype.Component
+
+            @Component("myProps")
+            class MyProps {
+                val cron: String = "0 0 * * * *"
+            }
+
+            @Component
+            class TestComponent {
+                @Scheduled(cron = "$spel")
+                fun run() {
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    /** The elements the reference under the caret resolves to, poly-variant or not. */
+    private fun resolveAtCaret(): List<PsiElement?> {
+        val reference = file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Expected a reference at the caret", reference)
+        return when (reference) {
+            is PsiPolyVariantReference -> reference.multiResolve(false).map { it.element }
+            else -> listOfNotNull(reference?.resolve())
+        }
+    }
+
+    /**
+     * Asserts the bean references the provider's SpEL patterns extract, rendered as `bean` or `bean.member`.
+     * Mirrors the provider's own two-stage scan — blocks first, then bean accesses inside one — without needing
+     * a PSI fixture, so the pattern boundaries can be pinned down independently of bean resolution.
+     */
+    private fun assertExtractedBeanMembers(value: String, vararg expected: String) {
+        val spelMatcher = ValueConfigurationPropertyReferenceProvider.SPEL_PATTERN.matcher(value)
+        val actual = mutableListOf<String>()
+        while (spelMatcher.find()) {
+            val beanMatcher = ValueConfigurationPropertyReferenceProvider.SPEL_BEAN_PATTERN
+                .matcher(spelMatcher.group(1))
+            while (beanMatcher.find()) {
+                val member = beanMatcher.group(2)
+                actual += if (member == null) beanMatcher.group(1) else "${beanMatcher.group(1)}.$member"
+            }
+        }
+        assertEquals("Unexpected SpEL bean references extracted from '$value'", expected.toList(), actual)
+    }
+
+    //endregion
 
     /**
      * Configures a component whose `@Value` argument is the given placeholder and asserts that a


### PR DESCRIPTION
## Problem

`#{@myProps.cron}` produced no references at all, so neither the bean it names nor the property it reads could be navigated or completed.

## Why this does not add the warning the issue title asks for

The issue asks to *warn* on this syntax, on the premise that injecting configuration properties through SpEL is invalid. That premise is false.

`ScheduledAnnotationBeanPostProcessor` passes `cron` through `EmbeddedValueResolver.resolveStringValue`, which evaluates SpEL **after** placeholder resolution:

```java
String value = this.exprContext.getBeanFactory().resolveEmbeddedValue(strVal);  // ${...}
if (this.exprResolver != null && value != null) {
    Object evaluated = this.exprResolver.evaluate(value, this.exprContext);     // #{...}
    value = (evaluated != null ? evaluated.toString() : null);
}
```

So the shape works at runtime, and an inspection reporting it would flag idiomatic code. The actionable half of the issue is its first sentence — *"such syntax doesn't show references"* — which wants a reference provider. The `#{` bail-outs in `UastUtil.getPropertyValue` and `SpringValueAnnotationInspection` therefore stay, now with comments explaining why.

## Approach

Two patterns in the existing `ValueConfigurationPropertyReferenceProvider`, which already runs on `@Value.value` and the five `@Scheduled` attributes — no new contributor or `plugin.xml` registration:

1. `SPEL_PATTERN` finds `#{...}` blocks.
2. `SPEL_BEAN_PATTERN` finds `@bean.member` **inside one block**, so an `@` in ordinary text (`${mail.from:support@example.com}`) is never read as a bean, and `:#{null}` stays a default.

Only the first access in a chain gets a member reference: resolving the `c` of `#{@a.b.c}` needs the type of `b`, which a flat name index cannot supply, and a reference that never resolves is worse than none.

Offsets come from the raw host text rather than the evaluated string, so they are valid by construction. Searching the host for a key extracted from the *evaluated* value is what produced the invalid `TextRange` of #236; a bean name in a SpEL block is always written out literally, so no search is needed.

## Why not reuse `ExplytBeanReference`

`ExplytBeanReference` is built for an injection point, where the bean name only narrows candidates already filtered by the required type — so when the name matches none of them, `NativeSearchService.findActiveBeanDeclarations` widens to every candidate it found:

```kotlin
val filteredByBeanName = resultByType.filter { byBeanName == it.name }
return filteredByBeanName.map { it.psiMember }.ifEmpty { resultByType.map { it.psiMember } }
```

SpEL carries no type — the name is the whole query — and with `byBeanPsiType = null` that fallback resolved a misspelled `#{@myPropz.cron}` to **every bean in the module**. `SpelBeanReference` resolves strictly by name through `SpringSearchServiceFacade.getAllBeanByNames` instead; `SpelBeanMemberReference` shares the same lookup so both halves of one expression agree on which bean is meant. A test pins this down.

Member resolution follows SpEL's own property accessor order: getter, then public field, then a no-argument method of that name.

## Testing

- `ValueConfigurationPropertyReferenceProviderTest` (+12 tests, Kotlin) — pattern boundaries (whitespace, several beans per block, bean in a placeholder default, `@` outside SpEL, `#{null}`, `T(...)`, `systemProperties[...]`) and resolution for `@Value` and `@Scheduled`, including that an unknown bean resolves to nothing.
- `SpelBeanReferenceTest` (new, 5 tests, Java) — the offsets are taken from the raw injection host, which is a `PsiLiteralExpression` in Java and a `KtStringTemplateExpression` in Kotlin, so an off-by-one is invisible from the Kotlin side alone. Two of the tests assert the reference spans *exactly* the bean and member names.
- The existing `testPureSpelValueHasNoPropertyKey` still passes: `PROPERTIES_PATTERN` is untouched, and SpEL is matched by separate patterns.
- `./gradlew :spring-core:test` green; `lint_files` reports nothing new.

Closes #44