### PR TITLE
fix: Report every handler parameter, not only the annotation-bound ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 - fix: Resolve `MockMvc` and `WebTestClient` autowired in tests as beans provided by test auto-configuration
 - fix: Inject the regular expression of a `@RequestMapping` path built by concatenation into the literal that actually contains it
 
+### Spring MCP
+- fix: Report every handler parameter in `explyt_get_spring_endpoint_contract` and `explyt_get_spring_http_endpoints`, not only the annotation-bound ones: a parameter bound by a custom `HandlerMethodArgumentResolver` was dropped silently, which is indistinguishable from an endpoint that never declared it — the opposite conclusion when the parameter is the one carrying authorization. Each parameter now names its `source` (`PATH`, `QUERY`, `BODY`, `HEADER`, `COOKIE`, `MODEL`, `FRAMEWORK` or `UNKNOWN`), and `required` is null wherever nothing declares it
+
 ### Other
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded (#307)
 - fix: Keep Sentry action breadcrumbs useful by dropping editor typing and caret movement, recording a repeated action once, and trimming a captured report to the actions that led to it

--- a/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
+++ b/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
@@ -35,6 +35,7 @@ import com.intellij.psi.*
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import com.intellij.psi.search.searches.MethodReferencesSearch
+import com.intellij.psi.util.InheritanceUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.VisibleForTesting
@@ -231,7 +232,55 @@ class SpringBootApplicationMcpToolset : McpToolset {
             result += EndpointParameterJson(info.name, "HEADER", info.typeFqn, info.isRequired, info.defaultValue)
         }
 
+        result += parametersOutsideCollectors(psiMethod)
         return result
+    }
+
+    /**
+     * The handler parameters none of the four annotation collectors claims.
+     *
+     * Enumerating only annotated parameters drops everything bound by a `HandlerMethodArgumentResolver`, and a
+     * dropped parameter is indistinguishable from one that was never declared. That is the dangerous half: a
+     * `currentUser` argument absent from the output can mean either "the endpoint authenticates its caller" or
+     * "the endpoint has no authorization at all", and those have opposite meanings for anyone reading the
+     * contract to audit it. Reporting the parameter with a source of `UNKNOWN` says "there is an argument here I
+     * cannot classify", which is actionable; silence is not.
+     */
+    private fun parametersOutsideCollectors(psiMethod: PsiMethod): List<EndpointParameterJson> =
+        psiMethod.parameterList.parameters
+            .filter { param -> COLLECTED_BINDING_ANNOTATIONS.none { param.isMetaAnnotatedBy(it) } }
+            .map { param ->
+                EndpointParameterJson(
+                    name = wireNameOf(param),
+                    source = sourceOfUncollected(param),
+                    type = param.type.canonicalText,
+                    // Not null-by-omission: the four annotations above declare their requiredness, whereas a
+                    // resolver's contract is private to the resolver. Defaulting to `true` or `false` here would
+                    // invent a fact about the wire format, which is the failure this method exists to avoid.
+                    required = null,
+                )
+            }
+
+    /**
+     * The name the client sends, which is not always the Java name: `@CookieValue("sid") String sessionId` is
+     * `sid` on the wire. The four collectors above already report the annotation's name, so reporting the
+     * declared identifier here instead would make one parameter list speak two different vocabularies — and the
+     * wire name is the one a generated client or a test fixture has to use.
+     *
+     * Falls back to the declared name, which is also Spring's own rule when the annotation names nothing.
+     */
+    private fun wireNameOf(param: PsiParameter): String {
+        val annotation = param.findFirstAnnotation(NAMED_BINDING_ANNOTATIONS) ?: return param.name
+        return annotation.getStringAttribute("value")
+            ?: annotation.getStringAttribute(ATTR_NAME)
+            ?: param.name
+    }
+
+    private fun sourceOfUncollected(param: PsiParameter): String = when {
+        param.isMetaAnnotatedBy(SpringWebClasses.COOKIE_VALUE) -> "COOKIE"
+        param.isMetaAnnotatedBy(SpringWebClasses.MODEL_ATTRIBUTE) -> "MODEL"
+        FRAMEWORK_SUPPLIED_TYPES.any { InheritanceUtil.isInheritor(param.type, it) } -> "FRAMEWORK"
+        else -> "UNKNOWN"
     }
 
     // ---- explyt_get_spring_http_endpoints ----
