### PR TITLE
feat: Let the endpoint listing be narrowed to fit a context window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
 
 ### Spring MCP
 - fix: Report every handler parameter in `explyt_get_spring_endpoint_contract` and `explyt_get_spring_http_endpoints`, not only the annotation-bound ones: a parameter bound by a custom `HandlerMethodArgumentResolver` was dropped silently, which is indistinguishable from an endpoint that never declared it — the opposite conclusion when the parameter is the one carrying authorization. Each parameter now names its `source` (`PATH`, `QUERY`, `BODY`, `HEADER`, `COOKIE`, `MODEL`, `FRAMEWORK` or `UNKNOWN`), and `required` is null wherever nothing declares it
+- feat: Add `compact` to `explyt_get_spring_http_endpoints`, omitting the `parameters` and `returnType` of each endpoint — they dominate the response, which on a 136-endpoint project reached 122 KB of single-line JSON that a line-based reader cannot chunk, and the controller/type filters cannot narrow it in the situation the tool is first called for: not yet knowing which controllers exist
+- fix: Describe the endpoint listing with the field names it actually returns, and show one complete example object: the description said "HTTP method, full path, line number" while the keys are `httpMethods` (an array), `fullPath` and `line`, so a first parse written against the prose silently yielded empty rows instead of failing
 
 ### Other
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded (#307)

--- a/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
+++ b/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
@@ -191,7 +191,7 @@ class SpringBootApplicationMcpToolset : McpToolset {
         return false
     }
 
-    private fun toEndpointJson(endpoint: EndpointElement, project: Project): EndpointJson {
+    private fun toCompactEndpointJson(endpoint: EndpointElement, project: Project): CompactEndpointJson {
         val psiMethod = endpoint.psiElement as? PsiMethod
         val controllerClass = endpoint.containingClass ?: psiMethod?.containingClass
         val position = sourcePositionOf(endpoint.psiElement, project)
@@ -199,19 +199,31 @@ class SpringBootApplicationMcpToolset : McpToolset {
         val filePath = position.filePath
             ?: endpoint.containingFile?.let { relativePathOf(it, project) }
 
-        val parameters = if (psiMethod != null) extractParameters(psiMethod) else emptyList()
-        val returnType = psiMethod?.returnType?.canonicalText
-
-        return EndpointJson(
+        return CompactEndpointJson(
             httpMethods = endpoint.requestMethods.ifEmpty { listOf("ALL") },
             fullPath = endpoint.path,
             controllerClass = controllerClass?.qualifiedName,
             methodName = psiMethod?.name,
             filePath = filePath,
             line = position.line,
-            parameters = parameters,
-            returnType = returnType,
             endpointType = endpoint.type.readable,
+        )
+    }
+
+    private fun toEndpointJson(endpoint: EndpointElement, project: Project): EndpointJson {
+        val psiMethod = endpoint.psiElement as? PsiMethod
+        val core = toCompactEndpointJson(endpoint, project)
+
+        return EndpointJson(
+            httpMethods = core.httpMethods,
+            fullPath = core.fullPath,
+            controllerClass = core.controllerClass,
+            methodName = core.methodName,
+            filePath = core.filePath,
+            line = core.line,
+            parameters = if (psiMethod != null) extractParameters(psiMethod) else emptyList(),
+            returnType = psiMethod?.returnType?.canonicalText,
+            endpointType = core.endpointType,
         )
     }
 
@@ -289,10 +301,18 @@ class SpringBootApplicationMcpToolset : McpToolset {
     @McpDescription(
         description = "Lists all HTTP endpoints in the project. " +
                 "Covers Spring MVC, WebFlux, JAX-RS, HttpExchange, OpenFeign, and Spring Boot actuator endpoints. " +
-                "Returns an object: 'endpoints' is the array (each entry has the HTTP method, full path, " +
-                "controller class, method name, return type, file path, line number, and endpoint type), " +
-                "'totalCount' is how many endpoints matched the filters, 'offset' is the index the returned page " +
-                "starts at, and 'truncated' is true when more matches remain after this page. " +
+                "Returns an object with 'totalCount' (how many endpoints matched the filters), 'offset' (the index " +
+                "the returned page starts at), 'truncated' (true when more matches remain after this page), and " +
+                "'endpoints'. One endpoint looks exactly like this - note 'httpMethods' is an array, and the keys " +
+                "are 'fullPath' and 'line', not 'path' or 'lineNumber': " +
+                "{\"httpMethods\":[\"GET\"],\"fullPath\":\"/api/demo/items/{id}\"," +
+                "\"controllerClass\":\"com.example.app.web.DemoController\",\"methodName\":\"getItem\"," +
+                "\"filePath\":\"src/main/java/com/example/app/web/DemoController.java\",\"line\":40," +
+                "\"parameters\":[{\"name\":\"id\",\"source\":\"PATH\",\"type\":\"java.lang.Long\"," +
+                "\"required\":true,\"defaultValue\":null}],\"returnType\":\"com.example.app.dto.DemoDto\"," +
+                "\"endpointType\":\"SPRING_MVC\"}. " +
+                "Pass compact=true to omit 'parameters' and 'returnType' entirely - they dominate the response, " +
+                "and on a large project the full form can exceed 100 KB on a single line. " +
                 "When 'truncated' is true, either narrow the result with the controller or endpoint-type filters, " +
                 "or request the next page with 'offset' = 'offset' + number of returned endpoints. " +
                 "Use optional filters to narrow results by controller class name or endpoint type."
@@ -314,6 +334,12 @@ class SpringBootApplicationMcpToolset : McpToolset {
                     "capped at $MAX_ENDPOINT_LIST_RESULTS."
         )
         limit: Int = DEFAULT_ENDPOINT_PAGE_SIZE,
+        @McpDescription(
+            "Omit 'parameters' and 'returnType' from each endpoint. Use this for a first inventory of a project " +
+                    "you do not know yet: those two fields dominate the response, and the controller/type " +
+                    "filters cannot narrow it before you know which controllers exist. Defaults to false."
+        )
+        compact: Boolean = false,
     ): String {
         val project = getCurrentProject(projectPath) ?: mcpFail("project not found")
         val controllerSubstring = controllerFilter.trim().takeIf { it.isNotEmpty() }
@@ -338,14 +364,17 @@ class SpringBootApplicationMcpToolset : McpToolset {
 
                 // Convert only the requested page: building an EndpointJson resolves PSI (module, line number,
                 // parameters), which is far too expensive to do for every endpoint of a large project.
-                val endpoints = matching.asSequence()
+                // 'compact' also skips the parameter extraction itself, so it is cheaper to compute and not
+                // merely smaller to send.
+                val page = matching.asSequence()
                     .drop(pageStart)
                     .take(pageSize)
-                    .map {
-                        ProgressManager.checkCanceled()
-                        toEndpointJson(it, project)
-                    }
-                    .toList()
+                    .onEach { ProgressManager.checkCanceled() }
+                val endpoints: List<Any> = if (compact) {
+                    page.map { toCompactEndpointJson(it, project) }.toList()
+                } else {
+                    page.map { toEndpointJson(it, project) }.toList()
+                }
 
                 EndpointListJson(
                     totalCount = matching.size,
@@ -980,11 +1009,29 @@ data class EndpointJson(
     val endpointType: String,
 )
 
-data class EndpointListJson(
+/**
+ * One endpoint without its per-method signature, for the `compact` listing.
+ *
+ * Not [EndpointJson] with nulled-out fields: the two arrays are *absent* rather than empty, so a caller cannot
+ * mistake a projection for an endpoint that genuinely takes no parameters — the same absent-versus-empty
+ * confusion that made a dropped parameter unreadable before.
+ */
+data class CompactEndpointJson(
+    val httpMethods: List<String>,
+    val fullPath: String,
+    val controllerClass: String?,
+    val methodName: String?,
+    val filePath: String?,
+    /** `null` when the endpoint element has no physical declaration to point at. */
+    val line: Int?,
+    val endpointType: String,
+)
+
+data class EndpointListJson<T>(
     val totalCount: Int,
     val offset: Int,
     val truncated: Boolean,
-    val endpoints: List<EndpointJson>,
+    val endpoints: List<T>,
 )
 
 data class EndpointParameterJson(

--- a/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
+++ b/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
@@ -260,6 +260,91 @@ class SpringBootApplicationMcpToolsetTest : ExplytJavaLightTestCase() {
         assertEquals("A @PathVariable still declares its requiredness", true, pathParam["required"].asBoolean())
     }
 
+    /**
+     * The listing is the tool called *first*, before the caller knows which controllers exist — exactly when the
+     * `controllerFilter` / `endpointType` filters cannot help. On a real project it returned 136 endpoints as
+     * 122 722 characters of single-line JSON, most of it `parameters` arrays, which a line-based reader cannot
+     * chunk. `compact` drops the two per-endpoint arrays so an inventory fits in a context window.
+     */
+    fun testCompactListingOmitsParametersAndReturnType() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val endpoint = endpointsOf(
+            toolset.getHttpEndpoints(
+                projectPath = projectPath(),
+                controllerFilter = "ResolverController",
+                endpointType = "",
+                compact = true
+            )
+        ).first { it["methodName"].asText() == "getItem" }
+
+        assertFalse("compact must omit 'parameters', got $endpoint", endpoint.has("parameters"))
+        assertFalse("compact must omit 'returnType', got $endpoint", endpoint.has("returnType"))
+        // Everything an inventory needs is still there.
+        assertEquals("/api/resolver/items/{id}", endpoint["fullPath"].asText())
+        assertEquals("com.example.app.web.ResolverController", endpoint["controllerClass"].asText())
+        assertTrue("Expected a line number in $endpoint", endpoint["line"].isInt)
+    }
+
+    /** The default stays whole: `compact` is opt-in, so an existing caller sees no change. */
+    fun testDefaultListingKeepsParametersAndReturnType() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val endpoint = endpointsOf(
+            toolset.getHttpEndpoints(
+                projectPath = projectPath(),
+                controllerFilter = "ResolverController",
+                endpointType = ""
+            )
+        ).first { it["methodName"].asText() == "getItem" }
+
+        assertTrue("The default listing must keep 'parameters', got $endpoint", endpoint.has("parameters"))
+        assertTrue("The default listing must keep 'returnType', got $endpoint", endpoint.has("returnType"))
+    }
+
+    /** Paging metadata describes the page, not the projection, so it must survive `compact`. */
+    fun testCompactListingKeepsPagingMetadata() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val root = mapper.readTree(
+            toolset.getHttpEndpoints(
+                projectPath = projectPath(),
+                controllerFilter = "",
+                endpointType = "",
+                compact = true
+            )
+        )
+
+        assertEquals("totalCount must match the returned page for a small fixture",
+            root["endpoints"].size(), root["totalCount"].asInt())
+        assertEquals(0, root["offset"].asInt())
+        assertEquals(false, root["truncated"].asBoolean())
+    }
+
+    /**
+     * The response field names are part of the tool's contract, and a mismatch between them and the description
+     * is not cosmetic: a first parse written against `httpMethod` / `path` / `lineNumber` yields silent nulls
+     * rather than an error, costing a whole call to notice. This pins the names the description promises.
+     */
+    fun testListingFieldNamesMatchTheDocumentedContract() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val endpoint = endpointsOf(
+            toolset.getHttpEndpoints(projectPath = projectPath(), controllerFilter = "DemoController", endpointType = "")
+        ).first()
+
+        val names = endpoint.fieldNames().asSequence().toSet()
+        assertEquals(
+            "Endpoint field names drifted from the documented contract",
+            setOf(
+                "httpMethods", "fullPath", "controllerClass", "methodName",
+                "filePath", "line", "parameters", "returnType", "endpointType",
+            ),
+            names
+        )
+        assertTrue("'httpMethods' is an array, not a scalar", endpoint["httpMethods"].isArray)
+    }
+
     fun testTraceCallChainFileNotFoundFails() = runBlocking<Unit> {
         // `traceCallChain` resolves files via `LocalFileSystem` using `project.basePath + filePath`.
         // In a light test fixture, testdata lives in an in-memory temp VFS, so any real path


### PR DESCRIPTION
## Problem

`explyt_get_spring_http_endpoints` had no way to return less per endpoint. On a 136-endpoint project it answered with **122 722 characters of JSON on a single line**. The harness spilled that to a file and suggested reading it in chunks — but a single-line document cannot be chunked by a line-based reader, so it took an external `json.loads` round trip to read at all.

Roughly nine tenths of the volume is the `parameters` arrays.

**Filtering is not a workaround.** The existing `controllerFilter` / `endpointType` filters cannot help in the situation the tool is *first* called for — "I do not yet know which controllers exist." An independent run that did filter (`controllerFilter=ProjectSuccess`) still returned ~70 KB and still had to be script-parsed, because the per-endpoint expansion dominates however few endpoints match. The missing feature is a projection, not a filter.

This also got worse with #343: now that every handler parameter is reported rather than only the annotated ones, the full form is larger still.

## Approach

`compact=true` omits `parameters` and `returnType`.

They are **absent rather than empty**, via a separate `CompactEndpointJson` rather than `EndpointJson` with nulled-out fields — so a caller cannot mistake the projection for an endpoint that genuinely takes no parameters. That is the same absent-versus-empty confusion that made a dropped parameter unreadable before #343, and it would be a shame to reintroduce it in the fix for the volume.

`compact` also **skips the parameter extraction itself**, so it is cheaper to compute and not merely smaller to send. The existing comment on that block already notes that building an `EndpointJson` resolves PSI and is "far too expensive to do for every endpoint of a large project" — compact avoids most of that work.

`toEndpointJson` now delegates to `toCompactEndpointJson` for the shared fields, so the two shapes cannot drift.

## Description / payload mismatch

Second, smaller defect from the same report. The description said *"the HTTP method, full path, … line number"* while the keys are `httpMethods` (an **array**), `fullPath` and `line`. A first parse written against the prose produces silent `None None` rows rather than an error, which costs a whole call to notice.

The description now carries **one complete example object** — cheaper to read correctly than any amount of prose — and `testListingFieldNamesMatchTheDocumentedContract` pins the exact field-name set so the two cannot drift apart again.

## Testing

- 4 new tests: `compact` omits both fields while keeping path/controller/line; the default still includes them (the flag is opt-in, so existing callers see no change); paging metadata survives the projection; and the field-name contract matches the documented example.
- Written first and confirmed failing — the red run was a compile failure on the not-yet-existing `compact` parameter.
- `./gradlew :spring-ai:test` green: 34 tests, 0 failures, all 4 new ones confirmed executed in the JUnit XML.
- `lint_files` reports nothing new.

Reported internally; no GitHub issue to close.