### PR TITLE
fix: Keep the feedback nudge on screen and trigger it on engagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Spring Core
 - fix: Keep the one-time feedback nudge on screen until it is acted on, show it right after the engagement threshold is crossed instead of during IDE startup, and let installs that predate the nudge qualify from their existing usage instead of starting from zero
+- fix: Persist the local usage counters across IDE restarts — they were updated through `Map.compute`, which the platform's stored map does not count as a modification, so the state was never saved
 - fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
 - fix: Look up a configuration key in the metadata catalogue through an index instead of scanning it: validating a `.properties`/`.yaml` file re-normalised every one of the thousands of catalogue names for every key in the file, on every highlighting pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Spring Core
+- fix: Keep the one-time feedback nudge on screen until it is acted on, show it right after the engagement threshold is crossed instead of during IDE startup, and let installs that predate the nudge qualify from their existing usage instead of starting from zero
 - fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
 - fix: Look up a configuration key in the metadata catalogue through an index instead of scanning it: validating a `.properties`/`.yaml` file re-normalised every one of the thousands of catalogue names for every key in the file, on every highlighting pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
 
 ### Spring MCP
 - fix: Report every handler parameter in `explyt_get_spring_endpoint_contract` and `explyt_get_spring_http_endpoints`, not only the annotation-bound ones: a parameter bound by a custom `HandlerMethodArgumentResolver` was dropped silently, which is indistinguishable from an endpoint that never declared it — the opposite conclusion when the parameter is the one carrying authorization. Each parameter now names its `source` (`PATH`, `QUERY`, `BODY`, `HEADER`, `COOKIE`, `MODEL`, `FRAMEWORK` or `UNKNOWN`), and `required` is null wherever nothing declares it