@@ -315,9 +364,15 @@ class SpringBootApplicationMcpToolset : McpToolset {
     @McpTool("explyt_get_spring_endpoint_contract")
     @McpDescription(
         description = "Returns the full API contract for a specific endpoint. " +
-                "Includes HTTP method, full path, all parameters (path variables, query params, request body, headers) " +
-                "with types and required flags, return type, response DTO field schema (recursively expanded up to 3 levels), " +
+                "Includes HTTP method, full path, every declared handler parameter with its type, " +
+                "return type, response DTO field schema (recursively expanded up to 3 levels), " +
                 "produces/consumes media types, and the first service method called from the controller. " +
+                "Each parameter carries a 'source': PATH, QUERY, BODY, HEADER, COOKIE or MODEL for an " +
+                "annotation-bound one (whose 'name' is the wire name, not the Java name, and whose 'required' is " +
+                "declared); FRAMEWORK for one the container supplies, such as WebRequest or Principal; and " +
+                "UNKNOWN for one bound by a custom HandlerMethodArgumentResolver, whose wire format this tool " +
+                "cannot read - inspect the source before treating an UNKNOWN parameter as absent. " +
+                "'required' is null whenever nothing declares it. " +
                 "Use this after explyt_find_spring_endpoint or explyt_get_spring_http_endpoints to deeply inspect a single endpoint."
     )
     suspend fun getEndpointContract(
@@ -804,6 +859,59 @@ class SpringBootApplicationMcpToolset : McpToolset {
         private const val ATTR_UNIQUE = "unique"
         private const val NOT_NULL_SIMPLE_NAME = "NotNull"
 
+        /** The binding annotations the four `SpringWebUtil` collectors in [extractParameters] already report. */
+        private val COLLECTED_BINDING_ANNOTATIONS = listOf(
+            SpringWebClasses.PATH_VARIABLE,
+            SpringWebClasses.REQUEST_PARAM,
+            SpringWebClasses.REQUEST_BODY,
+            SpringWebClasses.REQUEST_HEADER,
+        )
+
+        /** The uncollected annotations that carry a client-visible name of their own. */
+        private val NAMED_BINDING_ANNOTATIONS = listOf(
+            SpringWebClasses.COOKIE_VALUE,
+            SpringWebClasses.MODEL_ATTRIBUTE,
+        )
+
+        /**
+         * Types Spring's own argument resolvers supply from the container rather than from a named place in the
+         * request — the "Method Arguments" table of the Spring MVC reference.
+         *
+         * Deliberately excludes `Pageable`, `Sort` and `HttpEntity`. Those are resolved by Spring too, but they
+         * *do* have a client-visible wire format (`?page=&size=&sort=`, the request body), and calling them
+         * `FRAMEWORK` would tell a reader generating a client that there is nothing to send. Leaving them
+         * `UNKNOWN` errs toward "look at this", which is the safe direction for this tool.
+         *
+         * Matched by inheritance, so `HttpServletRequest` matches `ServletRequest` and `BindingResult` matches
+         * `Errors` without listing every subtype.
+         */
+        private val FRAMEWORK_SUPPLIED_TYPES = listOf(
+            "jakarta.servlet.ServletRequest",
+            "jakarta.servlet.ServletResponse",
+            "jakarta.servlet.http.HttpSession",
+            "jakarta.servlet.http.Part",
+            "javax.servlet.ServletRequest",
+            "javax.servlet.ServletResponse",
+            "javax.servlet.http.HttpSession",
+            "java.security.Principal",
+            "java.util.Locale",
+            "java.util.TimeZone",
+            "java.time.ZoneId",
+            "java.io.InputStream",
+            "java.io.OutputStream",
+            "java.io.Reader",
+            "java.io.Writer",
+            "org.springframework.http.HttpMethod",
+            "org.springframework.ui.Model",
+            "org.springframework.ui.ModelMap",
+            "org.springframework.validation.Errors",
+            "org.springframework.web.context.request.WebRequest",
+            "org.springframework.web.util.UriComponentsBuilder",
+            "org.springframework.web.servlet.mvc.support.RedirectAttributes",
+            "org.springframework.web.bind.support.SessionStatus",
+            "org.springframework.security.core.Authentication",
+        )
+
         private val ENTITY_ANNOTATION_FQNS = JpaClasses.entity.allFqns
         private val TABLE_ANNOTATION_FQNS = JpaClasses.table.allFqns
         private val COLUMN_ANNOTATION_FQNS = JpaClasses.column.allFqns
@@ -881,9 +989,15 @@ data class EndpointListJson(
 
 data class EndpointParameterJson(
     val name: String,
+    /**
+     * Where the value comes from: `PATH`, `QUERY`, `BODY`, `HEADER`, `COOKIE` or `MODEL` for an annotation-bound
+     * parameter, `FRAMEWORK` for one the container supplies, and `UNKNOWN` for one this tool cannot classify —
+     * typically bound by a project-local `HandlerMethodArgumentResolver`.
+     */
     val source: String,
     val type: String,
-    val required: Boolean,
+    /** `null` when nothing declares it, which is every source the tool cannot read the contract of. */
+    val required: Boolean?,
     val defaultValue: String? = null,
 )
 

--- a/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
+++ b/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
@@ -185,6 +185,81 @@ class SpringBootApplicationMcpToolsetTest : ExplytJavaLightTestCase() {
         assertEquals("id", pathParam!!["name"].asText())
     }
 
+    /**
+     * Every handler parameter must appear in the contract, whatever binds it.
+     *
+     * A parameter bound by a custom `HandlerMethodArgumentResolver` carries no binding annotation, so an
+     * enumeration driven purely by annotations dropped it silently — and a dropped parameter is
+     * indistinguishable from one that was never declared. The two have opposite meanings when the parameter is
+     * the one carrying authorization: reading the tool's output alone, an endpoint that authenticates its caller
+     * looks exactly like one that does not.
+     */
+    fun testEndpointContractReportsEveryParameterSource() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val result = toolset.getEndpointContract(
+            urlPattern = "/api/resolver/items/{id}",
+            projectPath = projectPath(),
+            httpMethod = "GET"
+        )
+        val contract = parseArray(result)[0]
+        val parameters = contract["parameters"]
+        val bySource = parameters.associate { it["name"].asText() to it["source"].asText() }
+
+        assertEquals(
+            "Every declared parameter must be reported, whatever binds it",
+            mapOf(
+                "id" to "PATH",
+                "q" to "QUERY",
+                "sid" to "COOKIE",
+                "currentUser" to "UNKNOWN",
+                "webRequest" to "FRAMEWORK",
+                "locale" to "FRAMEWORK",
+            ),
+            bySource
+        )
+    }
+
+    /** The same completeness must hold for the endpoint listing, which shares the parameter enumeration. */
+    fun testHttpEndpointsReportTheResolverBoundParameter() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val result = toolset.getHttpEndpoints(
+            projectPath = projectPath(),
+            controllerFilter = "ResolverController",
+            endpointType = ""
+        )
+        val endpoint = endpointsOf(result).first { it["methodName"].asText() == "getItem" }
+        val names = endpoint["parameters"].map { it["name"].asText() }
+
+        assertTrue(
+            "Expected the resolver-bound 'currentUser' to be listed, got $names",
+            names.contains("currentUser")
+        )
+    }
+
+    /**
+     * An unclassified parameter must not claim a requiredness it cannot know. The four annotation-bound sources
+     * declare it; a resolver's contract is private to the resolver, so `required` stays null rather than
+     * defaulting to a plausible-looking boolean.
+     */
+    fun testUnclassifiedParameterDoesNotAssertRequiredness() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val result = toolset.getEndpointContract(
+            urlPattern = "/api/resolver/items/{id}",
+            projectPath = projectPath(),
+            httpMethod = "GET"
+        )
+        val parameters = parseArray(result)[0]["parameters"]
+
+        val currentUser = parameters.first { it["name"].asText() == "currentUser" }
+        assertTrue("Expected 'required' to be null for a resolver-bound parameter", currentUser["required"].isNull)
+
+        val pathParam = parameters.first { it["name"].asText() == "id" }
+        assertEquals("A @PathVariable still declares its requiredness", true, pathParam["required"].asBoolean())
+    }
+
     fun testTraceCallChainFileNotFoundFails() = runBlocking<Unit> {
         // `traceCallChain` resolves files via `LocalFileSystem` using `project.basePath + filePath`.
         // In a light test fixture, testdata lives in an in-memory temp VFS, so any real path

--- a/modules/spring-ai/testdata/java/mcp/springBootApp/com/example/app/web/CurrentUser.java
+++ b/modules/spring-ai/testdata/java/mcp/springBootApp/com/example/app/web/CurrentUser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2025 Explyt Ltd
+ *
+ * All rights reserved.
+ *
+ * This code and software are the property of Explyt Ltd and are protected by copyright and other intellectual property laws.
+ *
+ * You may use this code under the terms of the Explyt Source License Version 1.0 ("License"), if you accept its terms and conditions.
+ *
+ * By installing, downloading, accessing, using, or distributing this code, you agree to the terms and conditions of the License.
+ * If you do not agree to such terms and conditions, you must cease using this code and immediately delete all copies of it.
+ *
+ * You may obtain a copy of the License at: https://github.com/explyt/spring-plugin/blob/main/EXPLYT-SOURCE-LICENSE.md
+ *
+ * Unauthorized use of this code constitutes a violation of intellectual property rights and may result in legal action.
+ */
+
+package com.example.app.web;
+
+/** The authenticated caller, bound by a project-local {@code HandlerMethodArgumentResolver}. */
+public class CurrentUser {
+
+    private final String login;
+
+    public CurrentUser(String login) {
+        this.login = login;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+}

--- a/modules/spring-ai/testdata/java/mcp/springBootApp/com/example/app/web/ResolverController.java
+++ b/modules/spring-ai/testdata/java/mcp/springBootApp/com/example/app/web/ResolverController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2025 Explyt Ltd
+ *
+ * All rights reserved.
+ *
+ * This code and software are the property of Explyt Ltd and are protected by copyright and other intellectual property laws.
+ *
+ * You may use this code under the terms of the Explyt Source License Version 1.0 ("License"), if you accept its terms and conditions.
+ *
+ * By installing, downloading, accessing, using, or distributing this code, you agree to the terms and conditions of the License.
+ * If you do not agree to such terms and conditions, you must cease using this code and immediately delete all copies of it.
+ *
+ * You may obtain a copy of the License at: https://github.com/explyt/spring-plugin/blob/main/EXPLYT-SOURCE-LICENSE.md
+ *
+ * Unauthorized use of this code constitutes a violation of intellectual property rights and may result in legal action.
+ */
+
+package com.example.app.web;
+
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Locale;
+
+/**
+ * A handler whose signature mixes the four annotation-bound sources with a parameter Spring injects
+ * itself and one bound by a custom {@code HandlerMethodArgumentResolver}.
+ *
+ * The last kind is the point of the fixture: it carries no binding annotation, so an enumeration
+ * driven purely by annotations drops it, and a dropped parameter is indistinguishable from an absent
+ * one — which matters most for exactly the parameter that carries authorization.
+ */
+@RestController
+@RequestMapping("/api/resolver")
+public class ResolverController {
+
+    @GetMapping("/items/{id}")
+    public String getItem(
+            @PathVariable("id") Long id,
+            @RequestParam(value = "q", required = false) String query,
+            @CookieValue("sid") String sessionId,
+            CurrentUser currentUser,
+            WebRequest webRequest,
+            Locale locale
+    ) {
+        return id + query + sessionId + currentUser + webRequest + locale;
+    }
+}


### PR DESCRIPTION
## Problem

`extractParameters` enumerated four annotations — `@PathVariable`, `@RequestParam`, `@RequestBody`, `@RequestHeader` — and returned nothing for anything else. A parameter bound by a custom `HandlerMethodArgumentResolver` vanished, with no marker that the list was incomplete. `@CookieValue` and `@ModelAttribute` were dropped the same way, and those are plainly client-visible.

Measured on a real project: `ProjectSuccessMetricsController.metric1` declares 11 parameters and the tool reported 9, dropping `@OpaqueRequestParam("teams") teams` — a query parameter whose custom annotation exists *precisely* to avoid Spring's comma-splitting, so `?teams=QA&teams=Platform` disappeared from the contract entirely.

## Why this is a correctness bug and not a cosmetic gap

The omission is **indistinguishable from a true negative**, and the two cases have opposite meanings:

| Handler | `currentUser` in output | Reality |
|---|---|---|
| `ProjectSuccessIndividualSuccessController.users` | absent | **present** — the endpoint's entire authorization hangs on it |
| `ProjectSuccessDrilldownTasksController.downloadTrace` | absent | **genuinely absent** — no authorization at all |

An agent auditing authorization from the tool's output would clear the unprotected endpoint and flag the protected one. That removes most of the tool's value for exactly the review task it looks best suited to.

## Approach

Enumerate every declared parameter; classify what the collectors do not claim:

| `source` | Meaning |
|---|---|
| `PATH` / `QUERY` / `BODY` / `HEADER` | unchanged, from the four collectors |
| `COOKIE` / `MODEL` | `@CookieValue` / `@ModelAttribute`, previously dropped |
| `FRAMEWORK` | the container supplies it — `WebRequest`, `Principal`, `Locale`, `Errors`, … (matched by inheritance, so `HttpServletRequest` matches `ServletRequest`) |
| `UNKNOWN` | bound by something the tool cannot identify, typically a project-local resolver |

`UNKNOWN` is the point: *"there is an argument here I cannot classify"* is actionable; silence is not.

**`FRAMEWORK` deliberately excludes `Pageable`, `Sort` and `HttpEntity`.** Spring resolves those too, but they have a client-visible wire format (`?page=&size=&sort=`, the body), and calling them framework-supplied would tell a client generator there is nothing to send. Leaving them `UNKNOWN` errs toward "look at this", which is the safe direction for this tool.

**`required` becomes nullable** rather than defaulting. The four annotations declare requiredness; a resolver's contract is private to it, so asserting `true` or `false` would invent a fact about the wire format — the same wrong-but-plausible output this PR removes.

**An uncollected parameter reports its wire name**, not its Java name: `@CookieValue("sid") String sessionId` is `sid` to a client, and the collectors already report the annotation's name, so doing otherwise would make one list speak two vocabularies.

The tool description now states what each source means and that an `UNKNOWN` parameter must be checked against the source — that description is all a calling agent has to calibrate trust.

## Not in this PR

Naming the resolving class (`source: "RESOLVER"` with the class) needs static evaluation of `supportsParameter`, and a wrongly-named resolver would reproduce the wrong-but-plausible failure this PR fixes. `UNKNOWN` is honest today; naming the resolver can be added on top without changing the contract.

## Testing

- 3 new tests over a fixture handler mixing all four annotation sources with `@CookieValue`, a resolver-bound `CurrentUser`, `WebRequest` and `Locale`: full source map, presence in the endpoint *listing* (which shares the enumeration), and that `required` stays null for an unclassified parameter while `@PathVariable` still declares it.
- Written first and confirmed failing for the right reason — the initial red run showed `currentUser` simply absent from the map.
- `./gradlew :spring-ai:test` green: 30 tests, 0 failures. The 24 pre-existing tests were unaffected by the new fixture controller.
- `lint_files` reports nothing new.

Reported internally; no GitHub issue to close.