+- feat: Add `compact` to `explyt_get_spring_http_endpoints`, omitting the `parameters` and `returnType` of each endpoint — they dominate the response, which on a 136-endpoint project reached 122 KB of single-line JSON that a line-based reader cannot chunk, and the controller/type filters cannot narrow it in the situation the tool is first called for: not yet knowing which controllers exist
+- fix: Describe the endpoint listing with the field names it actually returns, and show one complete example object: the description said "HTTP method, full path, line number" while the keys are `httpMethods` (an array), `fullPath` and `line`, so a first parse written against the prose silently yielded empty rows instead of failing
 
 ### Other
 - fix: Do not freeze the UI on the first action after the IDE starts: error-reporting setup no longer runs while an action is being recorded (#307)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Spring Core
 - fix: Keep the one-time feedback nudge on screen until it is acted on, show it right after the engagement threshold is crossed instead of during IDE startup, and let installs that predate the nudge qualify from their existing usage instead of starting from zero
-- fix: Persist the local usage counters across IDE restarts — they were updated through `Map.compute`, which the platform's stored map does not count as a modification, so the state was never saved; the counters also opt out of the platform's five-minute save threshold, which silently dropped every session shorter than that
+- fix: Persist the local usage counters across IDE restarts — they were updated through `Map.compute`, which the platform's stored map does not count as a modification, so the state was never saved; they now live in a local, non-synced options file instead of the cache-file storage, which is saved at most once every five minutes, never forced on exit, and on 2026.2 kept in the opaque internal settings database
 - fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
 - fix: Look up a configuration key in the metadata catalogue through an index instead of scanning it: validating a `.properties`/`.yaml` file re-normalised every one of the thousands of catalogue names for every key in the file, on every highlighting pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Spring Core
 - fix: Keep the one-time feedback nudge on screen until it is acted on, show it right after the engagement threshold is crossed instead of during IDE startup, and let installs that predate the nudge qualify from their existing usage instead of starting from zero
-- fix: Persist the local usage counters across IDE restarts — they were updated through `Map.compute`, which the platform's stored map does not count as a modification, so the state was never saved
+- fix: Persist the local usage counters across IDE restarts — they were updated through `Map.compute`, which the platform's stored map does not count as a modification, so the state was never saved; the counters also opt out of the platform's five-minute save threshold, which silently dropped every session shorter than that
 - fix: Fold a `@Value` placeholder and an `Environment.getProperty` key to the value of the profile-less `application.*` file instead of an arbitrary one, and name the profile when the value comes only from `application-<profile>.*`
 - fix: Cache the `@PropertySource` lookup that decides whether a file is Spring configuration, so highlighting an unrelated `.properties`/`.yaml` file no longer runs a project-wide index search per PSI element
 - fix: Look up a configuration key in the metadata catalogue through an index instead of scanning it: validating a `.properties`/`.yaml` file re-normalised every one of the thousands of catalogue names for every key in the file, on every highlighting pass

--- a/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
+++ b/modules/spring-ai/src/main/kotlin/com/explyt/spring/ai/mcp/SpringMcpProvider.kt
@@ -191,7 +191,7 @@ class SpringBootApplicationMcpToolset : McpToolset {
         return false
     }
 
-    private fun toEndpointJson(endpoint: EndpointElement, project: Project): EndpointJson {
+    private fun toCompactEndpointJson(endpoint: EndpointElement, project: Project): CompactEndpointJson {
         val psiMethod = endpoint.psiElement as? PsiMethod
         val controllerClass = endpoint.containingClass ?: psiMethod?.containingClass
         val position = sourcePositionOf(endpoint.psiElement, project)
@@ -199,19 +199,31 @@ class SpringBootApplicationMcpToolset : McpToolset {
         val filePath = position.filePath
             ?: endpoint.containingFile?.let { relativePathOf(it, project) }
 
-        val parameters = if (psiMethod != null) extractParameters(psiMethod) else emptyList()
-        val returnType = psiMethod?.returnType?.canonicalText
-
-        return EndpointJson(
+        return CompactEndpointJson(
             httpMethods = endpoint.requestMethods.ifEmpty { listOf("ALL") },
             fullPath = endpoint.path,
             controllerClass = controllerClass?.qualifiedName,
             methodName = psiMethod?.name,
             filePath = filePath,
             line = position.line,
-            parameters = parameters,
-            returnType = returnType,
             endpointType = endpoint.type.readable,
+        )
+    }
+
+    private fun toEndpointJson(endpoint: EndpointElement, project: Project): EndpointJson {
+        val psiMethod = endpoint.psiElement as? PsiMethod
+        val core = toCompactEndpointJson(endpoint, project)
+
+        return EndpointJson(
+            httpMethods = core.httpMethods,
+            fullPath = core.fullPath,
+            controllerClass = core.controllerClass,
+            methodName = core.methodName,
+            filePath = core.filePath,
+            line = core.line,
+            parameters = if (psiMethod != null) extractParameters(psiMethod) else emptyList(),
+            returnType = psiMethod?.returnType?.canonicalText,
+            endpointType = core.endpointType,
         )
     }
 
@@ -289,10 +301,18 @@ class SpringBootApplicationMcpToolset : McpToolset {
     @McpDescription(
         description = "Lists all HTTP endpoints in the project. " +
                 "Covers Spring MVC, WebFlux, JAX-RS, HttpExchange, OpenFeign, and Spring Boot actuator endpoints. " +
-                "Returns an object: 'endpoints' is the array (each entry has the HTTP method, full path, " +
-                "controller class, method name, return type, file path, line number, and endpoint type), " +
-                "'totalCount' is how many endpoints matched the filters, 'offset' is the index the returned page " +
-                "starts at, and 'truncated' is true when more matches remain after this page. " +
+                "Returns an object with 'totalCount' (how many endpoints matched the filters), 'offset' (the index " +
+                "the returned page starts at), 'truncated' (true when more matches remain after this page), and " +
+                "'endpoints'. One endpoint looks exactly like this - note 'httpMethods' is an array, and the keys " +
+                "are 'fullPath' and 'line', not 'path' or 'lineNumber': " +
+                "{\"httpMethods\":[\"GET\"],\"fullPath\":\"/api/demo/items/{id}\"," +
+                "\"controllerClass\":\"com.example.app.web.DemoController\",\"methodName\":\"getItem\"," +
+                "\"filePath\":\"src/main/java/com/example/app/web/DemoController.java\",\"line\":40," +
+                "\"parameters\":[{\"name\":\"id\",\"source\":\"PATH\",\"type\":\"java.lang.Long\"," +
+                "\"required\":true,\"defaultValue\":null}],\"returnType\":\"com.example.app.dto.DemoDto\"," +
+                "\"endpointType\":\"SPRING_MVC\"}. " +
+                "Pass compact=true to omit 'parameters' and 'returnType' entirely - they dominate the response, " +
+                "and on a large project the full form can exceed 100 KB on a single line. " +
                 "When 'truncated' is true, either narrow the result with the controller or endpoint-type filters, " +
                 "or request the next page with 'offset' = 'offset' + number of returned endpoints. " +
                 "Use optional filters to narrow results by controller class name or endpoint type."
@@ -314,6 +334,12 @@ class SpringBootApplicationMcpToolset : McpToolset {
                     "capped at $MAX_ENDPOINT_LIST_RESULTS."
         )
         limit: Int = DEFAULT_ENDPOINT_PAGE_SIZE,
+        @McpDescription(
+            "Omit 'parameters' and 'returnType' from each endpoint. Use this for a first inventory of a project " +
+                    "you do not know yet: those two fields dominate the response, and the controller/type " +
+                    "filters cannot narrow it before you know which controllers exist. Defaults to false."
+        )
+        compact: Boolean = false,
     ): String {
         val project = getCurrentProject(projectPath) ?: mcpFail("project not found")
         val controllerSubstring = controllerFilter.trim().takeIf { it.isNotEmpty() }
@@ -338,14 +364,17 @@ class SpringBootApplicationMcpToolset : McpToolset {
 
                 // Convert only the requested page: building an EndpointJson resolves PSI (module, line number,
                 // parameters), which is far too expensive to do for every endpoint of a large project.
-                val endpoints = matching.asSequence()
+                // 'compact' also skips the parameter extraction itself, so it is cheaper to compute and not
+                // merely smaller to send.
+                val page = matching.asSequence()
                     .drop(pageStart)
                     .take(pageSize)
-                    .map {
-                        ProgressManager.checkCanceled()
-                        toEndpointJson(it, project)
-                    }
-                    .toList()
+                    .onEach { ProgressManager.checkCanceled() }
+                val endpoints: List<Any> = if (compact) {
+                    page.map { toCompactEndpointJson(it, project) }.toList()
+                } else {
+                    page.map { toEndpointJson(it, project) }.toList()
+                }
 
                 EndpointListJson(
                     totalCount = matching.size,
@@ -980,11 +1009,29 @@ data class EndpointJson(
     val endpointType: String,
 )
 
-data class EndpointListJson(
+/**
+ * One endpoint without its per-method signature, for the `compact` listing.
+ *
+ * Not [EndpointJson] with nulled-out fields: the two arrays are *absent* rather than empty, so a caller cannot
+ * mistake a projection for an endpoint that genuinely takes no parameters — the same absent-versus-empty
+ * confusion that made a dropped parameter unreadable before.
+ */
+data class CompactEndpointJson(
+    val httpMethods: List<String>,
+    val fullPath: String,
+    val controllerClass: String?,
+    val methodName: String?,
+    val filePath: String?,
+    /** `null` when the endpoint element has no physical declaration to point at. */
+    val line: Int?,
+    val endpointType: String,
+)
+
+data class EndpointListJson<T>(
     val totalCount: Int,
     val offset: Int,
     val truncated: Boolean,
-    val endpoints: List<EndpointJson>,
+    val endpoints: List<T>,
 )
 
 data class EndpointParameterJson(

--- a/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
+++ b/modules/spring-ai/src/test/kotlin/com/explyt/spring/ai/mcp/SpringBootApplicationMcpToolsetTest.kt
@@ -260,6 +260,91 @@ class SpringBootApplicationMcpToolsetTest : ExplytJavaLightTestCase() {
         assertEquals("A @PathVariable still declares its requiredness", true, pathParam["required"].asBoolean())
     }
 
+    /**
+     * The listing is the tool called *first*, before the caller knows which controllers exist — exactly when the
+     * `controllerFilter` / `endpointType` filters cannot help. On a real project it returned 136 endpoints as
+     * 122 722 characters of single-line JSON, most of it `parameters` arrays, which a line-based reader cannot
+     * chunk. `compact` drops the two per-endpoint arrays so an inventory fits in a context window.
+     */
+    fun testCompactListingOmitsParametersAndReturnType() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val endpoint = endpointsOf(
+            toolset.getHttpEndpoints(
+                projectPath = projectPath(),
+                controllerFilter = "ResolverController",
+                endpointType = "",
+                compact = true
+            )
+        ).first { it["methodName"].asText() == "getItem" }
+
+        assertFalse("compact must omit 'parameters', got $endpoint", endpoint.has("parameters"))
+        assertFalse("compact must omit 'returnType', got $endpoint", endpoint.has("returnType"))
+        // Everything an inventory needs is still there.
+        assertEquals("/api/resolver/items/{id}", endpoint["fullPath"].asText())
+        assertEquals("com.example.app.web.ResolverController", endpoint["controllerClass"].asText())
+        assertTrue("Expected a line number in $endpoint", endpoint["line"].isInt)
+    }
+
+    /** The default stays whole: `compact` is opt-in, so an existing caller sees no change. */
+    fun testDefaultListingKeepsParametersAndReturnType() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val endpoint = endpointsOf(
+            toolset.getHttpEndpoints(
+                projectPath = projectPath(),
+                controllerFilter = "ResolverController",
+                endpointType = ""
+            )
+        ).first { it["methodName"].asText() == "getItem" }
+
+        assertTrue("The default listing must keep 'parameters', got $endpoint", endpoint.has("parameters"))
+        assertTrue("The default listing must keep 'returnType', got $endpoint", endpoint.has("returnType"))
+    }
+
+    /** Paging metadata describes the page, not the projection, so it must survive `compact`. */
+    fun testCompactListingKeepsPagingMetadata() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val root = mapper.readTree(
+            toolset.getHttpEndpoints(
+                projectPath = projectPath(),
+                controllerFilter = "",
+                endpointType = "",
+                compact = true
+            )
+        )
+
+        assertEquals("totalCount must match the returned page for a small fixture",
+            root["endpoints"].size(), root["totalCount"].asInt())
+        assertEquals(0, root["offset"].asInt())
+        assertEquals(false, root["truncated"].asBoolean())
+    }
+
+    /**
+     * The response field names are part of the tool's contract, and a mismatch between them and the description
+     * is not cosmetic: a first parse written against `httpMethod` / `path` / `lineNumber` yields silent nulls
+     * rather than an error, costing a whole call to notice. This pins the names the description promises.
+     */
+    fun testListingFieldNamesMatchTheDocumentedContract() = runBlocking<Unit> {
+        myFixture.copyDirectoryToProject("springBootApp", "")
+
+        val endpoint = endpointsOf(
+            toolset.getHttpEndpoints(projectPath = projectPath(), controllerFilter = "DemoController", endpointType = "")
+        ).first()
+
+        val names = endpoint.fieldNames().asSequence().toSet()
+        assertEquals(
+            "Endpoint field names drifted from the documented contract",
+            setOf(
+                "httpMethods", "fullPath", "controllerClass", "methodName",
+                "filePath", "line", "parameters", "returnType", "endpointType",
+            ),
+            names
+        )
+        assertTrue("'httpMethods' is an array, not a scalar", endpoint["httpMethods"].isArray)
+    }
+
     fun testTraceCallChainFileNotFoundFails() = runBlocking<Unit> {
         // `traceCallChain` resolves files via `LocalFileSystem` using `project.basePath + filePath`.
         // In a light test fixture, testdata lives in an in-memory temp VFS, so any real path

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/notifications/SpringFeedbackNotificationGroup.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/notifications/SpringFeedbackNotificationGroup.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.notifications
+
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+
+/**
+ * Sticky group for the one-time feedback nudge.
+ *
+ * A regular `BALLOON` group expires after ten seconds; the nudge is shown once per installation, so it must stay
+ * on screen until the user acts on it or closes it.
+ */
+val SpringFeedbackNotificationGroup: NotificationGroup by lazy {
+    NotificationGroupManager.getInstance().getNotificationGroup("com.explyt.spring.feedback")
+}

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecision.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecision.kt
@@ -5,6 +5,8 @@
 
 package com.explyt.spring.core.statistic
 
+import kotlin.math.max
+
 /**
  * Engagement thresholds that gate the one-time feedback nudge.
  *
@@ -13,6 +15,13 @@ package com.explyt.spring.core.statistic
  */
 const val MIN_TOTAL_USAGES_FOR_NUDGE: Int = 30
 const val MIN_ACTIVE_DAYS_FOR_NUDGE: Int = 3
+
+/**
+ * Lifetime usage, taken from the legacy [StatisticState] counters, at which an install that predates the nudge
+ * counts as engaged without waiting for [MIN_ACTIVE_DAYS_FOR_NUDGE] more days: three times the usage threshold
+ * cannot plausibly come from a single sitting.
+ */
+const val LEGACY_USAGES_FOR_INSTANT_QUALIFICATION: Int = 3 * MIN_TOTAL_USAGES_FOR_NUDGE
 
 /** Immutable snapshot of the persisted engagement state, used by [shouldShowFeedbackNudge]. */
 data class NudgeStats(
@@ -32,3 +41,36 @@ fun shouldShowFeedbackNudge(stats: NudgeStats): Boolean =
         !stats.dismissed &&
         stats.totalUsages >= MIN_TOTAL_USAGES_FOR_NUDGE &&
         stats.distinctActiveDays >= MIN_ACTIVE_DAYS_FOR_NUDGE
+
+/**
+ * Folds the usage an install accumulated before the nudge existed into [stats].
+ *
+ * The counter is never lowered. Heavy legacy usage ([LEGACY_USAGES_FOR_INSTANT_QUALIFICATION] or more) also
+ * satisfies the active-days rule, because the legacy counters carry no per-day information and such a user has
+ * evidently been around for a while. The shown and dismissed flags are left untouched.
+ */
+fun seedFromLegacyUsage(stats: NudgeStats, legacyTotalUsages: Int): NudgeStats {
+    val qualifiesInstantly = legacyTotalUsages >= LEGACY_USAGES_FOR_INSTANT_QUALIFICATION
+    return stats.copy(
+        totalUsages = max(stats.totalUsages, legacyTotalUsages),
+        distinctActiveDays = if (qualifiesInstantly) {
+            max(stats.distinctActiveDays, MIN_ACTIVE_DAYS_FOR_NUDGE)
+        } else {
+            stats.distinctActiveDays
+        },
+    )
+}
+
+/** The nudge's own events and the statistics-file metadata keys: neither may ever count as engagement. */
+private val NON_ENGAGEMENT_ACTIONS: Set<StatisticActionId> = setOf(
+    StatisticActionId.DEVICE_ID,
+    StatisticActionId.PLUGIN_VERSION,
+    StatisticActionId.LOCAL_DATE,
+    StatisticActionId.FEEDBACK_NUDGE_SHOWN,
+    StatisticActionId.FEEDBACK_NUDGE_RATE_CLICKED,
+    StatisticActionId.FEEDBACK_NUDGE_STAR_CLICKED,
+    StatisticActionId.FEEDBACK_NUDGE_DISMISSED,
+)
+
+/** `true` for a real plugin action; `false` for the nudge's own events and for statistics metadata. */
+fun isEngagementAction(actionId: StatisticActionId): Boolean = actionId !in NON_ENGAGEMENT_ACTIONS

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeService.kt
@@ -6,27 +6,32 @@
 package com.explyt.spring.core.statistic
 
 import com.explyt.spring.core.SpringCoreBundle.message
-import com.explyt.spring.core.notifications.SpringToolNotificationGroup
+import com.explyt.spring.core.notifications.SpringFeedbackNotificationGroup
 import com.intellij.icons.AllIcons
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.wm.IdeFocusManager
 import java.time.LocalDate
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
- * Shows a one-time, non-intrusive notification that invites engaged users to rate the plugin on
- * the Marketplace or star it on GitHub — directly targeting the very low rating-vote conversion.
+ * Shows a one-time, sticky notification that invites engaged users to rate the plugin on the Marketplace or star
+ * it on GitHub — directly targeting the very low rating-vote conversion.
  *
- * Engagement is measured with [FeedbackNudgeState] (local counters only — no telemetry, no network)
- * and gated by the pure [shouldShowFeedbackNudge] decision. The balloon is shown at most once ever,
- * and "Dismiss" suppresses it permanently.
+ * Engagement is measured with [FeedbackNudgeState] (local counters only — nothing leaves the machine) and gated by
+ * the pure [shouldShowFeedbackNudge] decision. The notification is shown at most once ever, right after the
+ * threshold is crossed; the project-startup check only covers a threshold crossed while no project was open.
+ * "Don't show again" suppresses it permanently. Impressions and clicks are counted as [StatisticActionId]s.
  */
 @Service(Service.Level.APP)
 class FeedbackNudgeService {
@@ -34,21 +39,26 @@ class FeedbackNudgeService {
     private val logger = Logger.getInstance(FeedbackNudgeService::class.java)
 
     /**
-     * Records a single unit of engagement: increments the total usage counter and, the first time
-     * the plugin is used on a new calendar day, the distinct-active-days counter.
+     * Records one unit of engagement for a real plugin action and shows the nudge as soon as the thresholds are
+     * met. The nudge's own events never count (see [isEngagementAction]).
      */
-    fun recordEngagement() {
+    fun recordEngagement(actionId: StatisticActionId) {
         if (skipForUnitTestAndHeadlessMode()) return
+        if (!isEngagementAction(actionId)) return
         try {
-            val state = FeedbackNudgeState.getInstance().state
-            synchronized(this) {
+            val nudgeState = FeedbackNudgeState.getInstance()
+            val thresholdMet = synchronized(this) {
+                seedFromLegacyUsageOnce(nudgeState)
+                val state = nudgeState.state
                 state.totalUsages += 1
                 val today = LocalDate.now().toEpochDay()
                 if (state.lastActiveEpochDay != today) {
                     state.lastActiveEpochDay = today
                     state.distinctActiveDays += 1
                 }
+                shouldShowFeedbackNudge(nudgeState.toStats())
             }
+            if (thresholdMet) showNudgeOnEdt(preferredProject = null, force = false)
         } catch (e: CancellationException) {
             // Also covers ProcessCanceledException: cancellation must never be logged or swallowed.
             throw e
@@ -57,27 +67,61 @@ class FeedbackNudgeService {
         }
     }
 
-    /** Evaluates the thresholds and, if met, shows the nudge exactly once. */
+    /**
+     * Startup fallback for a threshold crossed while no project could host a notification, and the entry point of
+     * the [DEBUG_REGISTRY_KEY] registry key, which forces the nudge regardless of state.
+     */
     fun maybeShowNudge(project: Project) {
         if (skipForUnitTestAndHeadlessMode()) return
         try {
             val nudgeState = FeedbackNudgeState.getInstance()
-            val forceShow = Registry.`is`("explyt.spring.feedback.nudge.debug", false)
-            if (!forceShow && !shouldShowFeedbackNudge(nudgeState.toStats())) return
-
-            // Mark as shown *before* displaying, so a crash/restart can never double-show it.
-            nudgeState.state.nudgeShown = true
-            showNotification(project)
+            synchronized(this) { seedFromLegacyUsageOnce(nudgeState) }
+            val force = Registry.`is`(DEBUG_REGISTRY_KEY, false)
+            if (!force && !shouldShowFeedbackNudge(nudgeState.toStats())) return
+            showNudgeOnEdt(preferredProject = project, force = force)
         } catch (e: CancellationException) {
-            // Also covers ProcessCanceledException: cancellation must never be logged or swallowed.
             throw e
         } catch (e: Exception) {
             logger.warn(e)
         }
     }
 
+    /** Folds the pre-nudge lifetime usage into the nudge state, exactly once per installation. Call under the lock. */
+    private fun seedFromLegacyUsageOnce(nudgeState: FeedbackNudgeState) {
+        val state = nudgeState.state
+        if (state.legacySeeded) return
+        val legacyTotal = synchronized(StatisticService::class.java) {
+            service<StatisticState>().state.counterUsagesMap.values.sum()
+        }
+        val seeded = seedFromLegacyUsage(nudgeState.toStats(), legacyTotal)
+        state.totalUsages = seeded.totalUsages
+        state.distinctActiveDays = seeded.distinctActiveDays
+        state.legacySeeded = true
+    }
+
+    /**
+     * Shows the notification on the EDT outside modal dialogs. The decision is re-checked there: the EDT is serial,
+     * so two engagement events racing for the same threshold cannot both show it, and `nudgeShown` is set only after
+     * the notification was actually displayed. A project in dumb mode is skipped — the next engagement retries.
+     */
+    private fun showNudgeOnEdt(preferredProject: Project?, force: Boolean) {
+        ApplicationManager.getApplication().invokeLater({
+            val project = preferredProject?.takeIf { !it.isDisposed } ?: focusedOpenProject() ?: return@invokeLater
+            if (DumbService.isDumb(project)) return@invokeLater
+            val nudgeState = FeedbackNudgeState.getInstance()
+            if (!force && !shouldShowFeedbackNudge(nudgeState.toStats())) return@invokeLater
+            showNotification(project)
+            nudgeState.state.nudgeShown = true
+            StatisticService.getInstance().addActionUsage(StatisticActionId.FEEDBACK_NUDGE_SHOWN)
+        }, ModalityState.nonModal())
+    }
+
+    private fun focusedOpenProject(): Project? =
+        IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project?.takeIf { !it.isDisposed && !it.isDefault }
+            ?: ProjectManager.getInstance().openProjects.firstOrNull { !it.isDisposed }
+
     private fun showNotification(project: Project) {
-        SpringToolNotificationGroup
+        SpringFeedbackNotificationGroup
             .createNotification(
                 message("explyt.spring.feedback.nudge.title"),
                 message("explyt.spring.feedback.nudge.content"),
@@ -85,12 +129,15 @@ class FeedbackNudgeService {
             )
             .setIcon(AllIcons.Nodes.Favorite)
             .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.rate")) {
+                StatisticService.getInstance().addActionUsage(StatisticActionId.FEEDBACK_NUDGE_RATE_CLICKED)
                 BrowserUtil.browse(MARKETPLACE_REVIEWS_URL)
             })
             .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.star")) {
+                StatisticService.getInstance().addActionUsage(StatisticActionId.FEEDBACK_NUDGE_STAR_CLICKED)
                 BrowserUtil.browse(GITHUB_REPO_URL)
             })
             .addAction(NotificationAction.createSimpleExpiring(message("explyt.spring.feedback.nudge.dismiss")) {
+                StatisticService.getInstance().addActionUsage(StatisticActionId.FEEDBACK_NUDGE_DISMISSED)
                 FeedbackNudgeState.getInstance().state.dismissed = true
             })
             .notify(project)
@@ -103,6 +150,9 @@ class FeedbackNudgeService {
     companion object {
         fun getInstance(): FeedbackNudgeService = service()
 
+        const val DEBUG_REGISTRY_KEY = "explyt.spring.feedback.nudge.debug"
+
+        /** Plain destinations until the first-party, per-placement short links exist. */
         const val MARKETPLACE_REVIEWS_URL = "https://plugins.jetbrains.com/plugin/28675-spring-explyt/reviews"
         const val GITHUB_REPO_URL = "https://github.com/explyt/spring-plugin"
     }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeState.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeState.kt
@@ -37,6 +37,9 @@ class FeedbackNudgeState : SimplePersistentStateComponent<NudgeData>(NudgeData()
 
         /** Set when the user explicitly dismisses the nudge — honored forever. */
         var dismissed by property(false)
+
+        /** Set once the legacy [StatisticState] counters have been folded in — exactly once per installation. */
+        var legacySeeded by property(false)
     }
 
     fun toStats(): NudgeStats = with(state) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticActionId.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticActionId.kt
@@ -99,4 +99,9 @@ enum class StatisticActionId(description: String) {
     GENERATE_WEB_METHOD("Method generate - Spring Web Method from generate menu"),
     GENERATE_HTTP_CLIENT_METHOD("Method generate - Curl to HttpClient method"),
     GENERATE_SPRING_BOOT_BEAN_ANALYZE("Generate code block - Spring Boot startup wrapper for beans analyzer"),
+
+    FEEDBACK_NUDGE_SHOWN("Feedback nudge - shown"),
+    FEEDBACK_NUDGE_RATE_CLICKED("Feedback nudge - Rate on Marketplace clicked"),
+    FEEDBACK_NUDGE_STAR_CLICKED("Feedback nudge - Star on GitHub clicked"),
+    FEEDBACK_NUDGE_DISMISSED("Feedback nudge - Don't show again clicked"),
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
@@ -42,7 +42,11 @@ class StatisticService {
 
         try {
             synchronized(StatisticService::class.java) {
-                getStatisticState().state.incrementUsage(actionId.name)
+                val state = getStatisticState().state
+                state.incrementUsage(actionId.name)
+                if (logger.isDebugEnabled) {
+                    logger.debug("Recorded usage $actionId → ${state.counterUsagesMap[actionId.name]}; state modificationCount=${state.modificationCount}")
+                }
             }
             FeedbackNudgeService.getInstance().recordEngagement(actionId)
         } catch (e: CancellationException) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
@@ -47,7 +47,7 @@ class StatisticService {
                     if (count == null) 1 else count + 1
                 }
             }
-            FeedbackNudgeService.getInstance().recordEngagement()
+            FeedbackNudgeService.getInstance().recordEngagement(actionId)
         } catch (e: CancellationException) {
             // Also covers ProcessCanceledException: cancellation must never be logged or swallowed.
             throw e

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticService.kt
@@ -42,10 +42,7 @@ class StatisticService {
 
         try {
             synchronized(StatisticService::class.java) {
-                val statisticState = getStatisticState()
-                statisticState.state.counterUsagesMap.compute(actionId.name) { _, count ->
-                    if (count == null) 1 else count + 1
-                }
+                getStatisticState().state.incrementUsage(actionId.name)
             }
             FeedbackNudgeService.getInstance().recordEngagement(actionId)
         } catch (e: CancellationException) {

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticState.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticState.kt
@@ -18,5 +18,16 @@ class StatisticState : SimplePersistentStateComponent<UsagesMapStatistic>(Usages
 
     class UsagesMapStatistic : BaseState() {
         var counterUsagesMap by map<String, Int>()
+
+        /**
+         * Increments a usage counter through `put`.
+         *
+         * The platform's stored map counts only `put`, `remove` and `clear` as modifications; `Map.compute` on it
+         * is implemented natively and never marks the state dirty, so a component that only ever used `compute`
+         * was never saved — no usage counter survived an IDE restart until this method replaced it.
+         */
+        fun incrementUsage(actionName: String) {
+            counterUsagesMap[actionName] = (counterUsagesMap[actionName] ?: 0) + 1
+        }
     }
 }

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticState.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticState.kt
@@ -7,12 +7,20 @@ package com.explyt.spring.core.statistic
 
 import com.explyt.spring.core.statistic.StatisticState.UsagesMapStatistic
 import com.intellij.openapi.components.*
+import com.intellij.util.ThreeState
 
+/**
+ * Local usage counters.
+ *
+ * `useSaveThreshold = NO` opts out of the platform's rule that saves a non-roamable component at most once every five
+ * minutes and does not force it on exit: with the default, every IDE session shorter than five minutes after the first
+ * counted action lost its counters.
+ */
 @Service(Service.Level.APP)
 @State(
     name = "ExplytSpringStatisticCache",
     category = SettingsCategory.PLUGINS,
-    storages = [Storage(StoragePathMacros.CACHE_FILE)]
+    storages = [Storage(StoragePathMacros.CACHE_FILE, useSaveThreshold = ThreeState.NO)]
 )
 class StatisticState : SimplePersistentStateComponent<UsagesMapStatistic>(UsagesMapStatistic()) {
 

--- a/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticState.kt
+++ b/modules/spring-core/src/main/kotlin/com/explyt/spring/core/statistic/StatisticState.kt
@@ -7,20 +7,20 @@ package com.explyt.spring.core.statistic
 
 import com.explyt.spring.core.statistic.StatisticState.UsagesMapStatistic
 import com.intellij.openapi.components.*
-import com.intellij.util.ThreeState
 
 /**
  * Local usage counters.
  *
- * `useSaveThreshold = NO` opts out of the platform's rule that saves a non-roamable component at most once every five
- * minutes and does not force it on exit: with the default, every IDE session shorter than five minutes after the first
- * counted action lost its counters.
+ * Stored in a plain options file with [RoamingType.LOCAL]: kept on this machine, never shared through Settings Sync
+ * or exported, readable as XML. The previous `$CACHE_FILE$` storage is non-roamable, which on 2026.2 routes the state
+ * into the opaque internal settings database and saves it at most once every five minutes without forcing the save
+ * on exit, so every IDE session shorter than that lost its counters.
  */
 @Service(Service.Level.APP)
 @State(
     name = "ExplytSpringStatisticCache",
     category = SettingsCategory.PLUGINS,
-    storages = [Storage(StoragePathMacros.CACHE_FILE, useSaveThreshold = ThreeState.NO)]
+    storages = [Storage("explyt-spring-statistic.xml", roamingType = RoamingType.LOCAL)]
 )
 class StatisticState : SimplePersistentStateComponent<UsagesMapStatistic>(UsagesMapStatistic()) {
 

--- a/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
+++ b/modules/spring-core/src/main/resources/META-INF/spring-core-plugin.xml
@@ -82,6 +82,10 @@
                            displayType="BALLOON"
                            bundle="messages.SpringCoreBundle"
                            key="explyt.spring.common.notifications"/>
+        <notificationGroup id="com.explyt.spring.feedback"
+                           displayType="STICKY_BALLOON"
+                           bundle="messages.SpringCoreBundle"
+                           key="explyt.spring.feedback.notifications"/>
 
         <completion.contributor id="yamlContributor"
                                 language="yaml"
@@ -843,7 +847,7 @@
         <registryKey key="explyt.statistic.debug" defaultValue="false"
                      description="Enable statistic in debug mode"/>
         <registryKey key="explyt.spring.feedback.nudge.debug" defaultValue="false"
-                     description="Force-show the feedback nudge on next startup (ignores engagement thresholds)"/>
+                     description="Force-show the feedback nudge on the next project startup, ignoring engagement thresholds and the shown/dismissed state"/>
         <registryKey key="explyt.statistic.interval" defaultValue="3600"
                      description="Update statistic interval seconds"/>
         <registryKey key="explyt.spring.agent.path" defaultValue=""

--- a/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
+++ b/modules/spring-core/src/main/resources/messages/SpringCoreBundle.properties
@@ -9,6 +9,7 @@ explyt.spring.feedback.nudge.content=If the plugin saves you time, a quick ratin
 explyt.spring.feedback.nudge.rate=Rate on Marketplace
 explyt.spring.feedback.nudge.star=Star on GitHub
 explyt.spring.feedback.nudge.dismiss=Don''t show again
+explyt.spring.feedback.notifications=Explyt Spring feedback
 explyt.spring.inspection.bean.autowired=Incorrect @Autowired placement in Spring bean components
 explyt.spring.inspection.bean.autowired.type.none=Autowire failed. No beans of ''{0}'' found
 explyt.spring.inspection.bean.autowired.type.none.or=Autowire failed. No beans of ''{0}'' or ''{1}'' found

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecisionTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/FeedbackNudgeDecisionTest.kt
@@ -5,6 +5,16 @@
 
 package com.explyt.spring.core.statistic
 
+import com.explyt.spring.core.statistic.StatisticActionId.COMPLETION_PROPERTY_KEY_CONFIGURATION
+import com.explyt.spring.core.statistic.StatisticActionId.DEVICE_ID
+import com.explyt.spring.core.statistic.StatisticActionId.FEEDBACK_NUDGE_DISMISSED
+import com.explyt.spring.core.statistic.StatisticActionId.FEEDBACK_NUDGE_RATE_CLICKED
+import com.explyt.spring.core.statistic.StatisticActionId.FEEDBACK_NUDGE_SHOWN
+import com.explyt.spring.core.statistic.StatisticActionId.FEEDBACK_NUDGE_STAR_CLICKED
+import com.explyt.spring.core.statistic.StatisticActionId.GUTTER_BEAN_USAGE
+import com.explyt.spring.core.statistic.StatisticActionId.LOCAL_DATE
+import com.explyt.spring.core.statistic.StatisticActionId.PLUGIN_VERSION
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -56,5 +66,74 @@ class FeedbackNudgeDecisionTest {
     @Test
     fun hiddenAtZeroEngagement() {
         assertFalse(shouldShowFeedbackNudge(stats(totalUsages = 0, distinctActiveDays = 0)))
+    }
+
+    // --- Seeding from the legacy StatisticState counters (lifetime usage of installs that predate the nudge) ---
+
+    @Test
+    fun seedingLeavesAFreshInstallUntouched() {
+        val seeded = seedFromLegacyUsage(stats(totalUsages = 0, distinctActiveDays = 0), legacyTotalUsages = 0)
+        assertEquals(0, seeded.totalUsages)
+        assertEquals(0, seeded.distinctActiveDays)
+    }
+
+    @Test
+    fun seedingNeverLowersAlreadyRecordedUsage() {
+        val seeded = seedFromLegacyUsage(stats(totalUsages = 100, distinctActiveDays = 1), legacyTotalUsages = 40)
+        assertEquals(100, seeded.totalUsages)
+        assertEquals(1, seeded.distinctActiveDays)
+    }
+
+    @Test
+    fun moderateLegacyUsageSeedsTheCounterButStillWaitsForActiveDays() {
+        val legacy = LEGACY_USAGES_FOR_INSTANT_QUALIFICATION - 1
+        val seeded = seedFromLegacyUsage(stats(totalUsages = 0, distinctActiveDays = 0), legacyTotalUsages = legacy)
+        assertEquals(legacy, seeded.totalUsages)
+        assertEquals(0, seeded.distinctActiveDays)
+        assertFalse(shouldShowFeedbackNudge(seeded))
+    }
+
+    @Test
+    fun heavyLegacyUsageQualifiesImmediately() {
+        val seeded = seedFromLegacyUsage(
+            stats(totalUsages = 0, distinctActiveDays = 0),
+            legacyTotalUsages = LEGACY_USAGES_FOR_INSTANT_QUALIFICATION,
+        )
+        assertTrue(shouldShowFeedbackNudge(seeded))
+    }
+
+    @Test
+    fun seedingPreservesDismissalAndShownFlags() {
+        val dismissed = seedFromLegacyUsage(stats(dismissed = true), legacyTotalUsages = 10_000)
+        assertTrue(dismissed.dismissed)
+        assertFalse(shouldShowFeedbackNudge(dismissed))
+
+        val shown = seedFromLegacyUsage(stats(nudgeShown = true), legacyTotalUsages = 10_000)
+        assertTrue(shown.nudgeShown)
+        assertFalse(shouldShowFeedbackNudge(shown))
+    }
+
+    // --- The nudge's own events must never feed the engagement counter ---
+
+    @Test
+    fun nudgeEventsAreNotEngagement() {
+        for (id in listOf(
+            FEEDBACK_NUDGE_SHOWN, FEEDBACK_NUDGE_RATE_CLICKED, FEEDBACK_NUDGE_STAR_CLICKED, FEEDBACK_NUDGE_DISMISSED,
+        )) {
+            assertFalse(id.name, isEngagementAction(id))
+        }
+    }
+
+    @Test
+    fun statisticMetadataIdsAreNotEngagement() {
+        for (id in listOf(DEVICE_ID, PLUGIN_VERSION, LOCAL_DATE)) {
+            assertFalse(id.name, isEngagementAction(id))
+        }
+    }
+
+    @Test
+    fun regularPluginActionsAreEngagement() {
+        assertTrue(isEngagementAction(GUTTER_BEAN_USAGE))
+        assertTrue(isEngagementAction(COMPLETION_PROPERTY_KEY_CONFIGURATION))
     }
 }

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateRoundTripTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateRoundTripTest.kt
@@ -6,7 +6,7 @@
 package com.explyt.spring.core.statistic
 
 import com.intellij.openapi.util.JDOMUtil
-import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters
+import com.intellij.util.xmlb.SkipDefaultsSerializationFilter
 import com.intellij.util.xmlb.XmlSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -20,7 +20,7 @@ class StatisticStateRoundTripTest {
         original.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
         original.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
 
-        val element = XmlSerializer.serialize(original, SkipDefaultValuesSerializationFilters())
+        val element = XmlSerializer.serialize(original, SkipDefaultsSerializationFilter())
         val xml = JDOMUtil.writeElement(element)
 
         val restored = XmlSerializer.deserialize(JDOMUtil.load(xml), StatisticState.UsagesMapStatistic::class.java)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateRoundTripTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateRoundTripTest.kt
@@ -6,7 +6,6 @@
 package com.explyt.spring.core.statistic
 
 import com.intellij.openapi.util.JDOMUtil
-import com.intellij.util.xmlb.SkipDefaultsSerializationFilter
 import com.intellij.util.xmlb.XmlSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -20,7 +19,7 @@ class StatisticStateRoundTripTest {
         original.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
         original.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
 
-        val element = XmlSerializer.serialize(original, SkipDefaultsSerializationFilter())
+        val element = XmlSerializer.serialize(original)
         val xml = JDOMUtil.writeElement(element)
 
         val restored = XmlSerializer.deserialize(JDOMUtil.load(xml), StatisticState.UsagesMapStatistic::class.java)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateRoundTripTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateRoundTripTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters
+import com.intellij.util.xmlb.XmlSerializer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StatisticStateRoundTripTest {
+
+    @Test
+    fun countersSurviveSerializeThenDeserialize() {
+        val original = StatisticState.UsagesMapStatistic()
+        original.incrementUsage("FEEDBACK_NUDGE_SHOWN")
+        original.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
+        original.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
+
+        val element = XmlSerializer.serialize(original, SkipDefaultValuesSerializationFilters())
+        val xml = JDOMUtil.writeElement(element)
+
+        val restored = XmlSerializer.deserialize(JDOMUtil.load(xml), StatisticState.UsagesMapStatistic::class.java)
+
+        assertEquals(xml, mapOf("FEEDBACK_NUDGE_SHOWN" to 1, "FEEDBACK_NUDGE_STAR_CLICKED" to 2), restored.counterUsagesMap)
+    }
+
+    @Test
+    fun theOptionsFileWrittenByTheIdeDeserializesToTheSameCounters() {
+        // Verbatim content of config/options/explyt-spring-statistic.xml written by the sandbox IDE (round 7).
+        val componentElement = JDOMUtil.load(
+            """
+            <component name="ExplytSpringStatisticCache">
+              <option name="counterUsagesMap">
+                <map>
+                  <entry key="FEEDBACK_NUDGE_SHOWN" value="1" />
+                </map>
+              </option>
+            </component>
+            """.trimIndent()
+        )
+
+        val restored = XmlSerializer.deserialize(componentElement, StatisticState.UsagesMapStatistic::class.java)
+
+        assertEquals(mapOf("FEEDBACK_NUDGE_SHOWN" to 1), restored.counterUsagesMap)
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateSerializationTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateSerializationTest.kt
@@ -6,7 +6,6 @@
 package com.explyt.spring.core.statistic
 
 import com.intellij.openapi.util.JDOMUtil
-import com.intellij.util.xmlb.SkipDefaultsSerializationFilter
 import com.intellij.util.xmlb.XmlSerializer
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -21,7 +20,7 @@ class StatisticStateSerializationTest {
         state.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
         state.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
 
-        val element = XmlSerializer.serialize(state, SkipDefaultsSerializationFilter())
+        val element = XmlSerializer.serialize(state)
         assertNotNull("a populated state must not serialize to nothing", element)
         val xml = JDOMUtil.writeElement(element)
         println(xml)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateSerializationTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateSerializationTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters
+import com.intellij.util.xmlb.XmlSerializer
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StatisticStateSerializationTest {
+
+    @Test
+    fun populatedCountersSerializeToXmlThePlatformCanPersist() {
+        val state = StatisticState.UsagesMapStatistic()
+        state.incrementUsage("FEEDBACK_NUDGE_SHOWN")
+        state.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
+        state.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
+
+        val element = XmlSerializer.serialize(state, SkipDefaultValuesSerializationFilters())
+        assertNotNull("a populated state must not serialize to nothing", element)
+        val xml = JDOMUtil.writeElement(element)
+        println(xml)
+        assertTrue(xml, xml.contains("FEEDBACK_NUDGE_SHOWN"))
+        assertTrue(xml, xml.contains("FEEDBACK_NUDGE_STAR_CLICKED"))
+    }
+}

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateSerializationTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateSerializationTest.kt
@@ -6,7 +6,7 @@
 package com.explyt.spring.core.statistic
 
 import com.intellij.openapi.util.JDOMUtil
-import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters
+import com.intellij.util.xmlb.SkipDefaultsSerializationFilter
 import com.intellij.util.xmlb.XmlSerializer
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -21,7 +21,7 @@ class StatisticStateSerializationTest {
         state.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
         state.incrementUsage("FEEDBACK_NUDGE_STAR_CLICKED")
 
-        val element = XmlSerializer.serialize(state, SkipDefaultValuesSerializationFilters())
+        val element = XmlSerializer.serialize(state, SkipDefaultsSerializationFilter())
         assertNotNull("a populated state must not serialize to nothing", element)
         val xml = JDOMUtil.writeElement(element)
         println(xml)

--- a/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateTest.kt
+++ b/modules/spring-core/src/test/kotlin/com/explyt/spring/core/statistic/StatisticStateTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Explyt Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.explyt.spring.core.statistic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StatisticStateTest {
+
+    @Test
+    fun incrementingAUsageMarksTheStateModifiedSoThePlatformPersistsIt() {
+        val state = StatisticState.UsagesMapStatistic()
+        val before = state.modificationCount
+
+        state.incrementUsage("GUTTER_BEAN_USAGE")
+        state.incrementUsage("GUTTER_BEAN_USAGE")
+        state.incrementUsage("SETTINGS_OPEN")
+
+        assertEquals(2, state.counterUsagesMap["GUTTER_BEAN_USAGE"])
+        assertEquals(1, state.counterUsagesMap["SETTINGS_OPEN"])
+        assertTrue(
+            "modificationCount must grow, otherwise the component is never saved",
+            state.modificationCount > before,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

The one-time feedback nudge shipped in 262.34.101 as a `BALLOON` shown from the startup activity, with `nudgeShown` set before display. A `BALLOON` expires after ten seconds, the startup activity fires while the IDE is still indexing, and the flag was already burned — so the lifetime one-shot was gone before most users could see it (0 new Marketplace votes in the first weeks of the release).

This PR makes the nudge reach the user and makes its outcome countable:

- **Sticky:** a dedicated notification group `com.explyt.spring.feedback` with `STICKY_BALLOON`; the notification stays until the user acts on it.
- **Engagement-triggered:** shown right after the action that crosses the threshold (`recordEngagement` → EDT, non-modal, not in dumb mode). The startup check stays only as a fallback. The decision is re-checked on the EDT (serial, so it can never show twice) and `nudgeShown` is set only after `notify()` returned.
- **Seeded from existing usage:** the engagement state is initialised once from the `StatisticState` lifetime counters; ninety or more legacy usages also satisfy the active-days rule.
- **Counted:** `StatisticActionId.FEEDBACK_NUDGE_{SHOWN,RATE_CLICKED,STAR_CLICKED,DISMISSED}`; the nudge's own events never feed the engagement counter.
- **Counters actually persist now.** Three defects stacked on top of each other: (1) `StatisticService` incremented `counterUsagesMap` through `Map.compute`; the platform's stored map counts only `put`/`remove`/`clear` as modifications and fastutil implements `compute` natively, so `StatisticState` was never marked dirty and never saved — `UsagesMapStatistic.incrementUsage` goes through `put`, with a test on the modification count. (2) The `$CACHE_FILE$` storage is non-roamable: the platform saves it at most once every five minutes, never forces it on exit, and on 2026.2 keeps it in the opaque internal settings database — the state now lives in `explyt-spring-statistic.xml` with `RoamingType.LOCAL` (local, never synced or exported, readable XML, not throttled). (3) A debug-level log line in `addActionUsage` makes the recorded counter and modification count visible with `-Didea.log.debug.categories=#com.explyt.spring.core.statistic.StatisticService`. Consequence for this release: no install has persisted history yet, so every user needs 30 actions on 3 distinct days after updating before the nudge appears.

## Related issue

n/a

## Type of change

- [x] Bug fix
- [ ] New feature / inspection
- [ ] Documentation
- [ ] Refactoring / tech debt
- [ ] Other (describe below)

## How was this tested?

- `./gradlew :spring-core:test --tests "com.explyt.spring.core.statistic.*"` — 20 tests, 0 failures (12 new: legacy seeding, the engagement filter, the modification-count regression test, serialization and a round-trip over the exact XML the IDE wrote).
- Sandbox IDE (`:spring-bootstrap:runIde`, registry key `explyt.spring.feedback.nudge.debug=true`): the notification appears with all three actions and stays on screen for the whole 3-minute observation window; after quitting with ⌘Q the nudge state (`legacySeeded`, `nudgeShown`, `dismissed`) and the counters file (`explyt-spring-statistic.xml`) are persisted, and on the next start the counter loads back and increments (`FEEDBACK_NUDGE_SHOWN → 2` in the debug log; requires `explyt.statistic.debug=true` in a snapshot build, which otherwise clears the counters on its statistics write pass). No warnings from the nudge code in `idea.log`.
- IntelliJ inspections: no findings on the changed lines.

## Checklist

- [x] My branch targets `main`.
- [x] Code is Kotlin-idiomatic and consistent with the surrounding style.
- [x] Every new file has the Apache-2.0 SPDX header.
- [x] I added or updated tests for my change (or explained why not).
- [x] I updated relevant documentation (README / wiki / bundle messages) if behavior changed — bundle message for the new group, CHANGELOG `[Unreleased]`.
